### PR TITLE
Add fallback session token, and wrapper setting the active session so…

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSubsystem.cpp
@@ -186,6 +186,7 @@ bool URH_GameInstanceSubsystem::ValidateIncomingConnection(UNetConnection* Conne
 
 				// see if a security token was specified for the currently active session
 				const FString* SessionSecurityToken = nullptr;
+				const TOptional<FString> FallbackSessionSecurityToken = pRHSubsystem->GetSessionSubsystem()->GetFallbackSessionSecurityToken();
 				const auto* Session = pRHSubsystem->GetSessionSubsystem()->GetActiveSession();
 				if (Session != nullptr && Session->GetInstanceData() != nullptr)
 				{
@@ -203,6 +204,15 @@ bool URH_GameInstanceSubsystem::ValidateIncomingConnection(UNetConnection* Conne
 					if (*SessionSecurityToken != LoginSecurityToken)
 					{
 						ErrorMessage = TEXT("RH Security Token mismatch");
+						return false;
+					}
+				}
+				// this token is used to cover cases where clients attempt to connect before the server reads its own session data update to add the token
+				else if (FallbackSessionSecurityToken.IsSet())
+				{
+					if (FallbackSessionSecurityToken.GetValue() != LoginSecurityToken)
+					{
+						ErrorMessage = TEXT("RH Security Token (fallback) mismatch");
 						return false;
 					}
 				}


### PR DESCRIPTION
… that it can be cleared properly.  This uses storage on the game instance session subsystem, rather than the session.  If we need generic local storage on the session we need to make sure session lifetime is stable.