### PR TITLE
Change base model to default to using retry, so that RetryAfter headers should be respected automatically.

### DIFF
--- a/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIBaseModel.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIBaseModel.h
@@ -96,6 +96,11 @@ struct RALLYHEREAPI_API FRequestMetadata
 class RALLYHEREAPI_API FRequest
 {
 public:
+    FRequest()
+	{
+		// default to enabling retry
+		SetShouldRetry();
+	}
     virtual ~FRequest() = default;
     virtual bool SetupHttpRequest(const FHttpRequestRef& HttpRequest) const = 0;
     virtual FString ComputePath() const = 0;
@@ -105,6 +110,7 @@ public:
 
     /* Enables retry and optionally sets a retry policy for this request */
     void SetShouldRetry(const FHttpRetryParams& Params = FHttpRetryParams()) { RetryParams = Params; }
+	void ClearShouldRetry() { RetryParams.Reset(); }
     const TOptional<FHttpRetryParams>& GetRetryParams() const { return RetryParams; }
 
 protected:

--- a/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIBaseModel.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIBaseModel.h
@@ -97,10 +97,10 @@ class RALLYHEREAPI_API FRequest
 {
 public:
     FRequest()
-	{
-		// default to enabling retry
-		SetShouldRetry();
-	}
+    {
+        // default to enabling retry
+        SetShouldRetry();
+    }
     virtual ~FRequest() = default;
     virtual bool SetupHttpRequest(const FHttpRequestRef& HttpRequest) const = 0;
     virtual FString ComputePath() const = 0;
@@ -110,7 +110,7 @@ public:
 
     /* Enables retry and optionally sets a retry policy for this request */
     void SetShouldRetry(const FHttpRetryParams& Params = FHttpRetryParams()) { RetryParams = Params; }
-	void ClearShouldRetry() { RetryParams.Reset(); }
+    void ClearShouldRetry() { RetryParams.Reset(); }
     const TOptional<FHttpRetryParams>& GetRetryParams() const { return RetryParams; }
 
 protected:

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/model-base-header.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/model-base-header.mustache
@@ -109,10 +109,10 @@ class {{dllapi}} FRequest
 {
 public:
     FRequest()
-	{
-		// default to enabling retry
-		SetShouldRetry();
-	}
+    {
+        // default to enabling retry
+        SetShouldRetry();
+    }
     virtual ~FRequest() = default;
     virtual bool SetupHttpRequest(const FHttpRequestRef& HttpRequest) const = 0;
     virtual FString ComputePath() const = 0;
@@ -122,7 +122,7 @@ public:
 
     /* Enables retry and optionally sets a retry policy for this request */
     void SetShouldRetry(const FHttpRetryParams& Params = FHttpRetryParams()) { RetryParams = Params; }
-	void ClearShouldRetry() { RetryParams.Reset(); }
+    void ClearShouldRetry() { RetryParams.Reset(); }
     const TOptional<FHttpRetryParams>& GetRetryParams() const { return RetryParams; }
 
 protected:

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/model-base-header.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/model-base-header.mustache
@@ -108,6 +108,11 @@ struct {{dllapi}} FRequestMetadata
 class {{dllapi}} FRequest
 {
 public:
+    FRequest()
+	{
+		// default to enabling retry
+		SetShouldRetry();
+	}
     virtual ~FRequest() = default;
     virtual bool SetupHttpRequest(const FHttpRequestRef& HttpRequest) const = 0;
     virtual FString ComputePath() const = 0;
@@ -117,6 +122,7 @@ public:
 
     /* Enables retry and optionally sets a retry policy for this request */
     void SetShouldRetry(const FHttpRetryParams& Params = FHttpRetryParams()) { RetryParams = Params; }
+	void ClearShouldRetry() { RetryParams.Reset(); }
     const TOptional<FHttpRetryParams>& GetRetryParams() const { return RetryParams; }
 
 protected:


### PR DESCRIPTION
Note - this generally assumes that calls made on a timer are using our auto polling system, which does not start a new timing loop until the previous call fully completes.