### PR TITLE
Add error info to session update routines

### DIFF
--- a/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
@@ -1583,7 +1583,7 @@ void FRHDTW_Session::HandleBrowserSearchResult(bool bSuccess, const FRH_SessionB
 	}
 }
 
-void FRHDTW_Session::HandleSessionUpdatedResult(bool bSuccess, URH_JoinedSession* SessionData, FGuid PlayerUuid)
+void FRHDTW_Session::HandleSessionUpdatedResult(bool bSuccess, URH_JoinedSession* SessionData, const FRH_ErrorInfo& ErrorInfo, FGuid PlayerUuid)
 {
 	if (bSuccess)
 	{
@@ -1591,7 +1591,7 @@ void FRHDTW_Session::HandleSessionUpdatedResult(bool bSuccess, URH_JoinedSession
 	}
 	else
 	{
-		SessionActionResult += TEXT("[") + GetShortUuid(PlayerUuid) + TEXT("] Session action failed.") LINE_TERMINATOR;
+		SessionActionResult += FString::Printf(TEXT("[%s] Session action failed with code %d."), *GetShortUuid(PlayerUuid), ErrorInfo.ResponseCode) + LINE_TERMINATOR;
 	}
 }
 

--- a/RallyHereDebugTool/Source/Public/RHDTW_Session.h
+++ b/RallyHereDebugTool/Source/Public/RHDTW_Session.h
@@ -69,7 +69,7 @@ protected:
 	void ImGuiDisplayRegionsBrowser(URH_GameInstanceSubsystem* pGISubsystem);
 
 	void HandleBrowserSearchResult(bool bSuccess, const FRH_SessionBrowserSearchResult& Result);
-	void HandleSessionUpdatedResult(bool bSuccess, URH_JoinedSession* SessionData, FGuid PlayerUuid);
+	void HandleSessionUpdatedResult(bool bSuccess, URH_JoinedSession* SessionData, const FRH_ErrorInfo& ErrorInfo, FGuid PlayerUuid);
 
 	void HandleGetPlayerSessions(bool bSuccess, class URH_PlayerSessions* SessionsData, FGuid PlayerUuid);
 	FString GetPlayerSessionsResult;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -843,7 +843,7 @@ void URH_GameInstanceServerBootstrapper::OnRegistrationFinalizerComplete(bool bS
 			// create default instance data if needed
 			if (RHSession->GetInstanceData() != nullptr)
 			{
-				OnSessionInstanceCreationCompleted(true, RHSession);
+				OnSessionInstanceCreationCompleted(true, RHSession, FRH_ErrorInfo());
 			}
 			else
 			{
@@ -892,7 +892,7 @@ void URH_GameInstanceServerBootstrapper::OnRegistrationFinalizerComplete(bool bS
 	}
 }
 
-void URH_GameInstanceServerBootstrapper::OnSessionInstanceCreationCompleted(bool bSuccess, URH_JoinedSession* CreatedRHSession)
+void URH_GameInstanceServerBootstrapper::OnSessionInstanceCreationCompleted(bool bSuccess, URH_JoinedSession* CreatedRHSession, const FRH_ErrorInfo& ErrorInfo)
 {
 	UE_LOG(LogRallyHereIntegration, Verbose, TEXT("[%s]"), ANSI_TO_TCHAR(__FUNCTION__));
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlatformSessionSyncer.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlatformSessionSyncer.cpp
@@ -201,7 +201,7 @@ void URH_PlatformSessionSyncer::JoinRHSessionByPlatformSession(FRH_SessionOwnerP
 
 			if (PlatformOptional.IsSet())
 			{
-				auto CompletionDelegate = FRH_OnSessionUpdatedDelegate::CreateLambda([SessionInvite, Delegate](bool bSuccess, URH_JoinedSession* Session)
+				auto CompletionDelegate = FRH_OnSessionUpdatedDelegate::CreateLambda([SessionInvite, Delegate](bool bSuccess, URH_JoinedSession* Session, const FRH_ErrorInfo& ErrorInfo)
 					{
 						if (bSuccess)
 						{
@@ -611,7 +611,7 @@ void URH_PlatformSessionSyncer::UpdateRHSessionWithPlatformSession()
 		Request.Platform = RHPlatform;
 		Request.PlatformSessionIdBase64 = Base64Str;
 
-		auto Helper = MakeShared<FRH_SessionRequestAndModifyHelper<BaseType>>(SessionOwner, RHSession->GetSessionId(), FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this](bool bSuccess, URH_JoinedSession* Session)
+		auto Helper = MakeShared<FRH_SessionRequestAndModifyHelper<BaseType>>(SessionOwner, RHSession->GetSessionId(), FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this](bool bSuccess, URH_JoinedSession* Session, const FRH_ErrorInfo& ErrorInfo)
 			{
 				if (bSuccess)
 				{
@@ -924,7 +924,7 @@ void URH_PlatformSessionSyncer::OnScoutFailedToJoin()
 	Request.Platform = PlatformSession.GetPlatform();
 	Request.PlatformSessionIdBase64 = PlatformSession.GetPlatformSessionIdBase64();
 
-	auto Helper = MakeShared<FRH_SessionRequestAndModifyHelper<BaseType>>(SessionOwner, RHSession->GetSessionId(), FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this](bool bSuccess, URH_JoinedSession* Session)
+	auto Helper = MakeShared<FRH_SessionRequestAndModifyHelper<BaseType>>(SessionOwner, RHSession->GetSessionId(), FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this](bool bSuccess, URH_JoinedSession* Session, const FRH_ErrorInfo& ErrorInfo)
 		{
 			if (bSuccess)
 			{

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionData.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionData.cpp
@@ -267,7 +267,7 @@ void URH_SessionView::PollForUpdate(const FRH_PollCompleteFunc& Delegate)
 		return;
 	}
 
-	FRH_OnSessionUpdatedDelegate CompletionDelegate = FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this, Delegate](bool bSuccess, URH_JoinedSession* Session)
+	FRH_OnSessionUpdatedDelegate CompletionDelegate = FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this, Delegate](bool bSuccess, URH_JoinedSession* Session, const FRH_ErrorInfo& ErrorInfo)
 		{
 			// notify poller that execution is done
 			Delegate.ExecuteIfBound(bSuccess, true);
@@ -692,19 +692,19 @@ URH_OfflineSession::URH_OfflineSession(const FObjectInitializer& ObjectInitializ
 void URH_OfflineSession::InvitePlayer(const FGuid& PlayerId, int32 Team, const TMap<FString, FString>& CustomData, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
 {
 	// currently not supported for offline sessions
-	Delegate.ExecuteIfBound(false, this);
+	Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 }
 
 void URH_OfflineSession::KickPlayer(const FGuid& PlayerId, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
 {
 	// currently not supported for offline sessions
-	Delegate.ExecuteIfBound(false, this);
+	Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 }
 
 void URH_OfflineSession::SetLeader(const FGuid& PlayerId, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
 {
 	// currently not supported for offline sessions
-	Delegate.ExecuteIfBound(false, this);
+	Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 }
 
 void URH_OfflineSession::ChangePlayerTeam(const FGuid& PlayerUuid, int32 Team, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
@@ -726,7 +726,7 @@ void URH_OfflineSession::ChangePlayerTeam(const FGuid& PlayerUuid, int32 Team, c
 				if (Team == i)
 				{
 					// already on the correct team
-					Delegate.ExecuteIfBound(true, this);
+					Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 					return;
 				}
 				else
@@ -755,7 +755,7 @@ void URH_OfflineSession::ChangePlayerTeam(const FGuid& PlayerUuid, int32 Team, c
 
 	ImportSessionUpdateToAllPlayers(UpdateWrapper);
 
-	Delegate.ExecuteIfBound(true, this);
+	Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 }
 
 void URH_OfflineSession::UpdatePlayerCustomData(const FGuid& PlayerUuid, const TMap<FString, FString>& CustomData, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
@@ -772,13 +772,13 @@ void URH_OfflineSession::UpdatePlayerCustomData(const FGuid& PlayerUuid, const T
 			{
 				TeamPlayer.SetCustomData(CustomData);
 				ImportSessionUpdateToAllPlayers(UpdateWrapper);
-				Delegate.ExecuteIfBound(true, this);
+				Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 				return;
 			}
 		}
 	}
 
-	Delegate.ExecuteIfBound(false, this);
+	Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 }
 
 void URH_OfflineSession::Leave(bool bFromOSS, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
@@ -789,7 +789,7 @@ void URH_OfflineSession::Leave(bool bFromOSS, const FRH_OnSessionUpdatedDelegate
 	Update.Teams.Empty();
 	ImportSessionUpdateToAllPlayers(UpdateWrapper);
 
-	Delegate.ExecuteIfBound(true, this);
+	Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 }
 
 void URH_OfflineSession::RequestInstance(const FRHAPI_InstanceRequest& InstanceRequest, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
@@ -798,7 +798,7 @@ void URH_OfflineSession::RequestInstance(const FRHAPI_InstanceRequest& InstanceR
 	if (GetSessionData().GetInstanceOrNull())
 	{
 		UE_LOG(LogRHSession, Log, TEXT("[%s] - Failed because instance already exists"), ANSI_TO_TCHAR(__FUNCTION__));
-		Delegate.ExecuteIfBound(false, this);
+		Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 		return;
 	}
 
@@ -846,13 +846,13 @@ void URH_OfflineSession::RequestInstance(const FRHAPI_InstanceRequest& InstanceR
 
 		ImportSessionUpdateToAllPlayers(UpdateWrapper);
 
-		Delegate.ExecuteIfBound(true, this);
+		Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 	}
 	else
 	{
 		UE_LOG(LogRHSession, Log, TEXT("[%s] - Failed because owner was not a local player subsystem"), ANSI_TO_TCHAR(__FUNCTION__));
 
-		Delegate.ExecuteIfBound(false, this);
+		Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 	}
 }
 void URH_OfflineSession::EndInstance(const FRH_OnSessionUpdatedDelegateBlock& Delegate)
@@ -861,7 +861,7 @@ void URH_OfflineSession::EndInstance(const FRH_OnSessionUpdatedDelegateBlock& De
 	if (!GetSessionData().GetInstanceOrNull())
 	{
 		UE_LOG(LogRHSession, Log, TEXT("[%s] - Failed because instance does not exist"), ANSI_TO_TCHAR(__FUNCTION__));
-		Delegate.ExecuteIfBound(false, this);
+		Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 		return;
 	}
 
@@ -872,7 +872,7 @@ void URH_OfflineSession::EndInstance(const FRH_OnSessionUpdatedDelegateBlock& De
 
 	ImportSessionUpdateToAllPlayers(UpdateWrapper);
 
-	Delegate.ExecuteIfBound(true, this);
+	Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 }
 
 void URH_OfflineSession::StartMatch(const FRH_OnSessionUpdatedDelegateBlock& Delegate)
@@ -881,7 +881,7 @@ void URH_OfflineSession::StartMatch(const FRH_OnSessionUpdatedDelegateBlock& Del
 	if (GetSessionData().GetMatchOrNull())
 	{
 		UE_LOG(LogRHSession, Log, TEXT("[%s] - Failed because match already exists"), ANSI_TO_TCHAR(__FUNCTION__));
-		Delegate.ExecuteIfBound(false, this);
+		Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 		return;
 	}
 
@@ -903,7 +903,7 @@ void URH_OfflineSession::StartMatch(const FRH_OnSessionUpdatedDelegateBlock& Del
 
 	ImportSessionUpdateToAllPlayers(UpdateWrapper);
 
-	Delegate.ExecuteIfBound(true, this);
+	Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 }
 void URH_OfflineSession::EndMatch(const FRH_OnSessionUpdatedDelegateBlock& Delegate)
 {
@@ -911,7 +911,7 @@ void URH_OfflineSession::EndMatch(const FRH_OnSessionUpdatedDelegateBlock& Deleg
 	if (!GetSessionData().GetMatchOrNull())
 	{
 		UE_LOG(LogRHSession, Log, TEXT("[%s] - Failed because match does not exist"), ANSI_TO_TCHAR(__FUNCTION__));
-		Delegate.ExecuteIfBound(false, this);
+		Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 		return;
 	}
 
@@ -922,7 +922,7 @@ void URH_OfflineSession::EndMatch(const FRH_OnSessionUpdatedDelegateBlock& Deleg
 
 	ImportSessionUpdateToAllPlayers(UpdateWrapper);
 
-	Delegate.ExecuteIfBound(true, this);
+	Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 }
 
 void URH_OfflineSession::UpdateSessionInfo(const FRHAPI_SessionUpdate& SessionInfoUpdate, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
@@ -951,7 +951,7 @@ void URH_OfflineSession::UpdateSessionInfo(const FRHAPI_SessionUpdate& SessionIn
 
 	ImportSessionUpdateToAllPlayers(UpdateWrapper);
 
-	Delegate.ExecuteIfBound(true, this);
+	Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 }
 
 
@@ -961,7 +961,7 @@ void URH_OfflineSession::UpdateInstanceInfo(const FRHAPI_InstanceInfoUpdate& Ins
 	if (!GetSessionData().GetInstanceOrNull())
 	{
 		UE_LOG(LogRHSession, Log, TEXT("[%s] - Failed because instance does not exist"), ANSI_TO_TCHAR(__FUNCTION__));
-		Delegate.ExecuteIfBound(false, this);
+		Delegate.ExecuteIfBound(false, this, FRH_ErrorInfo());
 		return;
 	}
 
@@ -989,7 +989,7 @@ void URH_OfflineSession::UpdateInstanceInfo(const FRHAPI_InstanceInfoUpdate& Ins
 
 	ImportSessionUpdateToAllPlayers(UpdateWrapper);
 
-	Delegate.ExecuteIfBound(true, this);
+	Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 }
 
 void URH_OfflineSession::UpdateBrowserInfo(bool bEnable, const TMap<FString, FString>& CustomData, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
@@ -1013,7 +1013,7 @@ void URH_OfflineSession::UpdateBrowserInfo(bool bEnable, const TMap<FString, FSt
 
 	ImportSessionUpdateToAllPlayers(UpdateWrapper);
 
-	Delegate.ExecuteIfBound(true, this);
+	Delegate.ExecuteIfBound(true, this, FRH_ErrorInfo());
 }
 
 // this is necessary right now as each player stores session data separately

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
@@ -325,9 +325,10 @@ protected:
 	/**
 	* @brief Bootstrapping Flow [WaitingForSession] - callback for when registration process has completed and produced a bootstrapping result
 	* @param [in] bSuccess Whether or not the instance was successfully created
-	* @param [in] RHSession The session that was created with an instance
+	* @param [in] CreatedRHSession The session that was created with an instance
+	* @param [in] ErrorInfo Error information about the instance creation
 	*/
-	virtual void OnSessionInstanceCreationCompleted(bool bSuccess, URH_JoinedSession* RHSession);
+	virtual void OnSessionInstanceCreationCompleted(bool bSuccess, URH_JoinedSession* CreatedRHSession, const FRH_ErrorInfo& ErrorInfo);
 
 	/**
 	* @brief Bootstrapping Flow [SyncingToSession] - begin the process of synchronizing the session state into RH_GameInstanceSessionSubsystem

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_SessionData.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_SessionData.h
@@ -29,9 +29,9 @@ DECLARE_LOG_CATEGORY_EXTERN(LogRHSession, Log, All);
 
 // generic delegate for multiple types of session events
 UDELEGATE()
-DECLARE_DYNAMIC_DELEGATE_TwoParams(FRH_OnSessionUpdatedDynamicDelegate, bool, bSuccess, URH_JoinedSession*, SessionData);
-DECLARE_DELEGATE_TwoParams(FRH_OnSessionUpdatedDelegate, bool, URH_JoinedSession*);
-DECLARE_RH_DELEGATE_BLOCK(FRH_OnSessionUpdatedDelegateBlock, FRH_OnSessionUpdatedDelegate, FRH_OnSessionUpdatedDynamicDelegate, bool, URH_JoinedSession*);
+DECLARE_DYNAMIC_DELEGATE_ThreeParams(FRH_OnSessionUpdatedDynamicDelegate, bool, bSuccess, URH_JoinedSession*, SessionData, const FRH_ErrorInfo&, ErrorInfo);
+DECLARE_DELEGATE_ThreeParams(FRH_OnSessionUpdatedDelegate, bool, URH_JoinedSession*, const FRH_ErrorInfo&);
+DECLARE_RH_DELEGATE_BLOCK(FRH_OnSessionUpdatedDelegateBlock, FRH_OnSessionUpdatedDelegate, FRH_OnSessionUpdatedDynamicDelegate, bool, URH_JoinedSession*, const FRH_ErrorInfo&);
 
 // multicast delegates to notify listeners of session events
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FRH_OnSessionUpdatedMulticastDynamicDelegate, URH_SessionView*, UpdatedSession);


### PR DESCRIPTION
Note - this is a breaking change for anything bound to these delegates.  Fix is straightforward (error info can be ignored if not desired), but does require code tweaks to everything that binds those delegates.