### PR TITLE
Add configuration to fall back to GetAuthToken (synchronous)

### DIFF
--- a/RallyHereIntegration/Config/BaseRallyHereIntegration.ini
+++ b/RallyHereIntegration/Config/BaseRallyHereIntegration.ini
@@ -72,6 +72,10 @@ Google=Google
 Anon=Anon
 Basic=Basic
 
+[UseAuthTokenFallbackFromOSSNameMap]
+PS4_Crossgen=true
+PS5=true
+
 [/Script/RallyHereIntegration.RH_LocalPlayerLoginSubsystem]
 bLoginAllowStoredRefreshToken=true
 bLoginDuringPartialInstall=true

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Common.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Common.cpp
@@ -86,6 +86,26 @@ TOptional<ERHAPI_GrantType> RH_GetGrantTypeFromOSSName(FName OSSName)
 	return OutGrantType;
 }
 
+bool RH_UseGetAuthTokenFallbackFromOSSName(FName OSSName)
+{
+	FString OSSNameString = OSSName.ToString();
+
+	// detect PS4 crossgen support
+	if (OSSName == PS4_SUBSYSTEM)
+	{
+		if (GConfig->GetBoolOrDefault(TEXT("CrossgenSupport"), TEXT("bEnableCrossgenSupport"), false, GEngineIni))
+		{
+			OSSNameString += TEXT("_CrossGen");
+		}
+	}
+
+	bool bUseFallback = false;
+	GConfig->GetBool(TEXT("UseAuthTokenFallbackFromOSSNameMap"), *OSSNameString, bUseFallback, GRallyHereIntegrationIni);
+
+	return bUseFallback;
+}
+
+
 ERHAPI_InventoryBucket RH_GetInventoryBucketFromInventoryPortal(ERHAPI_InventoryPortal InventoryPlatform)
 {
 	switch (InventoryPlatform)

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -497,7 +497,16 @@ void URH_GameInstanceServerBootstrapper::OnOSSLoginComplete(int32 ControllerId, 
 		return;
 	}
 
-	Identity->GetLinkedAccountAuthToken(ControllerId, IOnlineIdentity::FOnGetLinkedAccountAuthTokenCompleteDelegate::CreateUObject(this, &URH_GameInstanceServerBootstrapper::RetrieveOSSAuthTokenComplete));
+	if (RH_UseGetAuthTokenFallbackFromOSSName(OSS->GetSubsystemName()))
+	{
+		FExternalAuthToken AuthToken;
+		AuthToken.TokenString = Identity->GetAuthToken(ControllerId);;
+		RetrieveOSSAuthTokenComplete(ControllerId, !AuthToken.IsValid(), AuthToken);
+	}
+	else
+	{
+		Identity->GetLinkedAccountAuthToken(ControllerId, IOnlineIdentity::FOnGetLinkedAccountAuthTokenCompleteDelegate::CreateUObject(this, &URH_GameInstanceServerBootstrapper::RetrieveOSSAuthTokenComplete));
+	}
 }
 
 void URH_GameInstanceServerBootstrapper::RetrieveOSSAuthTokenComplete(int32 LocalUserNum, bool bWasSuccessful, const FExternalAuthToken& AuthTokenWrapper)

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerLoginSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerLoginSubsystem.cpp
@@ -707,7 +707,16 @@ void URH_LocalPlayerLoginSubsystem::RetrieveOSSAuthToken(FRH_PendingLoginRequest
 
 	int32 ControllerId = GetLocalPlayerSubsystem()->GetLocalPlayer()->GetControllerId();
 
-	LoginIdentity->GetLinkedAccountAuthToken(ControllerId, IOnlineIdentity::FOnGetLinkedAccountAuthTokenCompleteDelegate::CreateUObject(this, &URH_LocalPlayerLoginSubsystem::RetrieveOSSAuthTokenComplete, Req));
+	if (RH_UseGetAuthTokenFallbackFromOSSName(LoginOSS->GetSubsystemName()))
+	{
+		FExternalAuthToken AuthToken;
+		AuthToken.TokenString = LoginIdentity->GetAuthToken(ControllerId);
+		RetrieveOSSAuthTokenComplete(ControllerId, AuthToken.IsValid(), AuthToken, Req);
+	}
+	else
+	{
+		LoginIdentity->GetLinkedAccountAuthToken(ControllerId, IOnlineIdentity::FOnGetLinkedAccountAuthTokenCompleteDelegate::CreateUObject(this, &URH_LocalPlayerLoginSubsystem::RetrieveOSSAuthTokenComplete, Req));
+	}
 }
 
 void URH_LocalPlayerLoginSubsystem::RetrieveOSSAuthTokenComplete(int32 LocalUserNum, bool bWasSuccessful, const FExternalAuthToken& AuthToken, FRH_PendingLoginRequest Req)

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
@@ -71,6 +71,7 @@ bool RALLYHEREINTEGRATION_API RH_GetPlayerIdFromLocalPlayer(const class ULocalPl
 TOptional<ERHAPI_Platform> RALLYHEREINTEGRATION_API RH_GetPlatformFromOSSName(FName OSSName);
 ERHAPI_ClientType RALLYHEREINTEGRATION_API RH_GetClientTypeFromOSSName(FName OSSName);
 TOptional<ERHAPI_GrantType> RALLYHEREINTEGRATION_API RH_GetGrantTypeFromOSSName(FName OSSName);
+bool RALLYHEREINTEGRATION_API RH_UseGetAuthTokenFallbackFromOSSName(FName OSSName);
 ERHAPI_InventoryBucket RALLYHEREINTEGRATION_API RH_GetInventoryBucketFromInventoryPortal(ERHAPI_InventoryPortal InventoryPlatform);
 ERHAPI_InventoryBucket RALLYHEREINTEGRATION_API RH_GetInventoryBucketFromPlatform(ERHAPI_Platform PlatformType);
 


### PR DESCRIPTION
GetLinkedAccountAuthToken did not work as desired for some platforms which had different handling and requirements for the request, especially around secrets clients were required to know.