### PR TITLE
Platform session join on login

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
@@ -11,6 +11,7 @@ URH_IntegrationSettings::URH_IntegrationSettings(const FObjectInitializer& Objec
 	SectionName = TEXT("Rally Here Integration Settings");
 
 	bAutoStartSessionsAfterJoin = true;
+	bAutoJoinPlatformSessionsAfterUserChange = true;
 
 	bLocalPlayerSubsystemSandboxing = false;
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerSessionSubsystem.cpp
@@ -117,6 +117,20 @@ void URH_LocalPlayerSessionSubsystem::OnUserChanged(const FGuid& OldPlayerUuid, 
 		GetLocalPlayerSubsystem()->GetPlayerNotifications()->OnNotificationStreamedByAPI.FindOrAdd(TEXT("session")).AddUObject(this, &URH_LocalPlayerSessionSubsystem::HandleNotification);
 	}
 
+	if (GetDefault<URH_IntegrationSettings>()->bAutoJoinPlatformSessionsAfterUserChange)
+	{
+		if (PlatformSessionToJoinOnUserChange.IsSet() && PlatformSessionToJoinOnUserChange->IsValid())
+		{
+			auto AuthContext = GetAuthContext();
+			if (AuthContext.IsValid() && AuthContext->IsLoggedIn())
+			{
+				// we need to join the session
+				URH_PlatformSessionSyncer::JoinRHSessionByPlatformSession(this, PlatformSessionToJoinOnUserChange.GetValue(), URH_OnlineSession::GetJoinDetailDefaults(this), FRH_GenericSuccessWithErrorBlock());
+			}
+		}
+	}
+	ClearPlatformSessionToJoinOnUserChange();
+
 	URH_SessionView::PollAllSessions(this, true, true, FRH_OnPollAllSessionsDelegate::CreateUObject(this, &URH_LocalPlayerSessionSubsystem::HandlePollAllSessionsComplete));	// immediate update
 	StartPolling();		// start poll timer
 }
@@ -772,8 +786,17 @@ void URH_LocalPlayerSessionSubsystem::OnPlatformActivityActivation(const FUnique
 
 	// we have received a notification that the user accepted an invitation from the system.  We need to attempt to join that session (at which point we will resynchronize with it via the RHSession)
 
-	// we need to join the session
-	URH_PlatformSessionSyncer::JoinRHSessionByPlatformSession(this, *SessionInfo, URH_OnlineSession::GetJoinDetailDefaults(this), FRH_GenericSuccessWithErrorBlock());
+	auto AuthContext = GetAuthContext();
+	if (!AuthContext.IsValid() || !AuthContext->IsLoggedIn())
+	{
+		// we need to wait for the player to log in before joining the session
+		SetPlatformSessionToJoinOnUserChange(*SessionInfo);
+	}
+	else
+	{
+		// we need to join the session
+		URH_PlatformSessionSyncer::JoinRHSessionByPlatformSession(this, *SessionInfo, URH_OnlineSession::GetJoinDetailDefaults(this), FRH_GenericSuccessWithErrorBlock());
+	}
 }
 
 void URH_LocalPlayerSessionSubsystem::OnPlatformSessionInviteAccepted(const bool bSuccesful, const int32 ControllerId, FUniqueNetIdPtr InvitingUserId, const FOnlineSessionSearchResult& Session)
@@ -792,8 +815,17 @@ void URH_LocalPlayerSessionSubsystem::OnPlatformSessionInviteAccepted(const bool
 
 	if (bSuccesful)
 	{
-		// we need to join the session
-		URH_PlatformSessionSyncer::JoinRHSessionByPlatformSession(this, Session, URH_OnlineSession::GetJoinDetailDefaults(this), FRH_GenericSuccessWithErrorBlock());
+		auto AuthContext = GetAuthContext();
+		if (!AuthContext.IsValid() || !AuthContext->IsLoggedIn())
+		{
+			// we need to wait for the player to log in before joining the session
+			SetPlatformSessionToJoinOnUserChange(Session);
+		}
+		else
+		{
+			// we need to join the session
+			URH_PlatformSessionSyncer::JoinRHSessionByPlatformSession(this, Session, URH_OnlineSession::GetJoinDetailDefaults(this), FRH_GenericSuccessWithErrorBlock());
+		}
 	}
 }
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerSessionSubsystem.cpp
@@ -121,7 +121,7 @@ void URH_LocalPlayerSessionSubsystem::OnUserChanged(const FGuid& OldPlayerUuid, 
 	{
 		if (PlatformSessionToJoinOnUserChange.IsSet() && PlatformSessionToJoinOnUserChange->IsValid())
 		{
-			auto AuthContext = GetAuthContext();
+			const auto AuthContext = GetAuthContext();
 			if (AuthContext.IsValid() && AuthContext->IsLoggedIn())
 			{
 				// we need to join the session
@@ -786,7 +786,7 @@ void URH_LocalPlayerSessionSubsystem::OnPlatformActivityActivation(const FUnique
 
 	// we have received a notification that the user accepted an invitation from the system.  We need to attempt to join that session (at which point we will resynchronize with it via the RHSession)
 
-	auto AuthContext = GetAuthContext();
+	const auto AuthContext = GetAuthContext();
 	if (!AuthContext.IsValid() || !AuthContext->IsLoggedIn())
 	{
 		// we need to wait for the player to log in before joining the session
@@ -815,7 +815,7 @@ void URH_LocalPlayerSessionSubsystem::OnPlatformSessionInviteAccepted(const bool
 
 	if (bSuccesful)
 	{
-		auto AuthContext = GetAuthContext();
+		const auto AuthContext = GetAuthContext();
 		if (!AuthContext.IsValid() || !AuthContext->IsLoggedIn())
 		{
 			// we need to wait for the player to log in before joining the session

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
@@ -102,7 +102,7 @@ public:
 	UPROPERTY(EditAnywhere, Config, Category = "Sessions|Platform")
 	bool bAutoStartSessionsAfterJoin;
 
-	/** @brief Whether to automatically start platform sessions after joining them */
+	/** @brief Whether to automatically join platform sessions after a user change when invites were received while logged out */
 	UPROPERTY(EditAnywhere, Config, Category = "Sessions|Platform")
 	bool bAutoJoinPlatformSessionsAfterUserChange;
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
@@ -98,9 +98,13 @@ public:
 	// Sessions
 	////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	/** @brief RallyHere BaseURL. Determines the base URL to use when connecting to the RallyHere API */
+	/** @brief Whether to automatically start platform sessions after joining them */
 	UPROPERTY(EditAnywhere, Config, Category = "Sessions|Platform")
 	bool bAutoStartSessionsAfterJoin;
+
+	/** @brief Whether to automatically start platform sessions after joining them */
+	UPROPERTY(EditAnywhere, Config, Category = "Sessions|Platform")
+	bool bAutoJoinPlatformSessionsAfterUserChange;
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Web Requests

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerSessionSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerSessionSubsystem.h
@@ -6,6 +6,7 @@
 #include "UObject/Object.h"
 #include "OnlineSubsystem.h"
 #include "Interfaces/OnlineSessionInterface.h"
+#include "OnlineSessionSettings.h"
 #include "Engine/EngineBaseTypes.h"
 #include "Misc/Guid.h"
 #include "Templates/SharedPointer.h"
@@ -178,6 +179,17 @@ public:
 	*/
 	UFUNCTION(BlueprintPure, Category = "Session")
 	virtual URH_PlatformSessionSyncer* GetPlatformSyncerByPlatformSessionId(const FUniqueNetIdRepl& PlatformSessionId) const override;
+
+	/** @brief Set a platform session to join upon the next user change */
+	virtual void SetPlatformSessionToJoinOnUserChange(const FOnlineSessionSearchResult& Session)
+	{
+		PlatformSessionToJoinOnUserChange = Session;
+	}
+	/** @brief Clear a platform session to join upon the next user change */
+	virtual void ClearPlatformSessionToJoinOnUserChange()
+	{
+		PlatformSessionToJoinOnUserChange.Reset();
+	}
 
 	/**
 	* @brief Utility function to Create or Join a session by a given SessionType (most times will create a session, but Hub join rules may do a Join instead)
@@ -523,6 +535,8 @@ protected:
 	TOptional<FString> AllSessionsETag;
 	/** @brief ETag of last QueryAllSessionTemplates call response. */
 	TOptional<FString> AllTemplatesETag;
+	/** @brief OSS Session that we need to join upon user change (ex: login). */
+	TOptional<FOnlineSessionSearchResult> PlatformSessionToJoinOnUserChange;
 	/** @brief Map of Session Ids to Sessions we are in. */
 	UPROPERTY(VisibleInstanceOnly, Transient, Category = "Session")
 	TMap<FString, URH_SessionView*> Sessions;


### PR DESCRIPTION
Add setting and storage for platform sessions when invites are received while logged out.  Attempt to join those sessions on login.

This is used for platforms that have session invites that cause the game to boot (or which allow them when a player is not fully logged into RH backend).