### PR TITLE
Include the users-api error code in the FRH_LoginResult object.

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerLoginSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerLoginSubsystem.h
@@ -128,6 +128,9 @@ public:
     /** @brief Login Error Message. */
     UPROPERTY()
     FString OSSErrorMessage;
+	/** @brief RallyHere API Auth Error Code */
+	UPROPERTY()
+	FString RallyHereErrorCode;
     /** @brief Unique Net Id for the player. */
     TSharedPtr<const FUniqueNetId> OSSUniqueId;
     /** @brief Unique Net ID for the player when using Nickname Login. */


### PR DESCRIPTION
Simplified the failed request to object conversion (now that the TryGet functions exist on the response object) Added better logging for users-api error code/desc