### PR TITLE
Fix ranking update delegate being passed by const value instead of passed by ref

### DIFF
--- a/RallyHereDebugTool/Source/Private/RHDTW_PlayerSessions.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_PlayerSessions.cpp
@@ -136,7 +136,7 @@ void FRHDTW_PlayerSessions::DoModifyRankings()
 	}
 }
 
-void FRHDTW_PlayerSessions::HandleUpdateRankingResponse(bool bSuccess, const TArray<FRHAPI_PlayerRankResponseV2> PlayerRankingInfo, FGuid PlayerUuid)
+void FRHDTW_PlayerSessions::HandleUpdateRankingResponse(bool bSuccess, const TArray<FRHAPI_PlayerRankResponseV2>& PlayerRankingInfo, FGuid PlayerUuid)
 {
 	if (bSuccess)
 	{

--- a/RallyHereDebugTool/Source/Public/RHDTW_PlayerSessions.h
+++ b/RallyHereDebugTool/Source/Public/RHDTW_PlayerSessions.h
@@ -23,6 +23,6 @@ struct FRHDTW_PlayerSessions : public FRH_DebugToolWindow
 	float ModifyRankSigmaInput;
 
 private:
-	void HandleUpdateRankingResponse(bool bSuccess, const TArray<FRHAPI_PlayerRankResponseV2> PlayerRankingInfo, FGuid PlayerUuid);
+	void HandleUpdateRankingResponse(bool bSuccess, const TArray<FRHAPI_PlayerRankResponseV2>& PlayerRankingInfo, FGuid PlayerUuid);
 	FString UpdateRankingActionResult;
 };

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInfoSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInfoSubsystem.h
@@ -62,9 +62,9 @@ DECLARE_DELEGATE_TwoParams(FRH_PlayerInfoLookupPlayerDelegate, bool, const TArra
 DECLARE_RH_DELEGATE_BLOCK(FRH_PlayerInfoLookupPlayerBlock, FRH_PlayerInfoLookupPlayerDelegate, FRH_PlayerInfoLookupPlayerDynamicDelegate, bool, const TArray<URH_PlayerInfo*>&)
 
 UDELEGATE()
-DECLARE_DYNAMIC_DELEGATE_TwoParams(FRH_PlayerInfoGetPlayerRankingsDynamicDelegate, bool, bSuccess, const TArray<FRHAPI_PlayerRankResponseV2>, PlayerRankingInfo);
-DECLARE_DELEGATE_TwoParams(FRH_PlayerInfoGetPlayerRankingsDelegate, bool, const TArray<FRHAPI_PlayerRankResponseV2>);
-DECLARE_RH_DELEGATE_BLOCK(FRH_PlayerInfoGetPlayerRankingsBlock, FRH_PlayerInfoGetPlayerRankingsDelegate, FRH_PlayerInfoGetPlayerRankingsDynamicDelegate, bool, const TArray<FRHAPI_PlayerRankResponseV2>)
+DECLARE_DYNAMIC_DELEGATE_TwoParams(FRH_PlayerInfoGetPlayerRankingsDynamicDelegate, bool, bSuccess, const TArray<FRHAPI_PlayerRankResponseV2>&, PlayerRankingInfo);
+DECLARE_DELEGATE_TwoParams(FRH_PlayerInfoGetPlayerRankingsDelegate, bool, const TArray<FRHAPI_PlayerRankResponseV2>&);
+DECLARE_RH_DELEGATE_BLOCK(FRH_PlayerInfoGetPlayerRankingsBlock, FRH_PlayerInfoGetPlayerRankingsDelegate, FRH_PlayerInfoGetPlayerRankingsDynamicDelegate, bool, const TArray<FRHAPI_PlayerRankResponseV2>&)
 
 // multicast delegates to notify listeners of presence events
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FRH_OnPresenceUpdatedMulticastDynamicDelegate, URH_PlayerPresence*, PresenceData);


### PR DESCRIPTION
This is causing blueprint bindings to fail