### PR TITLE
Clear session ETag on user change to prevent invalid session state

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerSessionSubsystem.cpp
@@ -100,6 +100,9 @@ void URH_LocalPlayerSessionSubsystem::OnUserChanged(const FGuid& OldPlayerUuid, 
 		RemoveSession(Session);
 	}
 
+	// clear out our etag storage for sessions, so we will do a full poll next time
+	AllSessionsETag.Reset();
+
 	// ensure sessions array has been cleared out by the above
 	check(Sessions.Num() == 0);
 


### PR DESCRIPTION
Since local session state is cleared on user change, we must clear the etag so that we do a fresh poll on the next login.  This resolves an invalid state if a user logs out and then back in again.