### PR TITLE
Fix session leave delegate callback to have proper value

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_BootstrappingHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_BootstrappingHelpers.h
@@ -228,7 +228,7 @@ protected:
 
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionBootstrappingFinalizer"));
+		static const FString Name(TEXT("FRH_SessionBootstrappingFinalizer"));
 		return Name;
 	}
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_EntitlementHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_EntitlementHelpers.h
@@ -409,7 +409,7 @@ protected:
 	 */
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_EntitlementProcessor"));
+		static const FString Name(TEXT("FRH_EntitlementProcessor"));
 		return Name;
 	}
 	/**

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_NotificationHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_NotificationHelpers.h
@@ -134,7 +134,7 @@ protected:
 
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_NotificationStreamingLongPollHelper"));
+		static const FString Name(TEXT("FRH_NotificationStreamingLongPollHelper"));
 		return Name;
 	}
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionBrowser.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionBrowser.cpp
@@ -237,7 +237,7 @@ protected:
 
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionBrowserSearchHelper"));
+		static const FString Name(TEXT("FRH_SessionBrowserSearchHelper"));
 		return Name;
 	}
 	virtual void ExecuteCallback(bool bSuccess) const override

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionData.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionData.cpp
@@ -414,7 +414,14 @@ void URH_InvitedSession::Join(const FRH_OnSessionUpdatedDelegateBlock& Delegate)
 
 void URH_InvitedSession::Leave(const FRH_OnSessionUpdatedDelegateBlock& Delegate)
 {
-	DoRequestViaHelper<RallyHereAPI::Traits_LeaveSessionByIdSelf>(GetSessionId(), GetSessionOwner(), Delegate, GetDefault<URH_IntegrationSettings>()->SessionLeavePriority);
+	UE_LOG(LogRHSession, Log, TEXT("[%s] - %s"), ANSI_TO_TCHAR(__FUNCTION__), *GetSessionId());
+
+	FRH_SessionLeaveHelper::BaseType::Request Request;
+	Request.AuthContext = GetSessionOwner()->GetSessionAuthContext();
+	Request.SessionId = GetSessionId();
+
+	auto Helper = MakeShared<FRH_SessionLeaveHelper>(MakeWeakInterface(GetSessionOwner()), GetSessionId(), Delegate, GetDefault<URH_IntegrationSettings>()->SessionLeavePriority);
+	Helper->Start(Request);
 }
 
 //////////////////////////////////////////////////////////////////////////////////
@@ -1296,7 +1303,14 @@ void URH_OnlineSession::UpdatePlayerCustomData(const FGuid& PlayerUuid, const TM
 
 void URH_OnlineSession::Leave(bool bFromOSS, const FRH_OnSessionUpdatedDelegateBlock& Delegate)
 {
-	DoRequestViaHelper<RallyHereAPI::Traits_LeaveSessionByIdSelf>(GetSessionId(), GetSessionOwner(), Delegate, GetDefault<URH_IntegrationSettings>()->SessionLeavePriority);
+	UE_LOG(LogRHSession, Log, TEXT("[%s] - %s"), ANSI_TO_TCHAR(__FUNCTION__), *GetSessionId());
+
+	FRH_SessionLeaveHelper::BaseType::Request Request;
+	Request.AuthContext = GetSessionOwner()->GetSessionAuthContext();
+	Request.SessionId = GetSessionId();
+
+	auto Helper = MakeShared<FRH_SessionLeaveHelper>(MakeWeakInterface(GetSessionOwner()), GetSessionId(), Delegate, GetDefault<URH_IntegrationSettings>()->SessionLeavePriority);
+	Helper->Start(Request);
 }
 
 void URH_OnlineSession::RequestInstance(const FRHAPI_InstanceRequest& InstanceRequest, const FRH_OnSessionUpdatedDelegateBlock& Delegate)

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
@@ -885,8 +885,20 @@ public:
 	virtual void OnSessionPollComplete(bool bSuccess, bool bResetTimer) override
 	{
 		// ignore success flag on the poll (it can succeed or fail depending on the session state, we just want to verify that it removed the session from the owner)
-		RHSession = Cast<URH_JoinedSession>(SessionOwner->GetSessionById(SessionId));
-		Completed(!RHSession.IsValid());	// since this is a delete helper, we want the session to be INVALID at this point
+		auto* Session = SessionOwner->GetSessionById(SessionId);
+		auto* InvitedSession = Cast<URH_InvitedSession>(Session);
+
+		if (Session || InvitedSession)
+		{
+			Failed(TEXT("Session still exists after leave"));
+			return;
+		}
+
+		// make sure RHSession is cleared, as it is no longer valid
+		RHSession.Reset();
+
+		// mark leave as complete
+		Completed(true);
 	}
 
 	virtual FString GetName() const override

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
@@ -78,7 +78,7 @@ protected:
 
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionPollHelper"));
+		static const FString Name(TEXT("FRH_SessionPollHelper"));
 		return Name;
 	}
 
@@ -237,7 +237,7 @@ protected:
 
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionLookupHelper"));
+		static const FString Name(TEXT("FRH_SessionLookupHelper"));
 		return Name;
 	}
 
@@ -345,7 +345,7 @@ public:
 protected:
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionPollOnlyHelper"));
+		static const FString Name(TEXT("FRH_SessionPollOnlyHelper"));
 		return Name;
 	}
 	virtual void ExecuteCallback(bool bSuccess) const override
@@ -640,7 +640,7 @@ protected:
 
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionPollAllHelper"));
+		static const FString Name(TEXT("FRH_SessionPollAllHelper"));
 		return Name;
 	}
 	virtual void ExecuteCallback(bool bSuccess) const override
@@ -708,7 +708,7 @@ protected:
 
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionCreateOrJoinByTypeHelper"));
+		static const FString Name(TEXT("FRH_SessionCreateOrJoinByTypeHelper"));
 		return Name;
 	}
 	virtual void ExecuteCallback(bool bSuccess) const override
@@ -784,7 +784,7 @@ protected:
 
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionCreateOrJoinByTypeHelper"));
+		static const FString Name(TEXT("FRH_SessionCreateOrJoinByTypeHelper"));
 		return Name;
 	}
 	virtual void ExecuteCallback(bool bSuccess) const override
@@ -859,7 +859,7 @@ protected:
 
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionJoinByPlatformIdHelper"));
+		static const FString Name(TEXT("FRH_SessionJoinByPlatformIdHelper"));
 		return Name;
 	}
 	virtual void ExecuteCallback(bool bSuccess) const override

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
@@ -76,6 +76,12 @@ protected:
 		}
 	}
 
+	virtual FString GetName() const override
+	{
+		static FString Name(TEXT("FRH_SessionPollHelper"));
+		return Name;
+	}
+
 	FString SessionId;
 	TWeakObjectPtr<URH_JoinedSession> RHSession;
 };
@@ -92,7 +98,7 @@ public:
 
 protected:
 
-	void DoSessionLookup()
+	virtual void DoSessionLookup()
 	{
 		if (!SessionOwner.IsValid())
 		{
@@ -114,7 +120,7 @@ protected:
 		}
 	}
 
-	void OnSessionLookup(const RallyHereAPI::Traits_GetSessionById::Response& Resp)
+	virtual void OnSessionLookup(const RallyHereAPI::Traits_GetSessionById::Response& Resp)
 	{
 		ErrorInfo = FRH_ErrorInfo(Resp);
 
@@ -229,6 +235,13 @@ protected:
 		Completed(RHSession.IsValid());	// add or update can fail in some edge cases, try to be graceful
 	}
 
+	virtual FString GetName() const override
+	{
+		static FString Name(TEXT("FRH_SessionLookupHelper"));
+		return Name;
+	}
+
+
 	FString SessionId;
 	TWeakObjectPtr<URH_JoinedSession> RHSession;
 	FRH_APISessionWithETag SessionCache;
@@ -245,6 +258,7 @@ public:
 		: FRH_SessionPollHelper(InSessionOwner, InSessionId, InPriority)
 		, Delegate(InDelegate)
 	{
+		bRequestWasSuccessful = false;
 	}
 
 	virtual void Start(const typename BaseType::Request& InRequest)
@@ -252,6 +266,7 @@ public:
 		Started();
 		if (SessionOwner.IsValid() && GetAuthContext().IsValid())
 		{
+			bRequestWasSuccessful = false;
 			auto HttpRequest = BaseType::DoCall(RH_APIs::GetSessionsAPI(), InRequest, BaseType::Delegate::CreateSP(this, &FRH_SessionRequestAndModifyHelper::OnRequestById), TaskPriority);
 			if (!HttpRequest)
 			{
@@ -265,12 +280,13 @@ public:
 	}
 protected:
 
-	void OnRequestById(const typename BaseType::Response& Resp)
+	virtual void OnRequestById(const typename BaseType::Response& Resp)
 	{
 		ErrorInfo = FRH_ErrorInfo(Resp);
 
 		if (Resp.IsSuccessful())
 		{
+			bRequestWasSuccessful = true;
 			DoSessionLookup();	// this will re-read the session, and attempt to import it.  The import will detect that we left the session and adjust accordingly
 		}
 		else
@@ -291,6 +307,7 @@ protected:
 	}
 
 	FRH_OnSessionUpdatedDelegateBlock Delegate;
+	bool bRequestWasSuccessful;
 };
 
 
@@ -328,7 +345,7 @@ public:
 protected:
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_SessionPollHelper"));
+		static FString Name(TEXT("FRH_SessionPollOnlyHelper"));
 		return Name;
 	}
 	virtual void ExecuteCallback(bool bSuccess) const override
@@ -851,4 +868,36 @@ protected:
 	}
 
 	FRH_OnSessionUpdatedDelegateBlock Delegate;
+};
+
+
+// Wrapper around a delete that will remove the session locally once the delete is completed, without requiring a poll on the session
+class FRH_SessionLeaveHelper : public FRH_SessionRequestAndModifyHelper<RallyHereAPI::Traits_LeaveSessionByIdSelf>
+{
+public:
+	typedef RallyHereAPI::Traits_LeaveSessionByIdSelf BaseType;
+
+	FRH_SessionLeaveHelper(FRH_SessionOwnerPtr InSessionOwner, const FString& InSessionId, FRH_OnSessionUpdatedDelegateBlock InDelegate = FRH_OnSessionUpdatedDelegateBlock(), int32 InPriority = DefaultRallyHereAPIPriority)
+		: FRH_SessionRequestAndModifyHelper(InSessionOwner, InSessionId, InDelegate, InPriority)
+	{
+	}
+
+	virtual void ExecuteCallback(bool bSuccess) const override
+	{
+		// intercept the callback, since it will fail to find a valid session if we were successful on the delete.  Instead, make sure session is no longer valid
+		if (bRequestWasSuccessful)
+		{
+			Delegate.ExecuteIfBound(!RHSession.IsValid(), RHSession.Get(), ErrorInfo);
+		}
+		else
+		{
+			Delegate.ExecuteIfBound(bSuccess, RHSession.Get(), ErrorInfo);
+		}		
+	}
+
+	virtual FString GetName() const override
+	{
+		static FString Name = FString::Printf(TEXT("FRH_SessionLeaveHelper"));
+		return Name;
+	}
 };

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
@@ -882,7 +882,7 @@ public:
 	{
 	}
 
-	virtual void OnSessionPollComplete(bool bSuccess, bool bResetTimer)
+	virtual void OnSessionPollComplete(bool bSuccess, bool bResetTimer) override
 	{
 		// ignore success flag on the poll (it can succeed or fail depending on the session state, we just want to verify that it removed the session from the owner)
 		RHSession = Cast<URH_JoinedSession>(SessionOwner->GetSessionById(SessionId));

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
@@ -42,7 +42,7 @@ protected:
 	}
 
 
-	void DoSessionLookup()
+	virtual void DoSessionLookup()
 	{
 		if (SessionOwner.IsValid())
 		{
@@ -63,7 +63,7 @@ protected:
 		}
 	}
 
-	void OnSessionPollComplete(bool bSuccess, bool bResetTimer)
+	virtual void OnSessionPollComplete(bool bSuccess, bool bResetTimer)
 	{
 		if (bSuccess && SessionOwner.IsValid())
 		{
@@ -882,17 +882,11 @@ public:
 	{
 	}
 
-	virtual void ExecuteCallback(bool bSuccess) const override
+	virtual void OnSessionPollComplete(bool bSuccess, bool bResetTimer)
 	{
-		// intercept the callback, since it will fail to find a valid session if we were successful on the delete.  Instead, make sure session is no longer valid
-		if (bRequestWasSuccessful)
-		{
-			Delegate.ExecuteIfBound(!RHSession.IsValid(), RHSession.Get(), ErrorInfo);
-		}
-		else
-		{
-			Delegate.ExecuteIfBound(bSuccess, RHSession.Get(), ErrorInfo);
-		}		
+		// ignore success flag on the poll (it can succeed or fail depending on the session state, we just want to verify that it removed the session from the owner)
+		RHSession = Cast<URH_JoinedSession>(SessionOwner->GetSessionById(SessionId));
+		Completed(!RHSession.IsValid());	// since this is a delete helper, we want the session to be INVALID at this point
 	}
 
 	virtual FString GetName() const override

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
@@ -419,7 +419,7 @@ public:
 	/** @brief Gets the templated name for this object */
 	virtual FString GetName() const override
 	{
-		static FString Name(FString::Printf(TEXT("FRH_SimpleQueryHelper<%s>"), *BaseType::Name));
+		static const FString Name(FString::Printf(TEXT("FRH_SimpleQueryHelper<%s>"), *BaseType::Name));
 		return Name;
 	}
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Diagnostics.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Diagnostics.h
@@ -227,7 +227,7 @@ protected:
 	*/
 	virtual FString GetName() const override
 	{
-		static FString Name(TEXT("FRH_DiagnosticReportGenerator"));
+		static const FString Name(TEXT("FRH_DiagnosticReportGenerator"));
 		return Name;
 	}
 	/**


### PR DESCRIPTION
Previously was returning a failure on callback because the poll after the delete was returning an error.