### PR TITLE
Make async helper uninit happen before the RH integration uninit, 

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RallyHereIntegrationModule.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RallyHereIntegrationModule.cpp
@@ -32,6 +32,9 @@ void FRallyHereIntegrationModule::ShutdownModule()
 {
     UE_LOG(LogRallyHereIntegration, Verbose, TEXT("[%s]"), ANSI_TO_TCHAR(__FUNCTION__));
 
+	// uninitialize async helper first, as it will attempt to cancel requests, which may require the integration layer to still be valid
+	FRH_AsyncTaskHelper::Uninitialize();
+
     if (Integration.IsValid())
     {
         Integration->Uninitialize();
@@ -40,5 +43,4 @@ void FRallyHereIntegrationModule::ShutdownModule()
     }
 
 	FRH_PollControl::Uninitialize();
-	FRH_AsyncTaskHelper::Uninitialize();
 }

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
@@ -190,6 +190,7 @@ protected:
 	{
 		bInitialized = true;
 	}
+
 	static void Uninitialize()
 	{
 		// set uninitialize flag immediately, so we can detect if any callbacks are fired after this point


### PR DESCRIPTION
The RH integration owns the retry manager, which async tasks may be using.