### PR TITLE
BREAKING CHANGE: Change FRH_OnSessionUpdated* delegate family signature to return URH_SessionView instead of URH_JoinedSession

### DIFF
--- a/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
@@ -1711,7 +1711,7 @@ void FRHDTW_Session::HandleBrowserSearchResult(bool bSuccess, const FRH_SessionB
 	}
 }
 
-void FRHDTW_Session::HandleSessionUpdatedResult(bool bSuccess, URH_JoinedSession* SessionData, const FRH_ErrorInfo& ErrorInfo, FGuid PlayerUuid)
+void FRHDTW_Session::HandleSessionUpdatedResult(bool bSuccess, URH_SessionView* SessionData, const FRH_ErrorInfo& ErrorInfo, FGuid PlayerUuid)
 {
 	if (bSuccess)
 	{

--- a/RallyHereDebugTool/Source/Public/RHDTW_Session.h
+++ b/RallyHereDebugTool/Source/Public/RHDTW_Session.h
@@ -75,7 +75,7 @@ protected:
 	void ImGuiDisplayRegionsBrowser(URH_GameInstanceSubsystem* pGISubsystem);
 
 	void HandleBrowserSearchResult(bool bSuccess, const FRH_SessionBrowserSearchResult& Result);
-	void HandleSessionUpdatedResult(bool bSuccess, URH_JoinedSession* SessionData, const FRH_ErrorInfo& ErrorInfo, FGuid PlayerUuid);
+	void HandleSessionUpdatedResult(bool bSuccess, URH_SessionView* SessionData, const FRH_ErrorInfo& ErrorInfo, FGuid PlayerUuid);
 
 	void HandleGetPlayerSessions(bool bSuccess, class URH_PlayerSessions* SessionsData, FGuid PlayerUuid);
 	FString GetPlayerSessionsResult;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -989,7 +989,7 @@ void URH_GameInstanceServerBootstrapper::OnRegistrationFinalizerComplete(bool bS
 	}
 }
 
-void URH_GameInstanceServerBootstrapper::OnSessionInstanceCreationCompleted(bool bSuccess, URH_JoinedSession* CreatedRHSession, const FRH_ErrorInfo& ErrorInfo)
+void URH_GameInstanceServerBootstrapper::OnSessionInstanceCreationCompleted(bool bSuccess, URH_SessionView* CreatedRHSession, const FRH_ErrorInfo& ErrorInfo)
 {
 	UE_LOG(LogRallyHereIntegration, Verbose, TEXT("[%s]"), ANSI_TO_TCHAR(__FUNCTION__));
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
@@ -512,7 +512,7 @@ void URH_GameInstanceSessionSubsystem::PollBackfill(const FRH_PollCompleteFunc& 
 		if (ActiveSession->GetInstanceData()->GetJoinStatus() == ERHAPI_InstanceJoinableStatus::Joinable)
 		{
 			ActiveSession->AcknowledgeBackfill(true,
-				FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this, Delegate](bool bSuccess, URH_JoinedSession* Session, const FRH_ErrorInfo& ErrorInfo)
+				FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this, Delegate](bool bSuccess, URH_SessionView* Session, const FRH_ErrorInfo& ErrorInfo)
 					{
 						Delegate.ExecuteIfBound(bSuccess, GetShouldKeepBackfillAlive());
 					}

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlatformSessionSyncer.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlatformSessionSyncer.cpp
@@ -226,18 +226,16 @@ void URH_PlatformSessionSyncer::JoinRHSessionByPlatformSession(FRH_SessionOwnerP
 
 			if (PlatformOptional.IsSet())
 			{
-				auto CompletionDelegate = FRH_OnSessionUpdatedDelegate::CreateLambda([SessionInvite, Delegate](bool bSuccess, URH_JoinedSession* Session, const FRH_ErrorInfo& ErrorInfo)
+				auto CompletionDelegate = FRH_OnSessionUpdatedDelegate::CreateLambda([SessionInvite, Delegate](bool bSuccess, URH_SessionView* Session, const FRH_ErrorInfo& ErrorInfo)
 					{
-						if (bSuccess)
+						auto JoinedSession = Cast<URH_JoinedSession>(Session);
+						if (bSuccess && JoinedSession != nullptr)
 						{
-							if (Session != nullptr)
+							// inject the invite into the session syncer, so it can consume it for joining.  This is required since not all OSS implementations allow you to look up the invite after the fact
+							auto* Syncer = JoinedSession->GetPlatformSyncer();
+							if (Syncer != nullptr)
 							{
-								// inject the invite into the session syncer, so it can consume it for joining.  This is required since not all OSS implementations allow you to look up the invite after the fact
-								auto* Syncer = Session->GetPlatformSyncer();
-								if (Syncer != nullptr)
-								{
-									Syncer->SetCachedPlatformSessionInvite(SessionInvite);
-								}
+								Syncer->SetCachedPlatformSessionInvite(SessionInvite);
 							}
 
 							Delegate.ExecuteIfBound(true, FRH_ErrorInfo());
@@ -643,7 +641,7 @@ void URH_PlatformSessionSyncer::UpdateRHSessionWithPlatformSession()
 		Request.Platform = RHPlatform;
 		Request.PlatformSessionIdBase64 = Base64Str;
 
-		auto Helper = MakeShared<FRH_SessionRequestAndModifyHelper<BaseType>>(SessionOwner, RHSession->GetSessionId(), FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this](bool bSuccess, URH_JoinedSession* Session, const FRH_ErrorInfo& ErrorInfo)
+		auto Helper = MakeShared<FRH_SessionRequestAndModifyHelper<BaseType>>(SessionOwner, RHSession->GetSessionId(), FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this](bool bSuccess, URH_SessionView* Session, const FRH_ErrorInfo& ErrorInfo)
 			{
 				if (bSuccess)
 				{
@@ -969,7 +967,7 @@ void URH_PlatformSessionSyncer::OnScoutFailedToJoin()
 	Request.Platform = PlatformSession.GetPlatform();
 	Request.PlatformSessionIdBase64 = PlatformSession.GetPlatformSessionIdBase64();
 
-	auto Helper = MakeShared<FRH_SessionRequestAndModifyHelper<BaseType>>(SessionOwner, RHSession->GetSessionId(), FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this](bool bSuccess, URH_JoinedSession* Session, const FRH_ErrorInfo& ErrorInfo)
+	auto Helper = MakeShared<FRH_SessionRequestAndModifyHelper<BaseType>>(SessionOwner, RHSession->GetSessionId(), FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this](bool bSuccess, URH_SessionView* Session, const FRH_ErrorInfo& ErrorInfo)
 		{
 			if (bSuccess)
 			{

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionData.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionData.cpp
@@ -269,7 +269,7 @@ void URH_SessionView::PollForUpdate(const FRH_PollCompleteFunc& Delegate)
 		return;
 	}
 
-	FRH_OnSessionUpdatedDelegate CompletionDelegate = FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this, Delegate](bool bSuccess, URH_JoinedSession* Session, const FRH_ErrorInfo& ErrorInfo)
+	FRH_OnSessionUpdatedDelegate CompletionDelegate = FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this, Delegate](bool bSuccess, URH_SessionView* Session, const FRH_ErrorInfo& ErrorInfo)
 		{
 			// notify poller that execution is done
 			Delegate.ExecuteIfBound(bSuccess, true);

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
@@ -342,7 +342,7 @@ protected:
 	* @param [in] CreatedRHSession The session that was created with an instance
 	* @param [in] ErrorInfo Error information about the instance creation
 	*/
-	virtual void OnSessionInstanceCreationCompleted(bool bSuccess, URH_JoinedSession* CreatedRHSession, const FRH_ErrorInfo& ErrorInfo);
+	virtual void OnSessionInstanceCreationCompleted(bool bSuccess, URH_SessionView* CreatedRHSession, const FRH_ErrorInfo& ErrorInfo);
 
 	/**
 	* @brief Bootstrapping Flow [SyncingToSession] - begin the process of synchronizing the session state into RH_GameInstanceSessionSubsystem

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_SessionData.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_SessionData.h
@@ -31,9 +31,9 @@ DECLARE_LOG_CATEGORY_EXTERN(LogRHSession, Log, All);
 
 // generic delegate for multiple types of session events
 UDELEGATE()
-DECLARE_DYNAMIC_DELEGATE_ThreeParams(FRH_OnSessionUpdatedDynamicDelegate, bool, bSuccess, URH_JoinedSession*, SessionData, const FRH_ErrorInfo&, ErrorInfo);
-DECLARE_DELEGATE_ThreeParams(FRH_OnSessionUpdatedDelegate, bool, URH_JoinedSession*, const FRH_ErrorInfo&);
-DECLARE_RH_DELEGATE_BLOCK(FRH_OnSessionUpdatedDelegateBlock, FRH_OnSessionUpdatedDelegate, FRH_OnSessionUpdatedDynamicDelegate, bool, URH_JoinedSession*, const FRH_ErrorInfo&);
+DECLARE_DYNAMIC_DELEGATE_ThreeParams(FRH_OnSessionUpdatedDynamicDelegate, bool, bSuccess, URH_SessionView*, SessionData, const FRH_ErrorInfo&, ErrorInfo);
+DECLARE_DELEGATE_ThreeParams(FRH_OnSessionUpdatedDelegate, bool, URH_SessionView*, const FRH_ErrorInfo&);
+DECLARE_RH_DELEGATE_BLOCK(FRH_OnSessionUpdatedDelegateBlock, FRH_OnSessionUpdatedDelegate, FRH_OnSessionUpdatedDynamicDelegate, bool, URH_SessionView*, const FRH_ErrorInfo&);
 
 // multicast delegates to notify listeners of session events
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FRH_OnSessionUpdatedMulticastDynamicDelegate, URH_SessionView*, UpdatedSession);


### PR DESCRIPTION
Note that this will break bindings to the delegate, and also may break code dependent upon the type being specifically a joined session (ex: now invited sessions will be returned whereas previously they would not be)

Rework session helpers to be properly generic to URH_SessionView, as they have become used for all session class types.