### PR TITLE
BREAKING CHANGE: Convert top level singletons from UObjects to non-UObjects

### DIFF
--- a/Documentation/md/Diagnostics.md
+++ b/Documentation/md/Diagnostics.md
@@ -7,7 +7,8 @@
 `public  `[`DECLARE_DELEGATE_RetVal`](#group__Diagnostics_1ga5c0e0f7ab52220c28ea3c2013a8d01ab)`(TSharedPtr< FJsonObject >,FGetCustomDiagnosticMetadata)`            | Bindable delegate to get custom metadata to add to diagnostic reports. Can be used by a project to add data to the Metadata section.
 `public  `[`DECLARE_DELEGATE_OneParam`](#group__Diagnostics_1gaca3c1dd67b5858439ff6ba89a1098a40)`(FRH_OnDiagnosticReportComplete,const TSharedRef< const `[`FRH_DiagnosticReportGenerator`](Diagnostics.md#classFRH__DiagnosticReportGenerator)` > &)`            | Bindable delegate to notify that a report generation is complete
 `class `[`FRH_DiagnosticReportGenerator`](#classFRH__DiagnosticReportGenerator) | Report generator worker, which is responsible for collecting information from various locations, organizing the report, and then writing it to a destination.
-`class `[`URH_Diagnostics`](#classURH__Diagnostics) | Class to handle initializing and running a diagnostic (blueprint compatible). Tracks and stores local state from the running engine for tracking previous errors.
+`class `[`FRH_Diagnostics`](#classFRH__Diagnostics) | Class to handle initializing and running a diagnostic (blueprint compatible). Tracks and stores local state from the running engine for tracking previous errors.
+`class `[`URH_DiagnosticsBlueprintLibrary`](#classURH__DiagnosticsBlueprintLibrary) | Wrapper library to generate diagnostic reports via blueprint.
 `struct `[`FRH_DiagnosticReportOptions`](#structFRH__DiagnosticReportOptions) | Options for generating a diagnostic report.
 
 ## Members
@@ -179,11 +180,11 @@ Complete            |
 Generation stage for report generation
 
 <br>
-## class `URH_Diagnostics` <a id="classURH__Diagnostics"></a>
+## class `FRH_Diagnostics` <a id="classFRH__Diagnostics"></a>
 
 ```
-class URH_Diagnostics
-  : public UObject
+class FRH_Diagnostics
+  : public TSharedFromThis< FRH_Diagnostics >
 ```
 
 Class to handle initializing and running a diagnostic (blueprint compatible). Tracks and stores local state from the running engine for tracking previous errors.
@@ -192,35 +193,39 @@ Class to handle initializing and running a diagnostic (blueprint compatible). Tr
 
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
-`public FGetCustomDiagnosticMetadata `[`CustomDiagnosticMetadataDelegate`](#classURH__Diagnostics_1ab860df08eb6095f4f5f43444e8d7c11d) | Delegate to bind to to add extra custom data to the diagnostic report.
-`public void `[`Initialize`](#classURH__Diagnostics_1a09db63ade24dff6ca72fa074123e2ae4)`()` | Initialize the system.
-`public void `[`Uninitialize`](#classURH__Diagnostics_1aef532309fb4b7286c73b1d13e28ec724)`()` | Safely tears down the system.
-`public inline void `[`ClearCache`](#classURH__Diagnostics_1ae4b65389f97cffb4688e812dbbfe1299)`()` | Clears the diagnostics cache.
-`public void `[`GenerateReport`](#classURH__Diagnostics_1a9a78e0f94f71290018966989baed3988)`(const `[`FRH_DiagnosticReportOptions`](Diagnostics.md#structFRH__DiagnosticReportOptions)` & Options) const` | Generates a report in JSON format.
+`public FGetCustomDiagnosticMetadata `[`CustomDiagnosticMetadataDelegate`](#classFRH__Diagnostics_1ac8e8b53c27e0c2f4d437654551cf235b) | Delegate to bind to to add extra custom data to the diagnostic report.
+`public  `[`FRH_Diagnostics`](#classFRH__Diagnostics_1ad3d045b72c14e877b003ee8c7e8d66da)`()` | 
+`public void `[`Initialize`](#classFRH__Diagnostics_1ad5444a3df81d6df8e72c6f28bd628ffb)`()` | Initialize the system.
+`public void `[`Uninitialize`](#classFRH__Diagnostics_1aabfaaf4bb0d726a2e1b88e5bd43ed23c)`()` | Safely tears down the system.
+`public inline void `[`ClearCache`](#classFRH__Diagnostics_1a2858cf748a6c4fcf3425f443b8d01e5c)`()` | Clears the diagnostics cache.
+`public void `[`GenerateReport`](#classFRH__Diagnostics_1ad763783b4820ab6e33a4588dffc87f29)`(const `[`FRH_DiagnosticReportOptions`](Diagnostics.md#structFRH__DiagnosticReportOptions)` & Options) const` | Generates a report in JSON format.
 
 #### Members
 
-#### `public FGetCustomDiagnosticMetadata `[`CustomDiagnosticMetadataDelegate`](#classURH__Diagnostics_1ab860df08eb6095f4f5f43444e8d7c11d) <a id="classURH__Diagnostics_1ab860df08eb6095f4f5f43444e8d7c11d"></a>
+#### `public FGetCustomDiagnosticMetadata `[`CustomDiagnosticMetadataDelegate`](#classFRH__Diagnostics_1ac8e8b53c27e0c2f4d437654551cf235b) <a id="classFRH__Diagnostics_1ac8e8b53c27e0c2f4d437654551cf235b"></a>
 
 Delegate to bind to to add extra custom data to the diagnostic report.
 
 <br>
-#### `public void `[`Initialize`](#classURH__Diagnostics_1a09db63ade24dff6ca72fa074123e2ae4)`()` <a id="classURH__Diagnostics_1a09db63ade24dff6ca72fa074123e2ae4"></a>
+#### `public  `[`FRH_Diagnostics`](#classFRH__Diagnostics_1ad3d045b72c14e877b003ee8c7e8d66da)`()` <a id="classFRH__Diagnostics_1ad3d045b72c14e877b003ee8c7e8d66da"></a>
+
+<br>
+#### `public void `[`Initialize`](#classFRH__Diagnostics_1ad5444a3df81d6df8e72c6f28bd628ffb)`()` <a id="classFRH__Diagnostics_1ad5444a3df81d6df8e72c6f28bd628ffb"></a>
 
 Initialize the system.
 
 <br>
-#### `public void `[`Uninitialize`](#classURH__Diagnostics_1aef532309fb4b7286c73b1d13e28ec724)`()` <a id="classURH__Diagnostics_1aef532309fb4b7286c73b1d13e28ec724"></a>
+#### `public void `[`Uninitialize`](#classFRH__Diagnostics_1aabfaaf4bb0d726a2e1b88e5bd43ed23c)`()` <a id="classFRH__Diagnostics_1aabfaaf4bb0d726a2e1b88e5bd43ed23c"></a>
 
 Safely tears down the system.
 
 <br>
-#### `public inline void `[`ClearCache`](#classURH__Diagnostics_1ae4b65389f97cffb4688e812dbbfe1299)`()` <a id="classURH__Diagnostics_1ae4b65389f97cffb4688e812dbbfe1299"></a>
+#### `public inline void `[`ClearCache`](#classFRH__Diagnostics_1a2858cf748a6c4fcf3425f443b8d01e5c)`()` <a id="classFRH__Diagnostics_1a2858cf748a6c4fcf3425f443b8d01e5c"></a>
 
 Clears the diagnostics cache.
 
 <br>
-#### `public void `[`GenerateReport`](#classURH__Diagnostics_1a9a78e0f94f71290018966989baed3988)`(const `[`FRH_DiagnosticReportOptions`](Diagnostics.md#structFRH__DiagnosticReportOptions)` & Options) const` <a id="classURH__Diagnostics_1a9a78e0f94f71290018966989baed3988"></a>
+#### `public void `[`GenerateReport`](#classFRH__Diagnostics_1ad763783b4820ab6e33a4588dffc87f29)`(const `[`FRH_DiagnosticReportOptions`](Diagnostics.md#structFRH__DiagnosticReportOptions)` & Options) const` <a id="classFRH__Diagnostics_1ad763783b4820ab6e33a4588dffc87f29"></a>
 
 Generates a report in JSON format.
 
@@ -233,6 +238,22 @@ Generates a report in JSON format.
 The generated object
 
 <br>
+## class `URH_DiagnosticsBlueprintLibrary` <a id="classURH__DiagnosticsBlueprintLibrary"></a>
+
+```
+class URH_DiagnosticsBlueprintLibrary
+  : public UBlueprintFunctionLibrary
+```
+
+Wrapper library to generate diagnostic reports via blueprint.
+
+#### Summary
+
+ Members                        | Descriptions                                
+--------------------------------|---------------------------------------------
+
+#### Members
+
 ## struct `FRH_DiagnosticReportOptions` <a id="structFRH__DiagnosticReportOptions"></a>
 
 Options for generating a diagnostic report.

--- a/Documentation/md/IntegrationBase.md
+++ b/Documentation/md/IntegrationBase.md
@@ -5,7 +5,7 @@
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
 `class `[`FRallyHereIntegrationModule`](#classFRallyHereIntegrationModule) | Module for the Rally Here Integration Layer.
-`class `[`URH_Integration`](#classURH__Integration) | Main integration layer handler.
+`class `[`FRH_Integration`](#classFRH__Integration) | Main integration layer handler.
 
 ## class `FRallyHereIntegrationModule` <a id="classFRallyHereIntegrationModule"></a>
 
@@ -23,7 +23,7 @@ Module for the Rally Here Integration Layer.
 `public  `[`~FRallyHereIntegrationModule`](#classFRallyHereIntegrationModule_1a05fc3130408ed64a45219dfdaca29120)`() = default` | Default constructor.
 `public void `[`StartupModule`](#classFRallyHereIntegrationModule_1ac91ef7cb3468c0eb68c74069f99fa47b)`()` | Initializes the module.
 `public void `[`ShutdownModule`](#classFRallyHereIntegrationModule_1a537c97b39e36b257d3499bb8f88b2aff)`()` | Safely ends the module.
-`public inline `[`URH_Integration`](IntegrationBase.md#classURH__Integration)` & `[`GetIntegration`](#classFRallyHereIntegrationModule_1aef9bad7d1f539b0e86e055663d30df2a)`() const` | Gets the Integration class fromt he module.
+`public inline `[`FRH_Integration`](IntegrationBase.md#classFRH__Integration)` & `[`GetIntegration`](#classFRallyHereIntegrationModule_1ab428b2c8db543b36835a636472d55ed8)`() const` | Gets the Integration class fromt he module.
 
 #### Members
 
@@ -42,17 +42,12 @@ Initializes the module.
 Safely ends the module.
 
 <br>
-#### `public inline `[`URH_Integration`](IntegrationBase.md#classURH__Integration)` & `[`GetIntegration`](#classFRallyHereIntegrationModule_1aef9bad7d1f539b0e86e055663d30df2a)`() const` <a id="classFRallyHereIntegrationModule_1aef9bad7d1f539b0e86e055663d30df2a"></a>
+#### `public inline `[`FRH_Integration`](IntegrationBase.md#classFRH__Integration)` & `[`GetIntegration`](#classFRallyHereIntegrationModule_1ab428b2c8db543b36835a636472d55ed8)`() const` <a id="classFRallyHereIntegrationModule_1ab428b2c8db543b36835a636472d55ed8"></a>
 
 Gets the Integration class fromt he module.
 
 <br>
-## class `URH_Integration` <a id="classURH__Integration"></a>
-
-```
-class URH_Integration
-  : public UObject
-```
+## class `FRH_Integration` <a id="classFRH__Integration"></a>
 
 Main integration layer handler.
 
@@ -60,52 +55,56 @@ Main integration layer handler.
 
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
-`public void `[`Initialize`](#classURH__Integration_1a900d421aea13c81ac91e48ec7a0b8f98)`()` | Initialize the Integration layer.
-`public void `[`Uninitialize`](#classURH__Integration_1af1069eb3dfe1229a2a2b0044b5d4ab17)`()` | Safely tears down the Integration layer.
-`public inline RallyHereAPI::FRallyHereAPIAll & `[`GetAPIs`](#classURH__Integration_1ae6de9d69bfaa3d3386a3bb47380156b3)`()` | Gets all the APIs.
-`public inline HttpRetryManagerPtr `[`GetRetryManager`](#classURH__Integration_1a79fc427b8c7eebdbd4a973bad90682ad)`() const` | Gets Base Retry Manager for all RallyHereAPI calls.
-`public void `[`SetEnvironmentId`](#classURH__Integration_1ad2478a83d20d2be82097d36162b2e94a)`(FString InEnvironmentId,const FString & Source)` | Sets the environment for he connection.
-`public FString `[`GetEnvironmentId`](#classURH__Integration_1a007194b606488da9cbc5299826c6c3ba)`()` | Get the current Environment Id (will run ResolveEnvironmentId if there isn't one)
-`public void `[`ResolveEnvironmentId`](#classURH__Integration_1a0b20b4df9925d720b4c1c97c1c38a149)`()` | Get the Environment ID used for finding the base URL from the first of the following sources:
-`public inline void `[`LockEnvironmentId`](#classURH__Integration_1a52b751ec4b8385731cf6490a8a4846ac)`(bool bLocked)` | Updates the locked status of the Environment Id.
-`public void `[`SetBaseURL`](#classURH__Integration_1a3f1a9a24ef392322deda7f4e08838889)`(FString InBaseUrl,const FString & Source)` | Set the base URL for all RallyHereAPI calls.
-`public FString `[`GetBaseURL`](#classURH__Integration_1a6a80ff137a6b4417db6a0e022f8bd7f2)`()` | Get the current base URL (will run ResolveBaseURL if there isn't one)
-`public void `[`ResolveBaseURL`](#classURH__Integration_1a9ba65df152ad1d5205d9a43959d63b3b)`()` | Check for a base URL across several sources and assign the first non-empty value to the APIs:
-`public inline void `[`LockBaseURL`](#classURH__Integration_1a2d48d18ed8c425037b48716951c609b7)`(bool bLocked)` | Updates the locked status of the Base URL.
-`public void `[`SetClientId`](#classURH__Integration_1ab09fcf4dd89f17f1867ce6ac9cf93ebb)`(FString InClientId,const FString & Source)` | Set the client ID for the AuthContext.
-`public FString `[`GetClientId`](#classURH__Integration_1a7dde924eb4f662a32d710711a2a5d45d)`()` | Get the current client ID (will run ResolveClientId if there isn't one).
-`public void `[`ResolveClientId`](#classURH__Integration_1aa5c8e07f1530d510afcb84e42c3eef06)`()` | Check for a client ID across several sources and assign the first non-empty value to the APIs:
-`public inline void `[`LockClientId`](#classURH__Integration_1a04b8f6446f4bc3380d15a20129804de6)`(bool bLocked)` | Updates the locked status of the Client Id.
-`public void `[`SetClientSecret`](#classURH__Integration_1aa3c279d80bcc31d8fb2366bf8d4a5a59)`(FString InClientSecret,const FString & Source)` | Set the client secret for the AuthContext.
-`public FString `[`GetClientSecret`](#classURH__Integration_1a3c51a0686676ab34896ed21fe7ed786e)`()` | Get the current client secret (will run ResolveClientSecret if there isn't one).
-`public void `[`ResolveClientSecret`](#classURH__Integration_1acf88cad66d6acbf99495f8895da38917)`()` | Check for a client secret across several sources and assign the first non-empty value to the APIs:
-`public inline void `[`LockClientSecret`](#classURH__Integration_1a05204a2d20528a3b4f59952368ae1814)`(bool bLocked)` | Updates the locked status of the Client Secret.
-`public inline class `[`URH_WebRequests`](WebRequest.md#classURH__WebRequests)` * `[`GetWebRequestTracker`](#classURH__Integration_1aa0eca33c0d2add66db9ecf8d169325a0)`() const` | Gets the Web Request Tracker.
-`public inline class `[`URH_Diagnostics`](Diagnostics.md#classURH__Diagnostics)` * `[`GetDiagnostics`](#classURH__Integration_1a9031d6508ab6dd48cbfa74e9e698fbdb)`() const` | Gets the Diagnostic Reporter.
+`public  `[`FRH_Integration`](#classFRH__Integration_1ad429ec1c11342e1a32bc418f9c527c7f)`()` | 
+`public void `[`Initialize`](#classFRH__Integration_1a5406bc46c19e6268c00ace04a51e13af)`()` | Initialize the Integration layer.
+`public void `[`Uninitialize`](#classFRH__Integration_1affec69b27c9acf7015815812bbb6833f)`()` | Safely tears down the Integration layer.
+`public inline RallyHereAPI::FRallyHereAPIAll & `[`GetAPIs`](#classFRH__Integration_1a890bf9b414bc85d6c057a3b9158204ed)`()` | Gets all the APIs.
+`public inline HttpRetryManagerPtr `[`GetRetryManager`](#classFRH__Integration_1afc39eec959666867e8c4bae0de6ff862)`() const` | Gets Base Retry Manager for all RallyHereAPI calls.
+`public void `[`SetEnvironmentId`](#classFRH__Integration_1a2c35e2e9223d77db72f0fc4927a61cac)`(FString InEnvironmentId,const FString & Source)` | Sets the environment for he connection.
+`public FString `[`GetEnvironmentId`](#classFRH__Integration_1ad0d54cb4e8185064ab8feb5b8cfe1158)`()` | Get the current Environment Id (will run ResolveEnvironmentId if there isn't one)
+`public void `[`ResolveEnvironmentId`](#classFRH__Integration_1a9579149b9470a1a8b8eefb9978a6d6aa)`()` | Get the Environment ID used for finding the base URL from the first of the following sources:
+`public inline void `[`LockEnvironmentId`](#classFRH__Integration_1a2416f70e5f8aefa4621077557046b518)`(bool bLocked)` | Updates the locked status of the Environment Id.
+`public void `[`SetBaseURL`](#classFRH__Integration_1a2de7c31c9f2df613372b70899612a75e)`(FString InBaseUrl,const FString & Source)` | Set the base URL for all RallyHereAPI calls.
+`public FString `[`GetBaseURL`](#classFRH__Integration_1a2133066a14b8ece9675e74ab9be18e68)`()` | Get the current base URL (will run ResolveBaseURL if there isn't one)
+`public void `[`ResolveBaseURL`](#classFRH__Integration_1ab948f32204bfe002d03f6faa58f4b761)`()` | Check for a base URL across several sources and assign the first non-empty value to the APIs:
+`public inline void `[`LockBaseURL`](#classFRH__Integration_1a5078259f8298619fa5ac7966da3f6e0c)`(bool bLocked)` | Updates the locked status of the Base URL.
+`public void `[`SetClientId`](#classFRH__Integration_1abbe2d34dc0d7a870c747f00c9ad1e4c5)`(FString InClientId,const FString & Source)` | Set the client ID for the AuthContext.
+`public FString `[`GetClientId`](#classFRH__Integration_1a695e02ae6c4327902afcfe12a121b6cd)`()` | Get the current client ID (will run ResolveClientId if there isn't one).
+`public void `[`ResolveClientId`](#classFRH__Integration_1a13a7c74b6fce44f275bc0131442c5f61)`()` | Check for a client ID across several sources and assign the first non-empty value to the APIs:
+`public inline void `[`LockClientId`](#classFRH__Integration_1ae547716a7648acf415dee0f3d334a7ac)`(bool bLocked)` | Updates the locked status of the Client Id.
+`public void `[`SetClientSecret`](#classFRH__Integration_1a6b05ae0200ee5f66ed2ce503abbbdf88)`(FString InClientSecret,const FString & Source)` | Set the client secret for the AuthContext.
+`public FString `[`GetClientSecret`](#classFRH__Integration_1ac50700a8ff4e112ed60171ffbf5817b7)`()` | Get the current client secret (will run ResolveClientSecret if there isn't one).
+`public void `[`ResolveClientSecret`](#classFRH__Integration_1a19706c54b4a17d6e82b3f86c22247be2)`()` | Check for a client secret across several sources and assign the first non-empty value to the APIs:
+`public inline void `[`LockClientSecret`](#classFRH__Integration_1aeb750cd617fad0b3ade042b7a7c1d54a)`(bool bLocked)` | Updates the locked status of the Client Secret.
+`public inline `[`FRH_WebRequests`](WebRequest.md#classFRH__WebRequests)` * `[`GetWebRequestTracker`](#classFRH__Integration_1a3b54823f537913d46a2266f9a4875a16)`() const` | Gets the Web Request Tracker.
+`public inline `[`FRH_Diagnostics`](Diagnostics.md#classFRH__Diagnostics)` * `[`GetDiagnostics`](#classFRH__Integration_1a0f7dc5599a89b010715dba506bb16288)`() const` | Gets the Diagnostic Reporter.
 
 #### Members
 
-#### `public void `[`Initialize`](#classURH__Integration_1a900d421aea13c81ac91e48ec7a0b8f98)`()` <a id="classURH__Integration_1a900d421aea13c81ac91e48ec7a0b8f98"></a>
+#### `public  `[`FRH_Integration`](#classFRH__Integration_1ad429ec1c11342e1a32bc418f9c527c7f)`()` <a id="classFRH__Integration_1ad429ec1c11342e1a32bc418f9c527c7f"></a>
+
+<br>
+#### `public void `[`Initialize`](#classFRH__Integration_1a5406bc46c19e6268c00ace04a51e13af)`()` <a id="classFRH__Integration_1a5406bc46c19e6268c00ace04a51e13af"></a>
 
 Initialize the Integration layer.
 
 <br>
-#### `public void `[`Uninitialize`](#classURH__Integration_1af1069eb3dfe1229a2a2b0044b5d4ab17)`()` <a id="classURH__Integration_1af1069eb3dfe1229a2a2b0044b5d4ab17"></a>
+#### `public void `[`Uninitialize`](#classFRH__Integration_1affec69b27c9acf7015815812bbb6833f)`()` <a id="classFRH__Integration_1affec69b27c9acf7015815812bbb6833f"></a>
 
 Safely tears down the Integration layer.
 
 <br>
-#### `public inline RallyHereAPI::FRallyHereAPIAll & `[`GetAPIs`](#classURH__Integration_1ae6de9d69bfaa3d3386a3bb47380156b3)`()` <a id="classURH__Integration_1ae6de9d69bfaa3d3386a3bb47380156b3"></a>
+#### `public inline RallyHereAPI::FRallyHereAPIAll & `[`GetAPIs`](#classFRH__Integration_1a890bf9b414bc85d6c057a3b9158204ed)`()` <a id="classFRH__Integration_1a890bf9b414bc85d6c057a3b9158204ed"></a>
 
 Gets all the APIs.
 
 <br>
-#### `public inline HttpRetryManagerPtr `[`GetRetryManager`](#classURH__Integration_1a79fc427b8c7eebdbd4a973bad90682ad)`() const` <a id="classURH__Integration_1a79fc427b8c7eebdbd4a973bad90682ad"></a>
+#### `public inline HttpRetryManagerPtr `[`GetRetryManager`](#classFRH__Integration_1afc39eec959666867e8c4bae0de6ff862)`() const` <a id="classFRH__Integration_1afc39eec959666867e8c4bae0de6ff862"></a>
 
 Gets Base Retry Manager for all RallyHereAPI calls.
 
 <br>
-#### `public void `[`SetEnvironmentId`](#classURH__Integration_1ad2478a83d20d2be82097d36162b2e94a)`(FString InEnvironmentId,const FString & Source)` <a id="classURH__Integration_1ad2478a83d20d2be82097d36162b2e94a"></a>
+#### `public void `[`SetEnvironmentId`](#classFRH__Integration_1a2c35e2e9223d77db72f0fc4927a61cac)`(FString InEnvironmentId,const FString & Source)` <a id="classFRH__Integration_1a2c35e2e9223d77db72f0fc4927a61cac"></a>
 
 Sets the environment for he connection.
 
@@ -115,12 +114,12 @@ Sets the environment for he connection.
 * `Source` The source of the environment change, for logging.
 
 <br>
-#### `public FString `[`GetEnvironmentId`](#classURH__Integration_1a007194b606488da9cbc5299826c6c3ba)`()` <a id="classURH__Integration_1a007194b606488da9cbc5299826c6c3ba"></a>
+#### `public FString `[`GetEnvironmentId`](#classFRH__Integration_1ad0d54cb4e8185064ab8feb5b8cfe1158)`()` <a id="classFRH__Integration_1ad0d54cb4e8185064ab8feb5b8cfe1158"></a>
 
 Get the current Environment Id (will run ResolveEnvironmentId if there isn't one)
 
 <br>
-#### `public void `[`ResolveEnvironmentId`](#classURH__Integration_1a0b20b4df9925d720b4c1c97c1c38a149)`()` <a id="classURH__Integration_1a0b20b4df9925d720b4c1c97c1c38a149"></a>
+#### `public void `[`ResolveEnvironmentId`](#classFRH__Integration_1a9579149b9470a1a8b8eefb9978a6d6aa)`()` <a id="classFRH__Integration_1a9579149b9470a1a8b8eefb9978a6d6aa"></a>
 
 Get the Environment ID used for finding the base URL from the first of the following sources:
 
@@ -129,7 +128,7 @@ Get the Environment ID used for finding the base URL from the first of the follo
 * Results from GetEnvironmentId from the EnvironmentOSSName (or default if one is not provided)
 
 <br>
-#### `public inline void `[`LockEnvironmentId`](#classURH__Integration_1a52b751ec4b8385731cf6490a8a4846ac)`(bool bLocked)` <a id="classURH__Integration_1a52b751ec4b8385731cf6490a8a4846ac"></a>
+#### `public inline void `[`LockEnvironmentId`](#classFRH__Integration_1a2416f70e5f8aefa4621077557046b518)`(bool bLocked)` <a id="classFRH__Integration_1a2416f70e5f8aefa4621077557046b518"></a>
 
 Updates the locked status of the Environment Id.
 
@@ -137,7 +136,7 @@ Updates the locked status of the Environment Id.
 * `bLocked` If locked, disables the ResolveEnvironmentId function.
 
 <br>
-#### `public void `[`SetBaseURL`](#classURH__Integration_1a3f1a9a24ef392322deda7f4e08838889)`(FString InBaseUrl,const FString & Source)` <a id="classURH__Integration_1a3f1a9a24ef392322deda7f4e08838889"></a>
+#### `public void `[`SetBaseURL`](#classFRH__Integration_1a2de7c31c9f2df613372b70899612a75e)`(FString InBaseUrl,const FString & Source)` <a id="classFRH__Integration_1a2de7c31c9f2df613372b70899612a75e"></a>
 
 Set the base URL for all RallyHereAPI calls.
 
@@ -147,12 +146,12 @@ Set the base URL for all RallyHereAPI calls.
 * `Source` The source of the base URL change, for logging.
 
 <br>
-#### `public FString `[`GetBaseURL`](#classURH__Integration_1a6a80ff137a6b4417db6a0e022f8bd7f2)`()` <a id="classURH__Integration_1a6a80ff137a6b4417db6a0e022f8bd7f2"></a>
+#### `public FString `[`GetBaseURL`](#classFRH__Integration_1a2133066a14b8ece9675e74ab9be18e68)`()` <a id="classFRH__Integration_1a2133066a14b8ece9675e74ab9be18e68"></a>
 
 Get the current base URL (will run ResolveBaseURL if there isn't one)
 
 <br>
-#### `public void `[`ResolveBaseURL`](#classURH__Integration_1a9ba65df152ad1d5205d9a43959d63b3b)`()` <a id="classURH__Integration_1a9ba65df152ad1d5205d9a43959d63b3b"></a>
+#### `public void `[`ResolveBaseURL`](#classFRH__Integration_1ab948f32204bfe002d03f6faa58f4b761)`()` <a id="classFRH__Integration_1ab948f32204bfe002d03f6faa58f4b761"></a>
 
 Check for a base URL across several sources and assign the first non-empty value to the APIs:
 
@@ -163,7 +162,7 @@ Check for a base URL across several sources and assign the first non-empty value
 * ini value from the section for this class, with the "BaseUrl" key.
 
 <br>
-#### `public inline void `[`LockBaseURL`](#classURH__Integration_1a2d48d18ed8c425037b48716951c609b7)`(bool bLocked)` <a id="classURH__Integration_1a2d48d18ed8c425037b48716951c609b7"></a>
+#### `public inline void `[`LockBaseURL`](#classFRH__Integration_1a5078259f8298619fa5ac7966da3f6e0c)`(bool bLocked)` <a id="classFRH__Integration_1a5078259f8298619fa5ac7966da3f6e0c"></a>
 
 Updates the locked status of the Base URL.
 
@@ -171,7 +170,7 @@ Updates the locked status of the Base URL.
 * `bLocked` If locked, disables the ResolveBaseURL function.
 
 <br>
-#### `public void `[`SetClientId`](#classURH__Integration_1ab09fcf4dd89f17f1867ce6ac9cf93ebb)`(FString InClientId,const FString & Source)` <a id="classURH__Integration_1ab09fcf4dd89f17f1867ce6ac9cf93ebb"></a>
+#### `public void `[`SetClientId`](#classFRH__Integration_1abbe2d34dc0d7a870c747f00c9ad1e4c5)`(FString InClientId,const FString & Source)` <a id="classFRH__Integration_1abbe2d34dc0d7a870c747f00c9ad1e4c5"></a>
 
 Set the client ID for the AuthContext.
 
@@ -181,12 +180,12 @@ Set the client ID for the AuthContext.
 * `Source` The source of the base Client Id Change, for logging.
 
 <br>
-#### `public FString `[`GetClientId`](#classURH__Integration_1a7dde924eb4f662a32d710711a2a5d45d)`()` <a id="classURH__Integration_1a7dde924eb4f662a32d710711a2a5d45d"></a>
+#### `public FString `[`GetClientId`](#classFRH__Integration_1a695e02ae6c4327902afcfe12a121b6cd)`()` <a id="classFRH__Integration_1a695e02ae6c4327902afcfe12a121b6cd"></a>
 
 Get the current client ID (will run ResolveClientId if there isn't one).
 
 <br>
-#### `public void `[`ResolveClientId`](#classURH__Integration_1aa5c8e07f1530d510afcb84e42c3eef06)`()` <a id="classURH__Integration_1aa5c8e07f1530d510afcb84e42c3eef06"></a>
+#### `public void `[`ResolveClientId`](#classFRH__Integration_1a13a7c74b6fce44f275bc0131442c5f61)`()` <a id="classFRH__Integration_1a13a7c74b6fce44f275bc0131442c5f61"></a>
 
 Check for a client ID across several sources and assign the first non-empty value to the APIs:
 
@@ -197,7 +196,7 @@ Check for a client ID across several sources and assign the first non-empty valu
 * ini value from the section for this class, with the "ClientId" key.
 
 <br>
-#### `public inline void `[`LockClientId`](#classURH__Integration_1a04b8f6446f4bc3380d15a20129804de6)`(bool bLocked)` <a id="classURH__Integration_1a04b8f6446f4bc3380d15a20129804de6"></a>
+#### `public inline void `[`LockClientId`](#classFRH__Integration_1ae547716a7648acf415dee0f3d334a7ac)`(bool bLocked)` <a id="classFRH__Integration_1ae547716a7648acf415dee0f3d334a7ac"></a>
 
 Updates the locked status of the Client Id.
 
@@ -205,7 +204,7 @@ Updates the locked status of the Client Id.
 * `bLocked` If locked, disables the ResolveClientId function.
 
 <br>
-#### `public void `[`SetClientSecret`](#classURH__Integration_1aa3c279d80bcc31d8fb2366bf8d4a5a59)`(FString InClientSecret,const FString & Source)` <a id="classURH__Integration_1aa3c279d80bcc31d8fb2366bf8d4a5a59"></a>
+#### `public void `[`SetClientSecret`](#classFRH__Integration_1a6b05ae0200ee5f66ed2ce503abbbdf88)`(FString InClientSecret,const FString & Source)` <a id="classFRH__Integration_1a6b05ae0200ee5f66ed2ce503abbbdf88"></a>
 
 Set the client secret for the AuthContext.
 
@@ -215,12 +214,12 @@ Set the client secret for the AuthContext.
 * `Source` The source of the base Client Secret Change, for logging.
 
 <br>
-#### `public FString `[`GetClientSecret`](#classURH__Integration_1a3c51a0686676ab34896ed21fe7ed786e)`()` <a id="classURH__Integration_1a3c51a0686676ab34896ed21fe7ed786e"></a>
+#### `public FString `[`GetClientSecret`](#classFRH__Integration_1ac50700a8ff4e112ed60171ffbf5817b7)`()` <a id="classFRH__Integration_1ac50700a8ff4e112ed60171ffbf5817b7"></a>
 
 Get the current client secret (will run ResolveClientSecret if there isn't one).
 
 <br>
-#### `public void `[`ResolveClientSecret`](#classURH__Integration_1acf88cad66d6acbf99495f8895da38917)`()` <a id="classURH__Integration_1acf88cad66d6acbf99495f8895da38917"></a>
+#### `public void `[`ResolveClientSecret`](#classFRH__Integration_1a19706c54b4a17d6e82b3f86c22247be2)`()` <a id="classFRH__Integration_1a19706c54b4a17d6e82b3f86c22247be2"></a>
 
 Check for a client secret across several sources and assign the first non-empty value to the APIs:
 
@@ -231,7 +230,7 @@ Check for a client secret across several sources and assign the first non-empty 
 * ini value from the section for this class, with the "ClientSecret" key.
 
 <br>
-#### `public inline void `[`LockClientSecret`](#classURH__Integration_1a05204a2d20528a3b4f59952368ae1814)`(bool bLocked)` <a id="classURH__Integration_1a05204a2d20528a3b4f59952368ae1814"></a>
+#### `public inline void `[`LockClientSecret`](#classFRH__Integration_1aeb750cd617fad0b3ade042b7a7c1d54a)`(bool bLocked)` <a id="classFRH__Integration_1aeb750cd617fad0b3ade042b7a7c1d54a"></a>
 
 Updates the locked status of the Client Secret.
 
@@ -239,12 +238,12 @@ Updates the locked status of the Client Secret.
 * `bLocked` If locked, disables the ResolveClientSecret function.
 
 <br>
-#### `public inline class `[`URH_WebRequests`](WebRequest.md#classURH__WebRequests)` * `[`GetWebRequestTracker`](#classURH__Integration_1aa0eca33c0d2add66db9ecf8d169325a0)`() const` <a id="classURH__Integration_1aa0eca33c0d2add66db9ecf8d169325a0"></a>
+#### `public inline `[`FRH_WebRequests`](WebRequest.md#classFRH__WebRequests)` * `[`GetWebRequestTracker`](#classFRH__Integration_1a3b54823f537913d46a2266f9a4875a16)`() const` <a id="classFRH__Integration_1a3b54823f537913d46a2266f9a4875a16"></a>
 
 Gets the Web Request Tracker.
 
 <br>
-#### `public inline class `[`URH_Diagnostics`](Diagnostics.md#classURH__Diagnostics)` * `[`GetDiagnostics`](#classURH__Integration_1a9031d6508ab6dd48cbfa74e9e698fbdb)`() const` <a id="classURH__Integration_1a9031d6508ab6dd48cbfa74e9e698fbdb"></a>
+#### `public inline `[`FRH_Diagnostics`](Diagnostics.md#classFRH__Diagnostics)` * `[`GetDiagnostics`](#classFRH__Integration_1a0f7dc5599a89b010715dba506bb16288)`() const` <a id="classFRH__Integration_1a0f7dc5599a89b010715dba506bb16288"></a>
 
 Gets the Diagnostic Reporter.
 

--- a/Documentation/md/IntegrationSettings.md
+++ b/Documentation/md/IntegrationSettings.md
@@ -30,7 +30,10 @@ Main settings for the Integration.
 `public FName `[`EnvironmentOSSName`](#classURH__IntegrationSettings_1a6dcea31e94599c761b3616e62f0b65ab) | Online Subsystem to use for selecting the base URL environment. If not provided, will use the default OSS.
 `public bool `[`bAutoStartSessionsAfterJoin`](#classURH__IntegrationSettings_1a43e468e0d80e224c6fc7479940e0bcab) | Whether to automatically start platform sessions after joining them.
 `public bool `[`bAutoJoinPlatformSessionsAfterUserChange`](#classURH__IntegrationSettings_1a999a80d02b5974b5be5be331ac13682a) | Whether to automatically join platform sessions after a user change when invites were received while logged out.
-`public int32 `[`MaxSimultaneousRequests`](#classURH__IntegrationSettings_1a250923c3c001c712d54691a9efa5f98b) | Sets the maximum number of Http Requests that can be made simultaneously. 0 = No Limit.
+`public int32 `[`WebRequestsMaxSimultaneousRequests`](#classURH__IntegrationSettings_1a86e14803734cde1b954191b437ceaafe) | Sets the maximum number of Http Requests that can be made simultaneously. 0 = No Limit.
+`public int `[`WebRequestsTrackedRequestsCountLimit`](#classURH__IntegrationSettings_1a35b03db2758bd2f4e393fb1fb3c7aab4) | Sets the maximum number of web requests for which tracking data is kept.
+`public int32 `[`WebRequestsBurstCountThreshold`](#classURH__IntegrationSettings_1af81d481668affe4c87d3fb8c20cf239d) | Sets the count above which web traffic is considered a burst.
+`public int32 `[`WebRequestsBurstTimeThresholdInSeconds`](#classURH__IntegrationSettings_1abb0a83cebcc39ea7215e7207bca115cb) | Sets the time threshold for web traffic burst detection.
 `public FSoftClassPath `[`LocalPlayerLoginSubsystemClass`](#classURH__IntegrationSettings_1aea8c51bec96a3a50100085354f8fe816) | Extensible LocalPlayerLoginSubsystem class path.
 `public FSoftClassPath `[`AdSubsystemClass`](#classURH__IntegrationSettings_1a134dbaebd973ab90d1bdb12027285009) | Extensible AdSubsystem class path.
 `public FSoftClassPath `[`FriendSubsystemClass`](#classURH__IntegrationSettings_1af67c19ac851c03c6e667a609182e1ac9) | Extensible FriendSubsystem class path.
@@ -182,9 +185,24 @@ Whether to automatically start platform sessions after joining them.
 Whether to automatically join platform sessions after a user change when invites were received while logged out.
 
 <br>
-#### `public int32 `[`MaxSimultaneousRequests`](#classURH__IntegrationSettings_1a250923c3c001c712d54691a9efa5f98b) <a id="classURH__IntegrationSettings_1a250923c3c001c712d54691a9efa5f98b"></a>
+#### `public int32 `[`WebRequestsMaxSimultaneousRequests`](#classURH__IntegrationSettings_1a86e14803734cde1b954191b437ceaafe) <a id="classURH__IntegrationSettings_1a86e14803734cde1b954191b437ceaafe"></a>
 
 Sets the maximum number of Http Requests that can be made simultaneously. 0 = No Limit.
+
+<br>
+#### `public int `[`WebRequestsTrackedRequestsCountLimit`](#classURH__IntegrationSettings_1a35b03db2758bd2f4e393fb1fb3c7aab4) <a id="classURH__IntegrationSettings_1a35b03db2758bd2f4e393fb1fb3c7aab4"></a>
+
+Sets the maximum number of web requests for which tracking data is kept.
+
+<br>
+#### `public int32 `[`WebRequestsBurstCountThreshold`](#classURH__IntegrationSettings_1af81d481668affe4c87d3fb8c20cf239d) <a id="classURH__IntegrationSettings_1af81d481668affe4c87d3fb8c20cf239d"></a>
+
+Sets the count above which web traffic is considered a burst.
+
+<br>
+#### `public int32 `[`WebRequestsBurstTimeThresholdInSeconds`](#classURH__IntegrationSettings_1abb0a83cebcc39ea7215e7207bca115cb) <a id="classURH__IntegrationSettings_1abb0a83cebcc39ea7215e7207bca115cb"></a>
+
+Sets the time threshold for web traffic burst detection.
 
 <br>
 #### `public FSoftClassPath `[`LocalPlayerLoginSubsystemClass`](#classURH__IntegrationSettings_1aea8c51bec96a3a50100085354f8fe816) <a id="classURH__IntegrationSettings_1aea8c51bec96a3a50100085354f8fe816"></a>

--- a/Documentation/md/LocalPlayer.md
+++ b/Documentation/md/LocalPlayer.md
@@ -82,7 +82,7 @@ Login Subsystem for the local player.
 `public bool `[`bLogoutAndRetryLoginIfRefreshLoginFailed`](#classURH__LocalPlayerLoginSubsystem_1a1f638ff5b5f352dfffdb315e30478d3c) | Should we logout of the OSS and retry the login (that included a refresh token) failed?
 `public bool `[`bLoginOSSUseIDTokenAsPortalParentAccessToken`](#classURH__LocalPlayerLoginSubsystem_1ae7c66f0f89b289dff65c385c23f0590d) | Should we use the ID Token for populating the PARENT Portal Access Token.
 `public bool `[`bLoginOSSUseIDTokenAsPortalAccessToken`](#classURH__LocalPlayerLoginSubsystem_1a2ddbbfbcad16d8ae949cfcbed714eef1) | Should we use the ID Token for populating the Portal Access Token.
-`public bool `[`bResolveRallyHereBaseURLAfterOSSLogin`](#classURH__LocalPlayerLoginSubsystem_1a92a9774beae64448f7c0895a7e6eacff) | Should an OSS Login trigger a Base URL Resolve on the [URH_Integration](IntegrationBase.md#classURH__Integration)? This is necessary for some OSSes (e.g. Switch/PS4) that don't have environment information until after a login is attempted.
+`public bool `[`bResolveRallyHereBaseURLAfterOSSLogin`](#classURH__LocalPlayerLoginSubsystem_1a92a9774beae64448f7c0895a7e6eacff) | Should an OSS Login trigger a Base URL Resolve on the [FRH_Integration](IntegrationBase.md#classFRH__Integration)? This is necessary for some OSSes (e.g. Switch/PS4) that don't have environment information until after a login is attempted.
 `public FString `[`SavedCredentialPrefix`](#classURH__LocalPlayerLoginSubsystem_1a5ff0051c770983ee18208136805b9754) | Prefix applied to the saved credentials on platforms that support storing the refresh token.
 `public virtual void `[`Initialize`](#classURH__LocalPlayerLoginSubsystem_1a938bd41c5c5fa6b5eacbeb43d0758a63)`()` | Initialize the subsystem.
 `public virtual void `[`Deinitialize`](#classURH__LocalPlayerLoginSubsystem_1a363bdf9386b7854ed44a03cfe6faea18)`()` | Safely tears down the subsystem.
@@ -230,7 +230,7 @@ Should we use the ID Token for populating the Portal Access Token.
 <br>
 #### `public bool `[`bResolveRallyHereBaseURLAfterOSSLogin`](#classURH__LocalPlayerLoginSubsystem_1a92a9774beae64448f7c0895a7e6eacff) <a id="classURH__LocalPlayerLoginSubsystem_1a92a9774beae64448f7c0895a7e6eacff"></a>
 
-Should an OSS Login trigger a Base URL Resolve on the [URH_Integration](IntegrationBase.md#classURH__Integration)? This is necessary for some OSSes (e.g. Switch/PS4) that don't have environment information until after a login is attempted.
+Should an OSS Login trigger a Base URL Resolve on the [FRH_Integration](IntegrationBase.md#classFRH__Integration)? This is necessary for some OSSes (e.g. Switch/PS4) that don't have environment information until after a login is attempted.
 
 <br>
 #### `public FString `[`SavedCredentialPrefix`](#classURH__LocalPlayerLoginSubsystem_1a5ff0051c770983ee18208136805b9754) <a id="classURH__LocalPlayerLoginSubsystem_1a5ff0051c770983ee18208136805b9754"></a>

--- a/Documentation/md/WebRequest.md
+++ b/Documentation/md/WebRequest.md
@@ -4,15 +4,15 @@
 
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
-`class `[`URH_WebRequests`](#classURH__WebRequests) | Class to handle executing and tracking low-level Http Web Requests.
+`class `[`FRH_WebRequests`](#classFRH__WebRequests) | Class to handle executing and tracking low-level Http Web Requests.
 `struct `[`FRH_WebResponse`](#structFRH__WebResponse) | Web call response data.
 `struct `[`FRH_WebRequest`](#structFRH__WebRequest) | Web call request data.
 
-## class `URH_WebRequests` <a id="classURH__WebRequests"></a>
+## class `FRH_WebRequests` <a id="classFRH__WebRequests"></a>
 
 ```
-class URH_WebRequests
-  : public UObject
+class FRH_WebRequests
+  : public TSharedFromThis< FRH_WebRequests >
 ```
 
 Class to handle executing and tracking low-level Http Web Requests.
@@ -21,28 +21,32 @@ Class to handle executing and tracking low-level Http Web Requests.
 
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
-`public void `[`Initialize`](#classURH__WebRequests_1a886700f37a477d596e3c9045efecaa5e)`(RallyHereAPI::FRallyHereAPIAll * InAPIs)` | Initialize the Web Request system.
-`public void `[`Uninitialize`](#classURH__WebRequests_1a0fe605b98c24740235f2d192f73b83ef)`()` | Safely tears down the Web Request system.
-`public const TDoubleLinkedList< TSharedPtr< `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` > > & `[`GetTrackedRequests`](#classURH__WebRequests_1ae509b51d596a857b604d52ebe268b196)`() const` | Gets all of the requests that have been tracked.
-`public const `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` * `[`GetTrackedRequestById`](#classURH__WebRequests_1a5eaf4f440b4e90f8a96e280cc0bc781f)`(const FGuid & id) const` | Gets a specific request that has been tracked.
-`public inline void `[`ClearTrackedRequests`](#classURH__WebRequests_1a5b244dbdc062a2ccc6215120568081ef)`()` | Clears all tracked requests out.
-`public const TArray< FName > `[`GetAPINames`](#classURH__WebRequests_1ac70288b2112bf750dcf1e10bceb0e58b)`() const` | Gets the list of all APIs able to be tracked.
-`public bool `[`GetLogAllWebRequests`](#classURH__WebRequests_1a0b7bd41f05fbd01363e4246418fcb2c0)`() const` | Gets if we are currently logging web requests from all APIs.
-`public void `[`SetLogAllWebRequests`](#classURH__WebRequests_1a896febe3fa4643357764c2822ce77ff4)`(bool bValue)` | Sets logging web requests for all APIs.
-`public FString `[`FormatWebRequestToJsonBlob`](#classURH__WebRequests_1ab0fcffa02db11aabcbe1e571f809e186)`(const `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` & request) const` | Converts a Web Request to a string in JSON format.
-`public TSharedPtr< FJsonObject > `[`LogTrackedWebRequestsToJSON`](#classURH__WebRequests_1aaf261d2509ba4e48a59613d53fd0b024)`() const` | Logs all tracked request to a specified file.
-`public inline FORCEINLINE bool `[`GetLogWebRequests`](#classURH__WebRequests_1a2e0e846ba66a95e7680a51d42edb6706)`(const FName & APIName) const` | Gets if a specific API is being logged currently.
-`public inline FORCEINLINE void `[`SetLogWebRequests`](#classURH__WebRequests_1a2a07322b447aac227feb43192aaf3372)`(const FName & APIName,bool bValue)` | Sets logging for a specific API.
-`public inline FORCEINLINE bool `[`GetIsRetainingWebRequests`](#classURH__WebRequests_1a9248d832ca7d43f05d7e528703cf5df1)`() const` | Get whether web requests should be cached indefinitely or cleared after reaching the cache limit.
-`public inline FORCEINLINE void `[`SetIsRetainingWebRequests`](#classURH__WebRequests_1ac640bcc4171398824dbca3fff9bcebfd)`(bool bValue)` | Set whether web requests should be cached indefinitely or cleared after reaching the cache limit.
-`public inline const TMap< FName, int32 > `[`GetAPINameToCallCountMap`](#classURH__WebRequests_1a018f06e0cf588740d42b80af334dd238)`() const` | Get the map that tracks all-time call count for each API.
-`public inline const TMap< FName, int32 > `[`GetSimplifiedPathToCallCountMap`](#classURH__WebRequests_1ac940579b57d7c6ad400fda8fc4a42e2e)`() const` | Get the map that tracks all-time call count for each generic URL.
-`public void `[`GetRecentCallCountMaps`](#classURH__WebRequests_1af8e59e4e179be1054a8783f6c56daca8)`(TMap< FName, int32 > * OutAPIRecentCallCountMap,TMap< FName, int32 > * OutURLRecentCallCountMap) const` | Get the maps that track call counts in the last 60s.
-`public void `[`DetectRecentBursts`](#classURH__WebRequests_1a96cc4bf85561ff86c5444563e5d4fe40)`(TMap< FName, TTuple< int32, int32 >> * OutBurstMapByAPIName,TMap< FName, TTuple< int32, int32 >> * OutBurstMapByURL) const` | Detects bursts in recent call counts (last 60s). The time and count thresholds for burst detection are specified by BurstCountThreshold and BurstTimeThreshold.
+`public  `[`FRH_WebRequests`](#classFRH__WebRequests_1a6bd3f313618ea335e953e4ae73f2451e)`()` | 
+`public void `[`Initialize`](#classFRH__WebRequests_1aa8eac9764a88b64c29ccb7cb51c4d622)`(RallyHereAPI::FRallyHereAPIAll * InAPIs)` | Initialize the Web Request system.
+`public void `[`Uninitialize`](#classFRH__WebRequests_1a382793a98b70e46a8c91d68e916eec79)`()` | Safely tears down the Web Request system.
+`public const TDoubleLinkedList< TSharedPtr< `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` > > & `[`GetTrackedRequests`](#classFRH__WebRequests_1a1007d0f3a728a313542c0102429fa025)`() const` | Gets all of the requests that have been tracked.
+`public const `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` * `[`GetTrackedRequestById`](#classFRH__WebRequests_1a7e6cd0b2db53bb9a2f5ac674d024e18a)`(const FGuid & id) const` | Gets a specific request that has been tracked.
+`public inline void `[`ClearTrackedRequests`](#classFRH__WebRequests_1a74effd6ec52cc0277dfbf74280d0b70e)`()` | Clears all tracked requests out.
+`public const TArray< FName > `[`GetAPINames`](#classFRH__WebRequests_1a445f4f1da7eed1b0f83d72e01b6b19ff)`() const` | Gets the list of all APIs able to be tracked.
+`public bool `[`GetLogAllWebRequests`](#classFRH__WebRequests_1ae17e6a97581a4e03b1342f792c5e90ed)`() const` | Gets if we are currently logging web requests from all APIs.
+`public void `[`SetLogAllWebRequests`](#classFRH__WebRequests_1a938ee62e398c42ffab1b1bf02b809530)`(bool bValue)` | Sets logging web requests for all APIs.
+`public FString `[`FormatWebRequestToJsonBlob`](#classFRH__WebRequests_1aa04c3d05ffaabb74d76bffe6ea96dac5)`(const `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` & request) const` | Converts a Web Request to a string in JSON format.
+`public TSharedPtr< FJsonObject > `[`LogTrackedWebRequestsToJSON`](#classFRH__WebRequests_1ab749e824dbdfe71df5263f06eac89967)`() const` | Logs all tracked request to a specified file.
+`public inline FORCEINLINE bool `[`GetLogWebRequests`](#classFRH__WebRequests_1a4754abff6242738e32ed65763be2b104)`(const FName & APIName) const` | Gets if a specific API is being logged currently.
+`public inline FORCEINLINE void `[`SetLogWebRequests`](#classFRH__WebRequests_1a400485994e0446ffdb240543cc829116)`(const FName & APIName,bool bValue)` | Sets logging for a specific API.
+`public inline FORCEINLINE bool `[`GetIsRetainingWebRequests`](#classFRH__WebRequests_1a7f81dfc689eead12123790431fd76b34)`() const` | Get whether web requests should be cached indefinitely or cleared after reaching the cache limit.
+`public inline FORCEINLINE void `[`SetIsRetainingWebRequests`](#classFRH__WebRequests_1af312673a93b7b16cf1661606237837ee)`(bool bValue)` | Set whether web requests should be cached indefinitely or cleared after reaching the cache limit.
+`public inline const TMap< FName, int32 > `[`GetAPINameToCallCountMap`](#classFRH__WebRequests_1abcb430aac4da7a8b12fc4e3d4a4735fa)`() const` | Get the map that tracks all-time call count for each API.
+`public inline const TMap< FName, int32 > `[`GetSimplifiedPathToCallCountMap`](#classFRH__WebRequests_1aed90013183d6a6ec2b05d621a2f3a9b3)`() const` | Get the map that tracks all-time call count for each generic URL.
+`public void `[`GetRecentCallCountMaps`](#classFRH__WebRequests_1ab93ed7476bba71269269d3d364189f86)`(TMap< FName, int32 > * OutAPIRecentCallCountMap,TMap< FName, int32 > * OutURLRecentCallCountMap) const` | Get the maps that track call counts in the last 60s.
+`public void `[`DetectRecentBursts`](#classFRH__WebRequests_1a64e8ecf52cf4760ab79f033ba0ef66e0)`(TMap< FName, TTuple< int32, int32 >> * OutBurstMapByAPIName,TMap< FName, TTuple< int32, int32 >> * OutBurstMapByURL) const` | Detects bursts in recent call counts (last 60s). The time and count thresholds for burst detection are specified by BurstCountThreshold and BurstTimeThreshold.
 
 #### Members
 
-#### `public void `[`Initialize`](#classURH__WebRequests_1a886700f37a477d596e3c9045efecaa5e)`(RallyHereAPI::FRallyHereAPIAll * InAPIs)` <a id="classURH__WebRequests_1a886700f37a477d596e3c9045efecaa5e"></a>
+#### `public  `[`FRH_WebRequests`](#classFRH__WebRequests_1a6bd3f313618ea335e953e4ae73f2451e)`()` <a id="classFRH__WebRequests_1a6bd3f313618ea335e953e4ae73f2451e"></a>
+
+<br>
+#### `public void `[`Initialize`](#classFRH__WebRequests_1aa8eac9764a88b64c29ccb7cb51c4d622)`(RallyHereAPI::FRallyHereAPIAll * InAPIs)` <a id="classFRH__WebRequests_1aa8eac9764a88b64c29ccb7cb51c4d622"></a>
 
 Initialize the Web Request system.
 
@@ -50,17 +54,17 @@ Initialize the Web Request system.
 * `InAPIs` The APIs the web request system tracks requests from.
 
 <br>
-#### `public void `[`Uninitialize`](#classURH__WebRequests_1a0fe605b98c24740235f2d192f73b83ef)`()` <a id="classURH__WebRequests_1a0fe605b98c24740235f2d192f73b83ef"></a>
+#### `public void `[`Uninitialize`](#classFRH__WebRequests_1a382793a98b70e46a8c91d68e916eec79)`()` <a id="classFRH__WebRequests_1a382793a98b70e46a8c91d68e916eec79"></a>
 
 Safely tears down the Web Request system.
 
 <br>
-#### `public const TDoubleLinkedList< TSharedPtr< `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` > > & `[`GetTrackedRequests`](#classURH__WebRequests_1ae509b51d596a857b604d52ebe268b196)`() const` <a id="classURH__WebRequests_1ae509b51d596a857b604d52ebe268b196"></a>
+#### `public const TDoubleLinkedList< TSharedPtr< `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` > > & `[`GetTrackedRequests`](#classFRH__WebRequests_1a1007d0f3a728a313542c0102429fa025)`() const` <a id="classFRH__WebRequests_1a1007d0f3a728a313542c0102429fa025"></a>
 
 Gets all of the requests that have been tracked.
 
 <br>
-#### `public const `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` * `[`GetTrackedRequestById`](#classURH__WebRequests_1a5eaf4f440b4e90f8a96e280cc0bc781f)`(const FGuid & id) const` <a id="classURH__WebRequests_1a5eaf4f440b4e90f8a96e280cc0bc781f"></a>
+#### `public const `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` * `[`GetTrackedRequestById`](#classFRH__WebRequests_1a7e6cd0b2db53bb9a2f5ac674d024e18a)`(const FGuid & id) const` <a id="classFRH__WebRequests_1a7e6cd0b2db53bb9a2f5ac674d024e18a"></a>
 
 Gets a specific request that has been tracked.
 
@@ -68,22 +72,22 @@ Gets a specific request that has been tracked.
 * `id` The id of the request to get.
 
 <br>
-#### `public inline void `[`ClearTrackedRequests`](#classURH__WebRequests_1a5b244dbdc062a2ccc6215120568081ef)`()` <a id="classURH__WebRequests_1a5b244dbdc062a2ccc6215120568081ef"></a>
+#### `public inline void `[`ClearTrackedRequests`](#classFRH__WebRequests_1a74effd6ec52cc0277dfbf74280d0b70e)`()` <a id="classFRH__WebRequests_1a74effd6ec52cc0277dfbf74280d0b70e"></a>
 
 Clears all tracked requests out.
 
 <br>
-#### `public const TArray< FName > `[`GetAPINames`](#classURH__WebRequests_1ac70288b2112bf750dcf1e10bceb0e58b)`() const` <a id="classURH__WebRequests_1ac70288b2112bf750dcf1e10bceb0e58b"></a>
+#### `public const TArray< FName > `[`GetAPINames`](#classFRH__WebRequests_1a445f4f1da7eed1b0f83d72e01b6b19ff)`() const` <a id="classFRH__WebRequests_1a445f4f1da7eed1b0f83d72e01b6b19ff"></a>
 
 Gets the list of all APIs able to be tracked.
 
 <br>
-#### `public bool `[`GetLogAllWebRequests`](#classURH__WebRequests_1a0b7bd41f05fbd01363e4246418fcb2c0)`() const` <a id="classURH__WebRequests_1a0b7bd41f05fbd01363e4246418fcb2c0"></a>
+#### `public bool `[`GetLogAllWebRequests`](#classFRH__WebRequests_1ae17e6a97581a4e03b1342f792c5e90ed)`() const` <a id="classFRH__WebRequests_1ae17e6a97581a4e03b1342f792c5e90ed"></a>
 
 Gets if we are currently logging web requests from all APIs.
 
 <br>
-#### `public void `[`SetLogAllWebRequests`](#classURH__WebRequests_1a896febe3fa4643357764c2822ce77ff4)`(bool bValue)` <a id="classURH__WebRequests_1a896febe3fa4643357764c2822ce77ff4"></a>
+#### `public void `[`SetLogAllWebRequests`](#classFRH__WebRequests_1a938ee62e398c42ffab1b1bf02b809530)`(bool bValue)` <a id="classFRH__WebRequests_1a938ee62e398c42ffab1b1bf02b809530"></a>
 
 Sets logging web requests for all APIs.
 
@@ -91,7 +95,7 @@ Sets logging web requests for all APIs.
 * `bValue` If true, turn on logging for all APIs, else turn off.
 
 <br>
-#### `public FString `[`FormatWebRequestToJsonBlob`](#classURH__WebRequests_1ab0fcffa02db11aabcbe1e571f809e186)`(const `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` & request) const` <a id="classURH__WebRequests_1ab0fcffa02db11aabcbe1e571f809e186"></a>
+#### `public FString `[`FormatWebRequestToJsonBlob`](#classFRH__WebRequests_1aa04c3d05ffaabb74d76bffe6ea96dac5)`(const `[`FRH_WebRequest`](WebRequest.md#structFRH__WebRequest)` & request) const` <a id="classFRH__WebRequests_1aa04c3d05ffaabb74d76bffe6ea96dac5"></a>
 
 Converts a Web Request to a string in JSON format.
 
@@ -102,7 +106,7 @@ Converts a Web Request to a string in JSON format.
 String of the request in JSON format.
 
 <br>
-#### `public TSharedPtr< FJsonObject > `[`LogTrackedWebRequestsToJSON`](#classURH__WebRequests_1aaf261d2509ba4e48a59613d53fd0b024)`() const` <a id="classURH__WebRequests_1aaf261d2509ba4e48a59613d53fd0b024"></a>
+#### `public TSharedPtr< FJsonObject > `[`LogTrackedWebRequestsToJSON`](#classFRH__WebRequests_1ab749e824dbdfe71df5263f06eac89967)`() const` <a id="classFRH__WebRequests_1ab749e824dbdfe71df5263f06eac89967"></a>
 
 Logs all tracked request to a specified file.
 
@@ -113,7 +117,7 @@ Logs all tracked request to a specified file.
 the full path of the file that was written
 
 <br>
-#### `public inline FORCEINLINE bool `[`GetLogWebRequests`](#classURH__WebRequests_1a2e0e846ba66a95e7680a51d42edb6706)`(const FName & APIName) const` <a id="classURH__WebRequests_1a2e0e846ba66a95e7680a51d42edb6706"></a>
+#### `public inline FORCEINLINE bool `[`GetLogWebRequests`](#classFRH__WebRequests_1a4754abff6242738e32ed65763be2b104)`(const FName & APIName) const` <a id="classFRH__WebRequests_1a4754abff6242738e32ed65763be2b104"></a>
 
 Gets if a specific API is being logged currently.
 
@@ -121,7 +125,7 @@ Gets if a specific API is being logged currently.
 * `APIName` API name to check.
 
 <br>
-#### `public inline FORCEINLINE void `[`SetLogWebRequests`](#classURH__WebRequests_1a2a07322b447aac227feb43192aaf3372)`(const FName & APIName,bool bValue)` <a id="classURH__WebRequests_1a2a07322b447aac227feb43192aaf3372"></a>
+#### `public inline FORCEINLINE void `[`SetLogWebRequests`](#classFRH__WebRequests_1a400485994e0446ffdb240543cc829116)`(const FName & APIName,bool bValue)` <a id="classFRH__WebRequests_1a400485994e0446ffdb240543cc829116"></a>
 
 Sets logging for a specific API.
 
@@ -131,12 +135,12 @@ Sets logging for a specific API.
 * `bValue` if true, turn on logging for the API, else turn off.
 
 <br>
-#### `public inline FORCEINLINE bool `[`GetIsRetainingWebRequests`](#classURH__WebRequests_1a9248d832ca7d43f05d7e528703cf5df1)`() const` <a id="classURH__WebRequests_1a9248d832ca7d43f05d7e528703cf5df1"></a>
+#### `public inline FORCEINLINE bool `[`GetIsRetainingWebRequests`](#classFRH__WebRequests_1a7f81dfc689eead12123790431fd76b34)`() const` <a id="classFRH__WebRequests_1a7f81dfc689eead12123790431fd76b34"></a>
 
 Get whether web requests should be cached indefinitely or cleared after reaching the cache limit.
 
 <br>
-#### `public inline FORCEINLINE void `[`SetIsRetainingWebRequests`](#classURH__WebRequests_1ac640bcc4171398824dbca3fff9bcebfd)`(bool bValue)` <a id="classURH__WebRequests_1ac640bcc4171398824dbca3fff9bcebfd"></a>
+#### `public inline FORCEINLINE void `[`SetIsRetainingWebRequests`](#classFRH__WebRequests_1af312673a93b7b16cf1661606237837ee)`(bool bValue)` <a id="classFRH__WebRequests_1af312673a93b7b16cf1661606237837ee"></a>
 
 Set whether web requests should be cached indefinitely or cleared after reaching the cache limit.
 
@@ -144,17 +148,17 @@ Set whether web requests should be cached indefinitely or cleared after reaching
 * `bValue` if true, requests are retained, if not, they are cleared upon reaching the cache limit.
 
 <br>
-#### `public inline const TMap< FName, int32 > `[`GetAPINameToCallCountMap`](#classURH__WebRequests_1a018f06e0cf588740d42b80af334dd238)`() const` <a id="classURH__WebRequests_1a018f06e0cf588740d42b80af334dd238"></a>
+#### `public inline const TMap< FName, int32 > `[`GetAPINameToCallCountMap`](#classFRH__WebRequests_1abcb430aac4da7a8b12fc4e3d4a4735fa)`() const` <a id="classFRH__WebRequests_1abcb430aac4da7a8b12fc4e3d4a4735fa"></a>
 
 Get the map that tracks all-time call count for each API.
 
 <br>
-#### `public inline const TMap< FName, int32 > `[`GetSimplifiedPathToCallCountMap`](#classURH__WebRequests_1ac940579b57d7c6ad400fda8fc4a42e2e)`() const` <a id="classURH__WebRequests_1ac940579b57d7c6ad400fda8fc4a42e2e"></a>
+#### `public inline const TMap< FName, int32 > `[`GetSimplifiedPathToCallCountMap`](#classFRH__WebRequests_1aed90013183d6a6ec2b05d621a2f3a9b3)`() const` <a id="classFRH__WebRequests_1aed90013183d6a6ec2b05d621a2f3a9b3"></a>
 
 Get the map that tracks all-time call count for each generic URL.
 
 <br>
-#### `public void `[`GetRecentCallCountMaps`](#classURH__WebRequests_1af8e59e4e179be1054a8783f6c56daca8)`(TMap< FName, int32 > * OutAPIRecentCallCountMap,TMap< FName, int32 > * OutURLRecentCallCountMap) const` <a id="classURH__WebRequests_1af8e59e4e179be1054a8783f6c56daca8"></a>
+#### `public void `[`GetRecentCallCountMaps`](#classFRH__WebRequests_1ab93ed7476bba71269269d3d364189f86)`(TMap< FName, int32 > * OutAPIRecentCallCountMap,TMap< FName, int32 > * OutURLRecentCallCountMap) const` <a id="classFRH__WebRequests_1ab93ed7476bba71269269d3d364189f86"></a>
 
 Get the maps that track call counts in the last 60s.
 
@@ -164,7 +168,7 @@ Get the maps that track call counts in the last 60s.
 * `OutURLRecentCallCountMap` Pointer to output call count map by Simplified Paths
 
 <br>
-#### `public void `[`DetectRecentBursts`](#classURH__WebRequests_1a96cc4bf85561ff86c5444563e5d4fe40)`(TMap< FName, TTuple< int32, int32 >> * OutBurstMapByAPIName,TMap< FName, TTuple< int32, int32 >> * OutBurstMapByURL) const` <a id="classURH__WebRequests_1a96cc4bf85561ff86c5444563e5d4fe40"></a>
+#### `public void `[`DetectRecentBursts`](#classFRH__WebRequests_1a64e8ecf52cf4760ab79f033ba0ef66e0)`(TMap< FName, TTuple< int32, int32 >> * OutBurstMapByAPIName,TMap< FName, TTuple< int32, int32 >> * OutBurstMapByURL) const` <a id="classFRH__WebRequests_1a64e8ecf52cf4760ab79f033ba0ef66e0"></a>
 
 Detects bursts in recent call counts (last 60s). The time and count thresholds for burst detection are specified by BurstCountThreshold and BurstTimeThreshold.
 

--- a/RallyHereDebugTool/Source/Private/RHDTW_Analytics.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Analytics.cpp
@@ -29,7 +29,7 @@ FRHDTW_Analytics::~FRHDTW_Analytics()
 
 void FRHDTW_Analytics::Do()
 {
-	URH_WebRequests* WebRequestsTracker = FRallyHereIntegrationModule::Get().GetWebRequestTracker();
+	FRH_WebRequests* WebRequestsTracker = FRallyHereIntegrationModule::Get().GetWebRequestTracker();
 	if (WebRequestsTracker == nullptr)
 	{
 		ImGui::Text("RH_WebRequests unavailable.");
@@ -182,7 +182,7 @@ void FRHDTW_Analytics::DoCallCountPlot(const TMap<FName, int32>& CountAllTime, T
 #endif
 }
 
-void FRHDTW_Analytics::DoTimelinePlot(URH_WebRequests* WebRequestsTracker, const FString& FilterString, TFunctionRef<FName(FRH_WebRequest*)> GetKeyFromRequest)
+void FRHDTW_Analytics::DoTimelinePlot(FRH_WebRequests* WebRequestsTracker, const FString& FilterString, TFunctionRef<FName(FRH_WebRequest*)> GetKeyFromRequest)
 {
 #ifdef WITH_IMGUI_IMPLOT
 	static const int SecondsInOneMinute = 60;

--- a/RallyHereDebugTool/Source/Private/RHDTW_WebRequests.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_WebRequests.cpp
@@ -45,7 +45,7 @@ FRHDTW_WebRequests::FRHDTW_WebRequests()
 void FRHDTW_WebRequests::Init(URallyHereDebugTool* InOwner, const FString& InName)
 {
 	Super::Init(InOwner, InName);
-	if (URH_WebRequests* WebRequestsTracker = FRallyHereIntegrationModule::Get().GetWebRequestTracker())
+	if (FRH_WebRequests* WebRequestsTracker = FRallyHereIntegrationModule::Get().GetWebRequestTracker())
 	{
 		for (const FName& APIName : WebRequestsTracker->GetAPINames())
 		{
@@ -56,7 +56,7 @@ void FRHDTW_WebRequests::Init(URallyHereDebugTool* InOwner, const FString& InNam
 
 void FRHDTW_WebRequests::Do()
 {
-	URH_WebRequests* WebRequestsTracker = FRallyHereIntegrationModule::Get().GetWebRequestTracker();
+	FRH_WebRequests* WebRequestsTracker = FRallyHereIntegrationModule::Get().GetWebRequestTracker();
 	if (WebRequestsTracker == nullptr)
 	{
 		ImGui::Text("RH_WebRequests unavailable.");
@@ -162,7 +162,7 @@ void FRHDTW_WebRequests::Do()
 	DoViewRequests(WebRequestsTracker);
 }
 
-void FRHDTW_WebRequests::DoViewRequests(URH_WebRequests* WebRequestsTracker)
+void FRHDTW_WebRequests::DoViewRequests(FRH_WebRequests* WebRequestsTracker)
 {
 	if (!WebRequestsTracker)
 		return;

--- a/RallyHereDebugTool/Source/Public/RHDTW_Analytics.h
+++ b/RallyHereDebugTool/Source/Public/RHDTW_Analytics.h
@@ -21,7 +21,7 @@ protected:
 
 #pragma region REUSABLE HELPERS
 	void DoCallCountPlot(const TMap<FName, int32>& CountAllTime, TMap<FName, int32>& CountRecent, bool bAllTime, const FString& PlotName, const FString& CategoryName, const FString& FilterString);
-	void DoTimelinePlot(class URH_WebRequests* WebRequestsTracker, const FString& FilterString, TFunctionRef<FName(struct FRH_WebRequest*)> GetKeyFromRequest);
+	void DoTimelinePlot(class FRH_WebRequests* WebRequestsTracker, const FString& FilterString, TFunctionRef<FName(struct FRH_WebRequest*)> GetKeyFromRequest);
 	void DoTable(const TMap<FName, int32>& CountAllTime, TMap<FName, int32>& CountRecent, TMap<FName, TTuple<int32, int32>>& Bursts, const FString& TableName, const FString& CategoryName, const FString& FilterString);
 #pragma endregion
 };

--- a/RallyHereDebugTool/Source/Public/RHDTW_WebRequests.h
+++ b/RallyHereDebugTool/Source/Public/RHDTW_WebRequests.h
@@ -19,7 +19,7 @@ public:
 
 	void Do() override;
 private:
-	void DoViewRequests(URH_WebRequests* WebRequestsTracker);
+	void DoViewRequests(FRH_WebRequests* WebRequestsTracker);
 	void DoViewRequest(const FRH_WebRequest* WebRequest);
 	void DoViewResponse(const FRH_WebResponse* WebResponse, const FRH_WebRequest* WebRequest);
 	void DoViewMetadata(const FRH_WebRequest* WebRequest);

--- a/RallyHereIntegration/Config/BaseRallyHereIntegration.ini
+++ b/RallyHereIntegration/Config/BaseRallyHereIntegration.ini
@@ -14,7 +14,10 @@
 +ClientSecretCommandLineKeys=RallyHereClientSecretX
 +ClientSecretCommandLineKeys=RallyHereClientSecret
 +ClientSecretCommandLineKeys=RallyHereClientSecretInternal
-MaxSimultaneousRequests=15
+WebRequestsMaxSimultaneousRequests=15
+WebRequestsTrackedRequestsCountLimit=200
+WebRequestBurstCountThreshold=5
+WebRequestBurstTimeThresholdInSeconds=5
 
 [PlatformFromOSSNameMap]
 Steam=Steam
@@ -117,11 +120,6 @@ DefaultPollingInterval = 60.0
 +PollingIntervals=(TimerName="PendingInventory",Interval=5.0)
 +PollingIntervals=(TimerName="SessionInstanceHealth",Interval=10.0)
 +PollingIntervals=(TimerName="SessionBackfill",Interval=20.0)
-
-[/Script/RallyHereIntegration.RH_WebRequests]
-TrackedRequestsCountLimit=200
-BurstCountThreshold=5
-BurstTimeThresholdInSeconds=5
 
 [/Script/RallyHereDebugTool.RallyHereDebugToolSettings]
 DefaultWindowPositions="[Window][Output Log]\nDockId=0x00000003,0\n[Window][Login]\nDockId=0x00000004,1\n[Window][Session]\nDockId=0x00000005,10\n[Window][Friends]\nDockId=0x00000005,3\n[Window][Config]\nDockId=0x00000005,1\n[Window][Presence]\nDockId=0x00000005,7\n[Window][Web Requests]\nDockId=0x00000003,1\n[Window][Analytics]\nDockId=0x00000003,2\n[Window][About]\nDockId=0x00000003,3\n[Window][Catalog]\nDockId=0x00000005,0\n[Window][Purge]\nDockId=0x00000005,8\n[Window][Entitlements]\nDockId=0x00000005,2\n[Window][Notifications]\nDockId=0x00000005,5\n[Window][Player Repository]\nDockId=0x00000004,0\n[Window][Platforms]\nDockId=0x00000005,6\n[Window][Inventory]\nDockId=0x00000005,4\n[Window][Ranks]\nDockId=0x00000005,9\n[Window][Settings]\nDockId=0x00000005,11\n[Window][Custom Endpoint]\nDockId=0x00000005,12\n[Docking][Data]\nDockNode      ID=0x00000001 Pos=0,19 Size=1633,905 Split=Y\nDockNode    ID=0x00000002 Parent=0x00000001 SizeRef=1008,561 Split=X Selected=0x380E6B3B\nDockNode  ID=0x00000004 Parent=0x00000002 SizeRef=508,300 Selected=0x48510B82\nDockNode  ID=0x00000005 Parent=0x00000002 SizeRef=1123,300 Selected=0x9D227BB7\nDockNode    ID=0x00000003 Parent=0x00000001 SizeRef=1008,337 Selected=0x05E372E7"

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Diagnostics.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Diagnostics.cpp
@@ -316,17 +316,33 @@ void FRH_DiagnosticReportGenerator::WriteToCloud()
 	StageComplete();
 }
 
-void URH_Diagnostics::Initialize()
+FRH_Diagnostics::FRH_Diagnostics()
+{
+
+}
+
+void FRH_Diagnostics::Initialize()
 {
 }
 
-void URH_Diagnostics::Uninitialize()
+void FRH_Diagnostics::Uninitialize()
 {
 }
 
-void URH_Diagnostics::GenerateReport(const FRH_DiagnosticReportOptions& Options) const
+void FRH_Diagnostics::GenerateReport(const FRH_DiagnosticReportOptions& Options) const
 {
 	auto Helper = MakeShared<FRH_DiagnosticReportGenerator>();
 
 	Helper->Start(Options);
+}
+
+void URH_DiagnosticsBlueprintLibrary::GenerateReport(const FRH_DiagnosticReportOptions& Options)
+{
+	if (FRallyHereIntegrationModule::IsAvailable())
+	{
+		if (auto Diagnostics = FRallyHereIntegrationModule::Get().GetDiagnostics())
+		{
+			Diagnostics->GenerateReport(Options);
+		}
+	}
 }

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Integration.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Integration.cpp
@@ -197,7 +197,15 @@ static FAutoConsoleCommandWithWorldArgsAndOutputDevice ConsoleRHSetOSS(
 			}
 		}));
 
-void URH_Integration::Initialize()
+FRH_Integration::FRH_Integration()
+	: bIsBaseUrlLocked(false)
+	, bIsEnvironmentIdLocked(false)
+	, bIsClientIdLocked(false)
+	, bIsClientSecretLocked(false)
+{
+}
+
+void FRH_Integration::Initialize()
 {
 	UE_LOG(LogRallyHereIntegration, Verbose, TEXT("[%s]"), ANSI_TO_TCHAR(__FUNCTION__));
 
@@ -228,27 +236,34 @@ void URH_Integration::Initialize()
 	auto* HttpRequester = RallyHereAPI::FRallyHereAPIHttpRequester::Get();
 	if (HttpRequester)
 	{
-		HttpRequester->SetMaxSimultaneousRequests(Settings->MaxSimultaneousRequests);
+		HttpRequester->SetMaxSimultaneousRequests(Settings->WebRequestsMaxSimultaneousRequests);
 	}
 
 	// Go ahead and load a base URL in case one was passed through at startup
 	ResolveBaseURL();
 
-	WebRequestTracker = NewObject<URH_WebRequests>(this);
+	WebRequestTracker = MakeShared<FRH_WebRequests>();
 	WebRequestTracker->Initialize(&APIs);
 
-	Diagnostics = NewObject<URH_Diagnostics>(this);
+	Diagnostics = MakeShared<FRH_Diagnostics>();
 	Diagnostics->Initialize();
 }
 
-void URH_Integration::Uninitialize()
+void FRH_Integration::Uninitialize()
 {
 	UE_LOG(LogRallyHereIntegration, Verbose, TEXT("[%s]"), ANSI_TO_TCHAR(__FUNCTION__));
-	WebRequestTracker->Uninitialize();
-	WebRequestTracker = nullptr;
 
-	Diagnostics->Uninitialize();
-	Diagnostics = nullptr;
+	if (WebRequestTracker.IsValid())
+	{
+		WebRequestTracker->Uninitialize();
+	}
+	WebRequestTracker.Reset();
+
+	if (Diagnostics.IsValid())
+	{
+		Diagnostics->Uninitialize();
+	}
+	Diagnostics.Reset();
 
 	for (auto& API : APIs.GetAllAPIs())
 	{
@@ -259,7 +274,7 @@ void URH_Integration::Uninitialize()
 	RetryManager = nullptr;
 }
 
-void URH_Integration::SetBaseURL(FString InBaseUrl, const FString& Source)
+void FRH_Integration::SetBaseURL(FString InBaseUrl, const FString& Source)
 {
 	ResolvedBaseUrl = MoveTemp(InBaseUrl);
 
@@ -299,7 +314,7 @@ void URH_Integration::SetBaseURL(FString InBaseUrl, const FString& Source)
 	}
 }
 
-FString URH_Integration::GetBaseURL()
+FString FRH_Integration::GetBaseURL()
 {
 	if (ResolvedBaseUrl.IsEmpty())
 	{
@@ -308,7 +323,7 @@ FString URH_Integration::GetBaseURL()
 	return ResolvedBaseUrl;
 }
 
-void URH_Integration::ResolveBaseURL()
+void FRH_Integration::ResolveBaseURL()
 {
 	if (bIsBaseUrlLocked)
 	{
@@ -351,14 +366,14 @@ void URH_Integration::ResolveBaseURL()
 	UE_LOG(LogRallyHereIntegration, Warning, TEXT("[%s] Could not find a base URL"), ANSI_TO_TCHAR(__FUNCTION__));
 }
 
-void URH_Integration::SetEnvironmentId(FString InEnvironmentId, const FString& Source)
+void FRH_Integration::SetEnvironmentId(FString InEnvironmentId, const FString& Source)
 {
 	ResolvedEnvironmentId = MoveTemp(InEnvironmentId);
 	UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] Value=%s Source=%s"), ANSI_TO_TCHAR(__FUNCTION__), *ResolvedEnvironmentId,
 		*Source);
 }
 
-FString URH_Integration::GetEnvironmentId()
+FString FRH_Integration::GetEnvironmentId()
 {
 	if (ResolvedEnvironmentId.IsEmpty())
 	{
@@ -384,7 +399,7 @@ bool GetEnvironmentIdFromOSS(IOnlineSubsystem* OSS, FString& OutEnvironmentId, F
 	return false;
 }
 
-void URH_Integration::ResolveEnvironmentId()
+void FRH_Integration::ResolveEnvironmentId()
 {
 	if (bIsEnvironmentIdLocked)
 	{
@@ -430,14 +445,14 @@ void URH_Integration::ResolveEnvironmentId()
 }
 
 
-void URH_Integration::SetClientId(FString InClientId, const FString& Source)
+void FRH_Integration::SetClientId(FString InClientId, const FString& Source)
 {
 	ResolvedClientId = MoveTemp(InClientId);
 	UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] Value=%s Source=%s"), ANSI_TO_TCHAR(__FUNCTION__), *ResolvedClientId,
 		*Source);
 }
 
-FString URH_Integration::GetClientId()
+FString FRH_Integration::GetClientId()
 {
 	if (ResolvedClientId.IsEmpty())
 	{
@@ -446,7 +461,7 @@ FString URH_Integration::GetClientId()
 	return ResolvedClientId;
 }
 
-void URH_Integration::ResolveClientId()
+void FRH_Integration::ResolveClientId()
 {
 	if (bIsClientIdLocked)
 	{
@@ -488,13 +503,13 @@ void URH_Integration::ResolveClientId()
 	UE_LOG(LogRallyHereIntegration, Warning, TEXT("[%s] Could not find a client ID"), ANSI_TO_TCHAR(__FUNCTION__));
 }
 
-void URH_Integration::SetClientSecret(FString InClientSecret, const FString& Source)
+void FRH_Integration::SetClientSecret(FString InClientSecret, const FString& Source)
 {
 	ResolvedClientSecret = MoveTemp(InClientSecret);
 	UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] Source=%s"), ANSI_TO_TCHAR(__FUNCTION__), *Source);
 }
 
-FString URH_Integration::GetClientSecret()
+FString FRH_Integration::GetClientSecret()
 {
 	if (ResolvedClientSecret.IsEmpty())
 	{
@@ -503,7 +518,7 @@ FString URH_Integration::GetClientSecret()
 	return ResolvedClientSecret;
 }
 
-void URH_Integration::ResolveClientSecret()
+void FRH_Integration::ResolveClientSecret()
 {
 	if (bIsClientSecretLocked)
 	{

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
@@ -15,6 +15,11 @@ URH_IntegrationSettings::URH_IntegrationSettings(const FObjectInitializer& Objec
 
 	bLocalPlayerSubsystemSandboxing = false;
 
+	WebRequestsMaxSimultaneousRequests = 15;
+	WebRequestsTrackedRequestsCountLimit = 200;
+	WebRequestsBurstCountThreshold = 5;
+	WebRequestsBurstTimeThresholdInSeconds = 5;
+
 	BeginNewAdSessionPriority = 1100000;
 	FindAdOppertunitiesPriority = 1100000;
 	UpdateAdOppertunitiesPriority = 900000;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RallyHereIntegrationModule.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RallyHereIntegrationModule.cpp
@@ -22,8 +22,7 @@ void FRallyHereIntegrationModule::StartupModule()
 
     if (!Integration.IsValid())
     {
-        Integration = NewObject<URH_Integration>();
-        Integration->AddToRoot();
+        Integration = MakeUnique<FRH_Integration>();
         Integration->Initialize();
     }
 }
@@ -38,7 +37,6 @@ void FRallyHereIntegrationModule::ShutdownModule()
     if (Integration.IsValid())
     {
         Integration->Uninitialize();
-        Integration->RemoveFromRoot();
 		Integration.Reset();
     }
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Diagnostics.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Diagnostics.h
@@ -267,12 +267,11 @@ public:
 /**
  * @brief Class to handle initializing and running a diagnostic (blueprint compatible).  Tracks and stores local state from the running engine for tracking previous errors.
  */
-UCLASS(Config = RallyHereIntegration, DefaultConfig)
-class RALLYHEREINTEGRATION_API URH_Diagnostics : public UObject
+class RALLYHEREINTEGRATION_API FRH_Diagnostics : public TSharedFromThis<FRH_Diagnostics>
 {
-	GENERATED_BODY()
-
 public:
+	FRH_Diagnostics();
+
 	/**
 	* @brief Initialize the system.
 	*/
@@ -300,11 +299,26 @@ public:
 	 * @param [in] Options Options for the generated report.
 	 * @return The generated object
 	 */
-	UFUNCTION(Category = "RallyHere | Diagnostics")
 	void GenerateReport(const FRH_DiagnosticReportOptions& Options) const;
+};
 
-private:
+/**
+ * @brief Wrapper library to generate diagnostic reports via blueprint
+ */
+UCLASS()
+class RALLYHEREINTEGRATION_API URH_DiagnosticsBlueprintLibrary : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
 
+public:
+	/**
+	 * @brief Generates a report in JSON format
+	 * @param [in] World The context world object.
+	 * @param [in] Options Options for the generated report.
+	 * @return The generated object
+	 */
+	UFUNCTION(Category = "RallyHere | Diagnostics")
+	static void GenerateReport(const FRH_DiagnosticReportOptions& Options);
 };
 
 /** @} */

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Integration.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Integration.h
@@ -7,8 +7,8 @@
 #include "RallyHereAPIAll.h"
 #include "RallyHereAPIHelpers.h"
 #include "RH_IntegrationSettings.h"
-
-#include "RH_Integration.generated.h"
+#include "RH_WebRequests.h"
+#include "RH_Diagnostics.h"
 
 typedef TSharedPtr<RallyHereAPI::FHttpRetryManager> HttpRetryManagerPtr;
 
@@ -19,12 +19,11 @@ typedef TSharedPtr<RallyHereAPI::FHttpRetryManager> HttpRetryManagerPtr;
 /**
  * @brief Main integration layer handler.
  */
-UCLASS()
-class RALLYHEREINTEGRATION_API URH_Integration : public UObject
+class RALLYHEREINTEGRATION_API FRH_Integration
 {
-    GENERATED_BODY()
-
 public:
+	FRH_Integration();
+
 	/**
 	 * @brief Initialize the Integration layer.
 	 */
@@ -170,49 +169,41 @@ public:
 	/**
 	 * @brief Gets the Web Request Tracker.
 	 */
-	class URH_WebRequests* GetWebRequestTracker() const { return WebRequestTracker; }
+	FRH_WebRequests* GetWebRequestTracker() const { return WebRequestTracker.Get(); }
 
 	/**
 	 * @brief Gets the Diagnostic Reporter.
 	 */
-	class URH_Diagnostics* GetDiagnostics() const { return Diagnostics; }
+	FRH_Diagnostics* GetDiagnostics() const { return Diagnostics.Get(); }
 private:
     RallyHereAPI::FRallyHereAPIAll APIs;
     HttpRetryManagerPtr RetryManager;
 
-    UPROPERTY(Transient)
     FString ResolvedBaseUrl;
 
 	// Is the base URL locked - aka will not change during ResolveBaseURL calls.
-    UPROPERTY(Transient)
     bool bIsBaseUrlLocked;
 
-    UPROPERTY(Transient)
     FString ResolvedEnvironmentId;
 
 	// Is the EnvironmentId locked - aka will not change during ResolveEnvironmentId calls.
-    UPROPERTY(Transient)
     bool bIsEnvironmentIdLocked;
 
-	UPROPERTY(Transient)
     FString ResolvedClientId;
 
     // Is the client ID locked - aka will not change during ResolveClientId calls.
-    UPROPERTY(Transient)
     bool bIsClientIdLocked;
 
-    UPROPERTY(Transient)
     FString ResolvedClientSecret;
 
     // Is the client secret locked - aka will not change during ResolveClientSecret calls.
-    UPROPERTY(Transient)
     bool bIsClientSecretLocked;
 
-	UPROPERTY()
-	class URH_WebRequests* WebRequestTracker;
+	// Web request tracker
+	TSharedPtr<FRH_WebRequests> WebRequestTracker;
 
-	UPROPERTY()
-	class URH_Diagnostics* Diagnostics;
+	// Diagnostic tracker and reporter
+	TSharedPtr<FRH_Diagnostics> Diagnostics;
 };
 
 /** @} */

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
@@ -112,7 +112,19 @@ public:
 
 	/** @brief Sets the maximum number of Http Requests that can be made simultaneously. 0 = No Limit */
 	UPROPERTY(EditAnywhere, Config, Category = "Web Requests")
-	int32 MaxSimultaneousRequests;
+	int32 WebRequestsMaxSimultaneousRequests;
+
+	/** @brief Sets the maximum number of web requests for which tracking data is kept. */
+	UPROPERTY(EditAnywhere, Config, Category = "Web Requests")
+	int WebRequestsTrackedRequestsCountLimit;
+
+	/** @brief Sets the count above which web traffic is considered a burst. */
+	UPROPERTY(EditAnywhere, Config, Category = "Web Requests")
+	int32 WebRequestsBurstCountThreshold;
+
+	/** @brief Sets the time threshold for web traffic burst detection. */
+	UPROPERTY(EditAnywhere, Config, Category = "Web Requests")
+	int32 WebRequestsBurstTimeThresholdInSeconds;
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Subsystem Classes

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerLoginSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerLoginSubsystem.h
@@ -304,7 +304,7 @@ public:
     bool bLoginOSSUseIDTokenAsPortalAccessToken;
 
     /**
-      * @brief Should an OSS Login trigger a Base URL Resolve on the URH_Integration?  This is necessary for some OSSes (e.g. Switch/PS4) that don't
+      * @brief Should an OSS Login trigger a Base URL Resolve on the FRH_Integration?  This is necessary for some OSSes (e.g. Switch/PS4) that don't
       * have environment information until after a login is attempted
       */
     UPROPERTY(Config)

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_WebRequests.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_WebRequests.h
@@ -7,8 +7,6 @@
 #include "RallyHereAPIAll.h"
 #include "RallyHereAPIHelpers.h"
 
-#include "RH_WebRequests.generated.h"
-
 /** @defgroup WebRequest RallyHere Web Request
  *  @{
  */
@@ -62,12 +60,12 @@ struct FRH_WebRequest
 /**
  * @brief Class to handle executing and tracking low-level Http Web Requests.
  */
-UCLASS(Config = RallyHereIntegration, DefaultConfig)
-class RALLYHEREINTEGRATION_API URH_WebRequests: public UObject
+class RALLYHEREINTEGRATION_API FRH_WebRequests : public TSharedFromThis<FRH_WebRequests>
 {
-	GENERATED_BODY()
-
 public:
+
+	FRH_WebRequests();
+
 	/**
 	* @brief Initialize the Web Request system.
 	* @param [in] InAPIs The APIs the web request system tracks requests from.
@@ -175,11 +173,7 @@ public:
 private:
 	RallyHereAPI::FRallyHereAPIAll* APIs = nullptr;
 
-	UPROPERTY(Config)
 	TArray<FName> LoggedAPIs;
-
-	UPROPERTY(Config)
-	int TrackedRequestsCountLimit;
 	bool bRetainWebRequests;
 
 	TDoubleLinkedList<TSharedPtr<FRH_WebRequest>> TrackedRequests;
@@ -187,12 +181,6 @@ private:
 
 	TMap<FName, int32> APINameToCallCountMap;
 	TMap<FName, int32> SimplifiedPathToCallCountMap;
-
-	UPROPERTY(Config)
-	int32 BurstCountThreshold;
-
-	UPROPERTY(Config)
-	int32 BurstTimeThresholdInSeconds;
 
 	void OnWebRequestStarted(const RallyHereAPI::FRequestMetadata& RequestMetadata, FHttpRequestRef HttpRequest, RallyHereAPI::FAPI* API);
 	void OnWebRequestCompleted(const RallyHereAPI::FResponse& Response, FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSuccess, bool bWillRetryWithAuth, RallyHereAPI::FAPI* API);

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RallyHereIntegrationModule.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RallyHereIntegrationModule.h
@@ -36,18 +36,18 @@ public:
 		return FModuleManager::Get().IsModuleLoaded(GetModuleName());
 	}
 	/** @brief Gets the module, lazy loads it if needed. */
-	static inline URH_Integration& Get()
+	static inline FRH_Integration& Get()
 	{
 		return FModuleManager::Get().LoadModuleChecked<FRallyHereIntegrationModule>(GetModuleName()).GetIntegration();
 	}
 	/** @brief Gets the Integration class fromt he module. */
-    inline URH_Integration& GetIntegration() const
+    inline FRH_Integration& GetIntegration() const
     {
         return *Integration;
     }
 
 private:
-    TWeakObjectPtr<URH_Integration> Integration;
+    TUniquePtr<FRH_Integration> Integration;
 };
 
 // shortener for the above lookup


### PR DESCRIPTION
Converted the following from UObjects to non-UObjects, to better control their lifetimes:

- URH_Integration -> FRH_Integration
- URH_Diagnostics -> FRH_Diagnostics / URH_DiagnosticsBlueprintLibrary
- URH_WebRequests -> FRH_WebRequests

The integration module now stores a unique pointer to the integration instance, which has shared pointers to the diagnostics and web requests objects. Moved config settings for the WebRequests object to URH_IntegrationSettings, and adjusted naming