### PR TITLE
Add support for directly looking up and caching matchmaking profiles …

### DIFF
--- a/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
@@ -55,6 +55,9 @@ FRHDTW_Session::FRHDTW_Session()
 
 	QueueSessionSelector.SetNumZeroed(IMGUI_SESSION_TEXTENTRY_PREALLOCATION_SIZE);
 
+	MatchmakingProfileSearchString.SetNumZeroed(IMGUI_SESSION_TEXTENTRY_PREALLOCATION_SIZE);
+	InstanceRequestSearchString.SetNumZeroed(IMGUI_SESSION_TEXTENTRY_PREALLOCATION_SIZE);
+
 	// inherit defaults from search params for paging
 	FRH_SessionBrowserSearchParams params;
 	SearchCursor = params.Cursor;
@@ -1432,14 +1435,14 @@ void FRHDTW_Session::ImGuiDisplayQueuesBrowser(URH_GameInstanceSubsystem* pGISub
 	{
 		if (Queue->IsActive() || !bFilterInactiveQueues)
 		{
-			ImGuiDisplayQueue(Queue, pLPSessionSubsystem, SelectedSession, pGIMatchmakingCache);
+			ImGuiDisplayQueue(Queue->GetQueueInfo(), pLPSessionSubsystem, SelectedSession, pGIMatchmakingCache);
 		}
 	}
 }
 
-void FRHDTW_Session::ImGuiDisplayQueue(const URH_MatchmakingQueueInfo* Queue, URH_LocalPlayerSessionSubsystem* pLPSessionSubsystem, URH_OnlineSession* pSelectedSession, URH_MatchmakingBrowserCache* pBrowerCache)
+void FRHDTW_Session::ImGuiDisplayQueue(const FRHAPI_QueueConfigV2& Queue, URH_LocalPlayerSessionSubsystem* pLPSessionSubsystem, URH_OnlineSession* pSelectedSession, URH_MatchmakingBrowserCache* pBrowerCache)
 {
-	FString HeaderString = FString::Printf(TEXT("Queue: %s"), *Queue->GetDescription());
+	FString HeaderString = FString::Printf(TEXT("Queue: %s"), *Queue.GetQueueId());
 
 	if (ImGui::TreeNodeEx(TCHAR_TO_UTF8(*HeaderString), RH_DefaultTreeFlags))
 	{
@@ -1447,102 +1450,55 @@ void FRHDTW_Session::ImGuiDisplayQueue(const URH_MatchmakingQueueInfo* Queue, UR
 		{
 			if (ImGui::Button("Join"))
 			{
-				pSelectedSession->JoinQueue(Queue->GetQueueId());
+				pSelectedSession->JoinQueue(Queue.GetQueueId());
 			}
 		}
 
-		ImGuiDisplayCopyableValue(TEXT("QueueId"), Queue->GetQueueId());
-		ImGuiDisplayCopyableValue(TEXT("Description"), Queue->GetDescription());
+		ImGuiDisplayCopyableValue(TEXT("QueueId"), Queue.GetQueueId());
 
-		const auto& QueueInfo = Queue->GetQueueInfo();
+		ImGui::Text("Active: %s", Queue.GetActive() ? "true" : "false");
+		ImGui::Text("MaxQueueGroupSize: %d", Queue.GetMaxQueueGroupSize());
 
-		ImGui::Text("Active: %s", QueueInfo.GetActive() ? "true" : "false");
-		ImGui::Text("MaxQueueGroupSize: %d", QueueInfo.GetMaxQueueGroupSize());
+		ImGuiDisplayCustomData(Queue.GetLegacyConfigOrNull(), TEXT(""), TEXT("LegacyConfig"));
 
-		ImGuiDisplayCustomData(QueueInfo.GetLegacyConfigOrNull(), TEXT(""), TEXT("LegacyConfig"));
-
-		ImGuiDisplayCopyableValue(TEXT("MatchMakingTemplateGroupId"), QueueInfo.GetMatchMakingTemplateGroupId());
+		ImGuiDisplayCopyableValue(TEXT("MatchMakingTemplateGroupId"), Queue.GetMatchMakingTemplateGroupId());
 
 		if (pBrowerCache != nullptr)
 		{
-			auto* TemplateGroup = pBrowerCache->GetMatchmakingTemplateGroup(QueueInfo.GetMatchMakingTemplateGroupId());
+			auto* TemplateGroup = pBrowerCache->GetMatchmakingTemplateGroup(Queue.GetMatchMakingTemplateGroupId());
 			if (TemplateGroup != nullptr)
 			{
+				const auto& TemplateInfo = TemplateGroup->GetInfo();
 				if (ImGui::TreeNodeEx(TCHAR_TO_UTF8(*TemplateGroup->GetDescription()), RH_DefaultTreeFlags))
 				{
-					// todo - pull more data
+					ImGuiDisplayCopyableValue(TEXT("TemplateGroupId"), TemplateInfo.GetMatchMakingTemplateGroupId());
+
 					FString RequiredItemsString;
-					auto RequiredItems = TemplateGroup->GetRequiredItemIds();
-					RequiredItemsString.Reset(RequiredItems.Num() * 4);
-					for (auto item : RequiredItems)
+					const auto* RequiredItems = TemplateInfo.GetRequiredItemIdsOrNull();
+					if (RequiredItems != nullptr)
 					{
-						if (RequiredItemsString.Len() == 0)
+						RequiredItemsString.Reset(RequiredItems->Num() * 4);
+						for (const auto& item : *RequiredItems)
 						{
-							RequiredItemsString = FString::Printf(TEXT("%d"), item);
+							if (RequiredItemsString.Len() == 0)
+							{
+								RequiredItemsString = FString::Printf(TEXT("%d"), item);
+							}
+							else
+							{
+								RequiredItemsString = FString::Printf(TEXT(",%d"), item);
+							}
 						}
-						else
-						{
-							RequiredItemsString = FString::Printf(TEXT(",%d"), item);
-						}
+						ImGuiDisplayCopyableValue(TEXT("RequiredItems"), RequiredItemsString);
 					}
-					ImGuiDisplayCopyableValue(TEXT("RequiredItems"), RequiredItemsString);
-
-					if (ImGui::TreeNodeEx("Possible Request Templates", RH_DefaultTreeFlagsLeaf))
+					else
 					{
-						TArray<FGuid> RequestTemplateIds = TemplateGroup->GetPossibleInstanceRequestTemplateIds();
-						if (pBrowerCache != nullptr)
-						{
-							for (auto& RequestTemplateId : RequestTemplateIds)
-							{
+						ImGui::Text("RequiredItems: <UNSET>");
+					}
 
-								if (ImGui::TreeNodeEx(TCHAR_TO_UTF8(*RequestTemplateId.ToString(EGuidFormats::DigitsWithHyphens)), RH_DefaultTreeFlagsLeaf))
-								{
-									ImGuiDisplayCopyableValue(RequestTemplateId.ToString(EGuidFormats::DigitsWithHyphens), RequestTemplateId, ECopyMode::Value);
-									auto* RequestTemplate = pBrowerCache->GetInstanceRequestTemplate(RequestTemplateId);
-									if (RequestTemplate != nullptr)
-									{
-										const auto& TemplateInfo = RequestTemplate->GetInfo();
-
-										const auto& MapList = TemplateInfo.GetMapSelectionList().GetMaps();
-
-										for (auto Map : MapList)
-										{
-											auto MapIdentifier = FString::Printf(TEXT("Map %s"), *Map.GetMapId());
-											if (ImGui::TreeNodeEx(TCHAR_TO_UTF8(*MapIdentifier), RH_DefaultTreeFlagsLeaf))
-											{
-												ImGuiDisplayCopyableValue(TEXT("MapId"), Map.GetMapId());
-												ImGuiDisplayCopyableValue(TEXT("Name"), Map.GetName());
-												ImGuiDisplayCopyableValue(TEXT("GameMode"), Map.GetModeOrNull());
-												ImGuiDisplayCopyableValue(TEXT("Weight"), Map.GetMapWeight());
-												ImGuiDisplayCustomData(Map.GetCustomData());
-												ImGui::TreePop();
-											}
-										}
-
-										ImGuiDisplayCustomData(RequestTemplate->GetCustomData());
-									}
-									else
-									{
-										if (ImGui::Button("Lookup Request Template"))
-										{
-											pBrowerCache->SearchInstanceRequestTemplate(RequestTemplateId);
-										}
-									}
-
-									ImGui::TreePop();
-								}
-							}
-						}
-						else
-						{
-							for (auto& RequestTemplateId : RequestTemplateIds)
-							{
-								ImGuiDisplayCopyableValue(RequestTemplateId.ToString(EGuidFormats::DigitsWithHyphens), RequestTemplateId, ECopyMode::Value);
-							}
-						}
-
-
-						ImGui::TreePop();
+					for (const auto& Template : TemplateGroup->GetInfo().GetTemplateOptions())
+					{
+						ImGuiDisplayMatchmakingTemplate(Template, pBrowerCache);
 					}
 
 					ImGui::TreePop();
@@ -1553,12 +1509,164 @@ void FRHDTW_Session::ImGuiDisplayQueue(const URH_MatchmakingQueueInfo* Queue, UR
 				ImGui::SameLine();
 				if (ImGui::SmallButton("Lookup Template Group Id"))
 				{
-					pBrowerCache->SearchMatchmakingTemplateGroup(QueueInfo.GetMatchMakingTemplateGroupId());
+					pBrowerCache->SearchMatchmakingTemplateGroup(Queue.GetMatchMakingTemplateGroupId());
 				}
 			}
 		}
 
 		ImGui::TreePop();
+	}
+}
+
+void FRHDTW_Session::ImGuiDisplayMatchmakingTemplate(const FRHAPI_MatchMakingTemplateV2& Template, URH_MatchmakingBrowserCache* pBrowserCache)
+{
+	FString TemplateHeaderString = FString::Printf(TEXT("Template: %s"), *Template.GetMatchMakingTemplateId(FGuid()).ToString(EGuidFormats::DigitsWithHyphens));
+	if (ImGui::TreeNodeEx(TCHAR_TO_UTF8(*TemplateHeaderString), RH_DefaultTreeFlags))
+	{
+		ImGuiDisplayCopyableValue(TEXT("TemplateId"), Template.GetMatchMakingTemplateIdOrNull());
+
+		ImGuiDisplayCopyableEnumValue(TEXT("MmrGroupingMethod"), Template.GetMmrGroupingMethod());
+
+		const auto* Ruleset = Template.GetRulesetOrNull();
+		if (Ruleset)
+		{
+			ImGuiDisplayModelData(*Ruleset);
+		}
+		else
+		{
+			ImGui::Text("Ruleset: <UNSET>");
+		}
+
+		for (const auto& Profile : Template.GetProfiles())
+		{
+			ImGuiDisplayMatchmakingProfile(Profile, pBrowserCache);
+		}
+
+		//ImGuiDisplayCustomData(Template.GetCustomData());
+
+		ImGui::TreePop();
+	}
+}
+
+void FRHDTW_Session::ImGuiDisplayMatchmakingProfile(const FRHAPI_MatchMakingProfileV2& Profile, URH_MatchmakingBrowserCache* pBrowserCache)
+{
+	FString TemplateHeaderString = FString::Printf(TEXT("Profile: %s"), *Profile.GetMatchMakingProfileId());
+	if (ImGui::TreeNodeEx(TCHAR_TO_UTF8(*TemplateHeaderString), RH_DefaultTreeFlags))
+	{
+		ImGuiDisplayCopyableValue(TEXT("TemplateId"), Profile.GetMatchMakingProfileId());
+
+		ImGuiDisplayCopyableEnumValue(TEXT("JoinMode"), Profile.GetJoinModeOrNull());
+
+		auto* LaunchTemplate = pBrowserCache->GetInstanceRequestTemplate(Profile.GetInstanceRequestTemplateId());
+		if (LaunchTemplate != nullptr)
+		{
+			ImGuiDisplayInstanceRequestTemplate(LaunchTemplate->GetInfo(), pBrowserCache);
+		}
+		else
+		{
+			ImGuiDisplayCopyableValue(TEXT("InstanceRequestTemplateId"), Profile.GetInstanceRequestTemplateId());
+
+			// add a handy "lookup" button
+			ImGui::SameLine();
+			if (ImGui::SmallButton("Lookup"))
+			{
+				pBrowserCache->SearchInstanceRequestTemplate(Profile.GetInstanceRequestTemplateId());
+			}
+		}
+
+		//ImGuiDisplayCustomData(Profile.GetCustomData());
+
+		ImGui::TreePop();
+	}
+}
+
+void FRHDTW_Session::ImGuiDisplayInstanceRequestTemplate(const FRHAPI_InstanceRequestTemplate& RequestTemplate, URH_MatchmakingBrowserCache* pBrowerCache)
+{
+	const auto& RequestTemplateId = RequestTemplate.GetInstanceRequestTemplateId();
+	if (ImGui::TreeNodeEx(TCHAR_TO_UTF8(*RequestTemplateId.ToString(EGuidFormats::DigitsWithHyphens)), RH_DefaultTreeFlags))
+	{
+		const auto& MapList = RequestTemplate.GetMapSelectionList().GetMaps();
+
+		ImGuiDisplayCopyableValue(TEXT("InstanceRequestTemplateId"), RequestTemplateId);
+		ImGuiDisplayCopyableEnumValue(TEXT("Default Hosting Type"), RequestTemplate.GetDefaultHostType());
+
+		for (auto Map : MapList)
+		{
+			auto MapIdentifier = FString::Printf(TEXT("Map %s"), *Map.GetMapId());
+			if (ImGui::TreeNodeEx(TCHAR_TO_UTF8(*MapIdentifier), RH_DefaultTreeFlagsLeaf))
+			{
+				ImGuiDisplayCopyableValue(TEXT("MapId"), Map.GetMapId());
+				ImGuiDisplayCopyableValue(TEXT("Name"), Map.GetName());
+				ImGuiDisplayCopyableValue(TEXT("GameMode"), Map.GetModeOrNull());
+				ImGuiDisplayCopyableValue(TEXT("Weight"), Map.GetMapWeight());
+				ImGuiDisplayCustomData(Map.GetCustomData());
+				ImGui::TreePop();
+			}
+		}
+
+		ImGuiDisplayCustomData(RequestTemplate.GetCustomData());
+
+		ImGui::TreePop();
+	}
+}
+
+void FRHDTW_Session::ImGuiDisplayMatchmakingProfiles(URH_GameInstanceSubsystem* pGISubsystem)
+{
+	auto pGIMatchmakingCache = pGISubsystem != nullptr ? pGISubsystem->GetMatchmakingCache() : nullptr;
+	if (pGIMatchmakingCache == nullptr)
+	{
+		ImGui::Text("No Matchmaking Cache found");
+		return;
+	}
+
+	ImGui::InputText("##LookupById", MatchmakingProfileSearchString.GetData(), MatchmakingProfileSearchString.Num());
+	FString InputString = ImGuiGetStringFromTextInputBuffer(MatchmakingProfileSearchString);
+
+	ImGui::SameLine();
+	if (ImGui::Button("Lookup By Id"))
+	{
+		pGIMatchmakingCache->SearchMatchmakingProfile(InputString);
+	}
+
+	ImGui::Separator();
+
+	for (const auto* RequestTemplate : pGIMatchmakingCache->GetAllInstanceRequestTemplates())
+	{
+		ImGuiDisplayInstanceRequestTemplate(RequestTemplate->GetInfo(), pGIMatchmakingCache);
+	}
+}
+
+void FRHDTW_Session::ImGuiDisplayInstanceRequestTemplates(URH_GameInstanceSubsystem* pGISubsystem)
+{
+	auto pGIMatchmakingCache = pGISubsystem != nullptr ? pGISubsystem->GetMatchmakingCache() : nullptr;
+	if (pGIMatchmakingCache == nullptr)
+	{
+		ImGui::Text("No Matchmaking Cache found");
+		return;
+	}
+
+	ImGui::InputText("##LookupById", InstanceRequestSearchString.GetData(), InstanceRequestSearchString.Num());
+	FString InputString = ImGuiGetStringFromTextInputBuffer(InstanceRequestSearchString);
+	FGuid InputGuid(InputString);
+
+	ImGui::SameLine();
+	ImGui::BeginDisabled(!InputGuid.IsValid());
+	if (ImGui::Button("Lookup By Id"))
+	{
+		pGIMatchmakingCache->SearchInstanceRequestTemplate(InputGuid);
+	}
+	ImGui::EndDisabled();
+	if (!InputGuid.IsValid())
+	{
+		ImGui::SameLine();
+		ImGui::Text("Invalid Guid");
+	}
+
+	ImGui::Separator();
+
+	for (const auto* RequestTemplate : pGIMatchmakingCache->GetAllInstanceRequestTemplates())
+	{
+		ImGuiDisplayInstanceRequestTemplate(RequestTemplate->GetInfo(), pGIMatchmakingCache);
 	}
 }
 
@@ -1684,13 +1792,13 @@ void FRHDTW_Session::Do()
 	static ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_FittingPolicyResizeDown | ImGuiTabBarFlags_FittingPolicyScroll;
 	if (ImGui::BeginTabBar("Sessions", tab_bar_flags))
 	{
-		if (ImGui::BeginTabItem("Local Player", nullptr, ImGuiTabItemFlags_None))
+		if (ImGui::BeginTabItem("Selected Player(s)", nullptr, ImGuiTabItemFlags_None))
 		{
 			ImGuiDisplayLocalPlayerSessions(pGISubsystem);
 			ImGui::EndTabItem();
 		}
 
-		if (ImGui::BeginTabItem("Player", nullptr, ImGuiTabItemFlags_None))
+		if (ImGui::BeginTabItem("Target Player(s)", nullptr, ImGuiTabItemFlags_None))
 		{
 			ImGuiDisplayPlayerSessions(pGISubsystem);
 			ImGui::EndTabItem();
@@ -1702,23 +1810,46 @@ void FRHDTW_Session::Do()
 			ImGui::EndTabItem();
 		}
 
-		if (ImGui::BeginTabItem("Queues", nullptr, ImGuiTabItemFlags_None))
+		if (ImGui::BeginTabItem("Session Config", nullptr, ImGuiTabItemFlags_None))
 		{
-			ImGuiDisplayQueuesBrowser(pGISubsystem);
+			if (ImGui::BeginTabBar("Sessions", tab_bar_flags))
+			{
+				if (ImGui::BeginTabItem("Session Types", nullptr, ImGuiTabItemFlags_None))
+				{
+					ImGuiDisplaySessionTypes(pGISubsystem);
+					ImGui::EndTabItem();
+				}
+
+				if (ImGui::BeginTabItem("Queues", nullptr, ImGuiTabItemFlags_None))
+				{
+					ImGuiDisplayQueuesBrowser(pGISubsystem);
+					ImGui::EndTabItem();
+				}
+
+				if (ImGui::BeginTabItem("Matchmaking Profiles", nullptr, ImGuiTabItemFlags_None))
+				{
+					ImGuiDisplayMatchmakingProfiles(pGISubsystem);
+					ImGui::EndTabItem();
+				}
+
+				if (ImGui::BeginTabItem("Instance Request Templates", nullptr, ImGuiTabItemFlags_None))
+				{
+					ImGuiDisplayInstanceRequestTemplates(pGISubsystem);
+					ImGui::EndTabItem();
+				}
+
+				if (ImGui::BeginTabItem("Regions", nullptr, ImGuiTabItemFlags_None))
+				{
+					ImGuiDisplayRegionsBrowser(pGISubsystem);
+					ImGui::EndTabItem();
+				}
+
+				ImGui::EndTabBar();
+			}
+
 			ImGui::EndTabItem();
 		}
 
-		if (ImGui::BeginTabItem("Regions", nullptr, ImGuiTabItemFlags_None))
-		{
-			ImGuiDisplayRegionsBrowser(pGISubsystem);
-			ImGui::EndTabItem();
-		}
-
-		if (ImGui::BeginTabItem("Session Types", nullptr, ImGuiTabItemFlags_None))
-		{
-			ImGuiDisplaySessionTypes(pGISubsystem);
-			ImGui::EndTabItem();
-		}
 
 		ImGui::EndTabBar();
 	}

--- a/RallyHereDebugTool/Source/Public/RHDTW_Session.h
+++ b/RallyHereDebugTool/Source/Public/RHDTW_Session.h
@@ -57,23 +57,34 @@ public:
 	int32 QueueSearchPageSize;
 	bool bFilterInactiveQueues;
 
+	TArray<ANSICHAR> MatchmakingProfileSearchString;
+	TArray<ANSICHAR> InstanceRequestSearchString;
+
 protected:
+	// helpers used for multiple tabs
 	void ImGuiDisplayInstance(const FRHAPI_InstanceInfo& Info, URH_SessionView* RHSession, URH_GameInstanceSessionSubsystem* pGISessionSubsystem);
 	void ImGuiDisplayMatch(const FRHAPI_MatchInfo& Info);
 	void ImGuiDisplaySessionPlayer(URH_SessionView* RHSession, const FRHAPI_SessionPlayer& Player, int32 TeamId, URH_GameInstanceSessionSubsystem* pGISessionSubsystem);
 	void ImGuiDisplayPlatformSession(const FRHAPI_PlatformSession& Info);
 	void ImGuiDisplaySession(const FRH_APISessionWithETag& Session, URH_SessionView* RHSession, URH_LocalPlayerSessionSubsystem* pLPSessionSubsystem, URH_GameInstanceSessionSubsystem* pGISessionSubsystem);
 
+	// session state tabs
 	void ImGuiDisplayLocalPlayerSessions(URH_GameInstanceSubsystem* pGISubsystem);
 	void ImGuiDisplayPlayerSessions(URH_GameInstanceSubsystem* pGISubsystem);
 	void ImGuiDisplaySessionBrowser(URH_GameInstanceSubsystem* pGISubsystem);
+	
+	// helpers used for multiple session config tabs
+	void ImGuiDisplayQueue(const FRHAPI_QueueConfigV2& Queue, URH_LocalPlayerSessionSubsystem* pLPSessionSubsystem, class URH_OnlineSession* pSelectedSession, class URH_MatchmakingBrowserCache* pBrowerCache);
+	void ImGuiDisplayMatchmakingTemplate(const FRHAPI_MatchMakingTemplateV2& Template, class URH_MatchmakingBrowserCache* pBrowerCache);
+	void ImGuiDisplayMatchmakingProfile(const FRHAPI_MatchMakingProfileV2& Profile, class URH_MatchmakingBrowserCache* pBrowerCache);
+	void ImGuiDisplayInstanceRequestTemplate(const FRHAPI_InstanceRequestTemplate& RequestTemplate, class URH_MatchmakingBrowserCache* pBrowerCache);
+
+	// session config sub tabs
 	void ImGuiDisplaySessionTypes(URH_GameInstanceSubsystem* pGISubsystem);
-
-	void ImGuiDisplayQueuesBrowser(URH_GameInstanceSubsystem* pGISubsystem);
-	void ImGuiDisplayQueue(const class URH_MatchmakingQueueInfo* Queue, URH_LocalPlayerSessionSubsystem* pLPSessionSubsystem, class URH_OnlineSession* pSelectedSession, class URH_MatchmakingBrowserCache* pBrowerCache);
-
 	void ImGuiDisplayRegionsBrowser(URH_GameInstanceSubsystem* pGISubsystem);
-
+	void ImGuiDisplayQueuesBrowser(URH_GameInstanceSubsystem* pGISubsystem);
+	void ImGuiDisplayMatchmakingProfiles(URH_GameInstanceSubsystem* pGISubsystem);
+	void ImGuiDisplayInstanceRequestTemplates(URH_GameInstanceSubsystem* pGISubsystem);
 	void HandleBrowserSearchResult(bool bSuccess, const FRH_SessionBrowserSearchResult& Result);
 	void HandleSessionUpdatedResult(bool bSuccess, URH_SessionView* SessionData, const FRH_ErrorInfo& ErrorInfo, FGuid PlayerUuid);
 

--- a/RallyHereDebugTool/Source/Public/RH_ImGuiUtilities.h
+++ b/RallyHereDebugTool/Source/Public/RH_ImGuiUtilities.h
@@ -60,6 +60,32 @@ void RALLYHEREDEBUGTOOL_API ImGuiDisplayCopyableValue(const FString& Key, const 
 }
 
 template<typename T>
+void RALLYHEREDEBUGTOOL_API ImGuiDisplayCopyableEnumValue(const FString& Key, const T& Value, ECopyMode CopyMode = ECopyMode::KeyValue, bool bButtonOnLeftSide = false, bool bContentAsTooltip = false)
+{
+	ImGuiDisplayCopyableValue(Key, EnumToString(Value), CopyMode, bButtonOnLeftSide, bContentAsTooltip);
+}
+
+template<typename T>
+void RALLYHEREDEBUGTOOL_API ImGuiDisplayCopyableEnumValue(const FString& Key, const T* Value, ECopyMode CopyMode = ECopyMode::KeyValue, bool bButtonOnLeftSide = false, bool bContentAsTooltip = false)
+{
+	if (Value != nullptr)
+	{
+		ImGuiDisplayCopyableEnumValue(Key, *Value, CopyMode, bButtonOnLeftSide, bContentAsTooltip);
+	}
+	else
+	{
+		if (CopyMode == ECopyMode::KeyValue)
+		{
+			ImGui::Text("%s : <UNSET>", TCHAR_TO_UTF8(*Key));
+		}
+		else if (CopyMode == ECopyMode::Value)
+		{
+			ImGui::Text("<UNSET>");
+		}
+	}
+}
+
+template<typename T>
 void RALLYHEREDEBUGTOOL_API ImGuiDisplayCopyableValue(const FString& Key, const TOptional<T>& Value, ECopyMode CopyMode = ECopyMode::KeyValue, bool bButtonOnLeftSide = false, bool bContentAsTooltip = false)
 {
 	ImGuiDisplayCopyableValue<T>(Key, GetPtrOrNull(Value), CopyMode, bButtonOnLeftSide, bContentAsTooltip);

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_MatchmakingBrowser.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_MatchmakingBrowser.cpp
@@ -76,7 +76,7 @@ void URH_MatchmakingBrowserCache::SearchMatchmakingTemplateGroup(const FGuid& Te
 			{
 				if (Resp.IsSuccessful())
 				{
-					ImportAPITemplateGroup(Resp.Content, Resp.ETag.Get(TEXT("")));
+					ImportAPIMatchmakingTemplateGroup(Resp.Content, Resp.ETag.Get(TEXT("")));
 				}
 			}),
 		FRH_GenericSuccessWithErrorDelegate::CreateWeakLambda(this, [this, TemplateId, Delegate](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
@@ -103,20 +103,81 @@ void URH_MatchmakingBrowserCache::SearchMatchmakingTemplateGroup(const FGuid& Te
 	Helper->Start(RH_APIs::GetQueuesAPI(), Request);
 }
 
-void URH_MatchmakingBrowserCache::ImportAPITemplateGroup(const FRHAPI_MatchMakingTemplateGroupV2& APITemplate, const FString& ETag)
+void URH_MatchmakingBrowserCache::ImportAPIMatchmakingTemplateGroup(const FRHAPI_MatchMakingTemplateGroupV2& APITemplate, const FString& ETag)
 {
 	UE_LOG(LogRallyHereIntegration, Verbose, TEXT("[%s] : %s"), ANSI_TO_TCHAR(__FUNCTION__), *APITemplate.GetMatchMakingTemplateGroupId().ToString(EGuidFormats::DigitsWithHyphens));
 
-	auto existingPtr = TemplateGroupCache.Find(APITemplate.GetMatchMakingTemplateGroupId());
-	URH_MatchmakingTemplateGroupInfo* TemplateWrapper = existingPtr ? *existingPtr : nullptr;
+	auto existingPtr = MatchmakingTemplateGroupCache.Find(APITemplate.GetMatchMakingTemplateGroupId());
+	auto* Wrapper = existingPtr ? *existingPtr : nullptr;
 
-	if (TemplateWrapper == nullptr)
+	if (Wrapper == nullptr)
 	{
-		TemplateWrapper = NewObject<URH_MatchmakingTemplateGroupInfo>(this);
-		TemplateGroupCache.Add(APITemplate.GetMatchMakingTemplateGroupId(), TemplateWrapper);
+		Wrapper = NewObject<URH_MatchmakingTemplateGroupInfo>(this);
+		MatchmakingTemplateGroupCache.Add(APITemplate.GetMatchMakingTemplateGroupId(), Wrapper);
 	}
 
-	TemplateWrapper->ImportAPITemplateGroup(APITemplate, ETag);
+	Wrapper->ImportAPITemplateGroup(APITemplate, ETag);
+
+	// import the profiles to the profile cache, since we have them anyways
+	for (const auto& Options : APITemplate.GetTemplateOptions())
+	{
+		for (const auto& Profile : Options.GetProfiles())
+		{
+			ImportAPIMatchmakingProfile(Profile, FString());
+		}
+	}
+}
+
+void URH_MatchmakingBrowserCache::SearchMatchmakingProfile(const FString& ProfileId, const FRH_OnGetMatchmakingProfileCompleteDelegateBlock& Delegate)
+{
+	typedef RallyHereAPI::Traits_GetMatchMakingProfileV2 BaseType;
+
+	auto Helper = MakeShared<FRH_SimpleQueryHelper<BaseType>>(
+		BaseType::Delegate::CreateWeakLambda(this, [this](const BaseType::Response& Resp)
+			{
+				if (Resp.IsSuccessful())
+				{
+					ImportAPIMatchmakingProfile(Resp.Content, Resp.ETag.Get(TEXT("")));
+				}
+			}),
+		FRH_GenericSuccessWithErrorDelegate::CreateWeakLambda(this, [this, ProfileId, Delegate](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
+			{
+				Delegate.ExecuteIfBound(bSuccess, GetMatchmakingProfile(ProfileId), ErrorInfo);
+			}),
+		GetDefault<URH_IntegrationSettings>()->GetMatchmakingTemplatePriority
+	);
+
+	BaseType::Request Request;
+	Request.AuthContext = GetAuthContext();
+	Request.MatchMakingProfileId = ProfileId;
+
+	const auto* Existing = GetMatchmakingProfile(ProfileId);
+	if (Existing != nullptr)
+	{
+		// if we have an etag, use it
+		if (Existing->GetETag().Len() > 0)
+		{
+			Request.IfNoneMatch = Existing->GetETag();
+		}
+	}
+
+	Helper->Start(RH_APIs::GetQueuesAPI(), Request);
+}
+
+void URH_MatchmakingBrowserCache::ImportAPIMatchmakingProfile(const FRHAPI_MatchMakingProfileV2& APIProfile, const FString& ETag)
+{
+	UE_LOG(LogRallyHereIntegration, Verbose, TEXT("[%s] : %s"), ANSI_TO_TCHAR(__FUNCTION__), *APIProfile.GetMatchMakingProfileId());
+
+	auto existingPtr = MatchmakingProfileCache.Find(APIProfile.GetMatchMakingProfileId());
+	auto* Wrapper = existingPtr ? *existingPtr : nullptr;
+
+	if (Wrapper == nullptr)
+	{
+		Wrapper = NewObject<URH_MatchmakingProfileInfo>(this);
+		MatchmakingProfileCache.Add(APIProfile.GetMatchMakingProfileId(), Wrapper);
+	}
+
+	Wrapper->ImportAPIProfile(APIProfile, ETag);
 }
 
 void URH_MatchmakingBrowserCache::SearchInstanceRequestTemplate(const FGuid& TemplateId, const FRH_OnGetInstanceRequestTemplateCompleteDelegateBlock& Delegate)


### PR DESCRIPTION
…(cache is autopopulated from template group lookups, since they contain profile data).

Rework Session Debug window to allow for displaying of config in a dedicated tab (with existing config tabs made subtabs of the new tab).  Add ability to directly lookup matchmaking profiles and launch templates by id in the debug tool.