### PR TITLE
Don't set max_players in the game host provider on init

### DIFF
--- a/RallyHereIntegration/Source/RallyHereGameHostProvider/Private/RH_GameHostProviderGHA.cpp
+++ b/RallyHereIntegration/Source/RallyHereGameHostProvider/Private/RH_GameHostProviderGHA.cpp
@@ -50,8 +50,6 @@ FRH_GameHostProviderGHA::FRH_GameHostProviderGHA(const FString& Commandline)
 		provided.set_folder = true;
 		stats.game = (ANSICHAR*)ProjectName.Get();
 		provided.set_game = true;
-		stats.max_players = 1;
-		provided.set_max_players = true;
 		stats.visibility = 0;
 		provided.set_visibility = true;
 		stats.version = (ANSICHAR*)EngineVersion.Get();


### PR DESCRIPTION
There currently is no way to override this value, so it just results in confusion on the side of the reporting systems since the number of current players can be greater than the number of max players. For now this leaves the GHA entirely responsible for managing the max_players number to the best of its ability.