### PR TITLE
Pass at marking many player info functions as virtual 

### DIFF
--- a/Documentation/md/PlayerInfo.md
+++ b/Documentation/md/PlayerInfo.md
@@ -36,11 +36,11 @@ Player Info Subobject base class used to store player data.
 `public FRH_OnPlayerInfoSubobjectUpdatedMulticastDelegate `[`OnUpdatedDelegate`](#classURH__PlayerInfoSubobject_1a79fe3beb1968bb4fec503603aab7c7c5) | Native delegate to listen for presence updates.
 `public TArray< FRH_OnRequestPlayerInfoSubobjectDelegateBlock > `[`TemporaryRequestDelegates`](#classURH__PlayerInfoSubobject_1a5968c4b094b525f7e54adc02b11a35bf) | Delegates stored to response to currently active requests.
 `public class `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`GetPlayerInfo`](#classURH__PlayerInfoSubobject_1aa4e6fb9d2cdcfd4690022db8ea155e0e)`() const` | Gets the PlayerInfo that owns this Player Matches object.
-`public inline void `[`MarkUpdated`](#classURH__PlayerInfoSubobject_1a58ec05a187f04f59e206487e5130c20d)`()` | Sets the last updated time to now.
-`public inline void `[`MarkDirty`](#classURH__PlayerInfoSubobject_1a65e9f132b7fb7d3dfa8be3fad451337a)`()` | Clears the last updated time to force an update.
-`public inline void `[`RequestUpdate`](#classURH__PlayerInfoSubobject_1a973f4d625860eb6477b615d24a906461)`(bool bForceUpdate,const FRH_OnRequestPlayerInfoSubobjectDelegateBlock & Delegate)` | Enqueues an update request for the players information from the RallyHere API.
+`public inline virtual void `[`MarkUpdated`](#classURH__PlayerInfoSubobject_1a23487defc38d317099f23d9b68086f03)`()` | Sets the last updated time to now.
+`public inline virtual void `[`MarkDirty`](#classURH__PlayerInfoSubobject_1ae49b2a6e09b8159f32f1ccedc27c3dcc)`()` | Clears the last updated time to force an update.
+`public inline virtual void `[`RequestUpdate`](#classURH__PlayerInfoSubobject_1aab35a732de0ee7a292776887fae18190)`(bool bForceUpdate,const FRH_OnRequestPlayerInfoSubobjectDelegateBlock & Delegate)` | Enqueues an update request for the players information from the RallyHere API.
 `public inline void `[`BLUEPRINT_RequestUpdate`](#classURH__PlayerInfoSubobject_1ad60fb784f621475df3a543126b379209)`(bool bForceUpdate,const FRH_OnRequestPlayerInfoSubobjectDynamicDelegate & Delegate)` | 
-`public void `[`CheckPollStatus`](#classURH__PlayerInfoSubobject_1a993e45b8a7968072c2469392e97c86b2)`(const bool bForceUpdate)` | Updates the poll status to be active or inactive based on if it should currently be polling.
+`public virtual void `[`CheckPollStatus`](#classURH__PlayerInfoSubobject_1a2e46e4cf8c81cee9eeafac9d8dcdee36)`(const bool bForceUpdate)` | Updates the poll status to be active or inactive based on if it should currently be polling.
 `protected FRH_AutoPollerPtr `[`Poller`](#classURH__PlayerInfoSubobject_1a9abab6c88fabe22a23835813a56bffbd) | Poller for the players matches.
 `protected FName `[`PollTimerName`](#classURH__PlayerInfoSubobject_1a697ccd6d2e132cd4ac05fcc31e64272f) | The name of the timer preset to use for polling.
 `protected int32 `[`PollPriority`](#classURH__PlayerInfoSubobject_1aa0795fa3b53d3842dc358564abed8f5d) | The priority of the poll request.
@@ -95,17 +95,17 @@ Gets the PlayerInfo that owns this Player Matches object.
 The PlayerInfo that owns the Player Matches object.
 
 <br>
-#### `public inline void `[`MarkUpdated`](#classURH__PlayerInfoSubobject_1a58ec05a187f04f59e206487e5130c20d)`()` <a id="classURH__PlayerInfoSubobject_1a58ec05a187f04f59e206487e5130c20d"></a>
+#### `public inline virtual void `[`MarkUpdated`](#classURH__PlayerInfoSubobject_1a23487defc38d317099f23d9b68086f03)`()` <a id="classURH__PlayerInfoSubobject_1a23487defc38d317099f23d9b68086f03"></a>
 
 Sets the last updated time to now.
 
 <br>
-#### `public inline void `[`MarkDirty`](#classURH__PlayerInfoSubobject_1a65e9f132b7fb7d3dfa8be3fad451337a)`()` <a id="classURH__PlayerInfoSubobject_1a65e9f132b7fb7d3dfa8be3fad451337a"></a>
+#### `public inline virtual void `[`MarkDirty`](#classURH__PlayerInfoSubobject_1ae49b2a6e09b8159f32f1ccedc27c3dcc)`()` <a id="classURH__PlayerInfoSubobject_1ae49b2a6e09b8159f32f1ccedc27c3dcc"></a>
 
 Clears the last updated time to force an update.
 
 <br>
-#### `public inline void `[`RequestUpdate`](#classURH__PlayerInfoSubobject_1a973f4d625860eb6477b615d24a906461)`(bool bForceUpdate,const FRH_OnRequestPlayerInfoSubobjectDelegateBlock & Delegate)` <a id="classURH__PlayerInfoSubobject_1a973f4d625860eb6477b615d24a906461"></a>
+#### `public inline virtual void `[`RequestUpdate`](#classURH__PlayerInfoSubobject_1aab35a732de0ee7a292776887fae18190)`(bool bForceUpdate,const FRH_OnRequestPlayerInfoSubobjectDelegateBlock & Delegate)` <a id="classURH__PlayerInfoSubobject_1aab35a732de0ee7a292776887fae18190"></a>
 
 Enqueues an update request for the players information from the RallyHere API.
 
@@ -118,7 +118,7 @@ Enqueues an update request for the players information from the RallyHere API.
 #### `public inline void `[`BLUEPRINT_RequestUpdate`](#classURH__PlayerInfoSubobject_1ad60fb784f621475df3a543126b379209)`(bool bForceUpdate,const FRH_OnRequestPlayerInfoSubobjectDynamicDelegate & Delegate)` <a id="classURH__PlayerInfoSubobject_1ad60fb784f621475df3a543126b379209"></a>
 
 <br>
-#### `public void `[`CheckPollStatus`](#classURH__PlayerInfoSubobject_1a993e45b8a7968072c2469392e97c86b2)`(const bool bForceUpdate)` <a id="classURH__PlayerInfoSubobject_1a993e45b8a7968072c2469392e97c86b2"></a>
+#### `public virtual void `[`CheckPollStatus`](#classURH__PlayerInfoSubobject_1a2e46e4cf8c81cee9eeafac9d8dcdee36)`(const bool bForceUpdate)` <a id="classURH__PlayerInfoSubobject_1a2e46e4cf8c81cee9eeafac9d8dcdee36"></a>
 
 Updates the poll status to be active or inactive based on if it should currently be polling.
 
@@ -307,7 +307,7 @@ Player Matches class used to store player match history information.
 `public int32 `[`PollMaxPageCount`](#classURH__PlayerMatches_1ab61d485e5d851ff8fea078e331c9c7b8) | Polling of new pages is stopped after this value is reached, if 0, polls until all pages are polled.
 `public FTimespan `[`PollMaxAge`](#classURH__PlayerMatches_1ae4bebdc4d6137fb5585f4310b1d7c4e7) | The maximum age after which to stop polling new pages, if 0, polls until max count is reached.
 `public TMap< FString, `[`FRHAPI_MatchPlayerWithMatch`](models/RHAPI_MatchPlayerWithMatch.md#structFRHAPI__MatchPlayerWithMatch)` > `[`Matches`](#classURH__PlayerMatches_1aca9fc68c9d093c1a90bce75d0f9832ea) | The matches the player has participated in.
-`protected virtual void `[`Poll`](#classURH__PlayerMatches_1a078e6c98d6151bf84750e9118fcdbf71)`(const FRH_PollCompleteFunc & Delegate)` | Starts a poll of the object data.
+`protected virtual void `[`Poll`](#classURH__PlayerMatches_1a40b839311638c5097b6bc1f74b3156d3)`(const FRH_PollCompleteFunc & Delegate)` | Starts a poll of the object data.
 `protected virtual void `[`PollNextPage`](#classURH__PlayerMatches_1a2ca5a0cec9f116fd4469fb3a2a387e11)`(const FRH_PollCompleteFunc & Delegate,TSharedPtr< `[`FPollContext`](undefined.md#structURH__PlayerMatches_1_1FPollContext)` > Context)` | Starts a poll of the object data.
 `protected inline virtual void `[`Update`](#classURH__PlayerMatches_1a2d718f1945307bc4570e9b6fc1a10a27)`(const GetMatchesType::Response & Other,TSharedPtr< `[`FPollContext`](undefined.md#structURH__PlayerMatches_1_1FPollContext)` > Context)` | Stores the response data from an API presence request.
 `typedef `[`GetMatchesType`](#classURH__PlayerMatches_1a13c41a6b6f28555aa13c6536c706c8b9) | 
@@ -334,7 +334,7 @@ The maximum age after which to stop polling new pages, if 0, polls until max cou
 The matches the player has participated in.
 
 <br>
-#### `protected virtual void `[`Poll`](#classURH__PlayerMatches_1a078e6c98d6151bf84750e9118fcdbf71)`(const FRH_PollCompleteFunc & Delegate)` <a id="classURH__PlayerMatches_1a078e6c98d6151bf84750e9118fcdbf71"></a>
+#### `protected virtual void `[`Poll`](#classURH__PlayerMatches_1a40b839311638c5097b6bc1f74b3156d3)`(const FRH_PollCompleteFunc & Delegate)` <a id="classURH__PlayerMatches_1a40b839311638c5097b6bc1f74b3156d3"></a>
 
 Starts a poll of the object data.
 
@@ -378,15 +378,15 @@ Player Reports class used to store and send player report information.
 
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
-`public void `[`GetReportsSentAsync`](#classURH__PlayerReports_1a998c9757f509c24745f705ee6f3152ec)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsBlock & Delegate)` | Request a list of player reports send by this player.
+`public virtual void `[`GetReportsSentAsync`](#classURH__PlayerReports_1a8286167a68b0b8f0dc9e57c394fd29fd)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsBlock & Delegate)` | Request a list of player reports send by this player.
 `public inline void `[`BLUEPRINT_GetReportsSentAsync`](#classURH__PlayerReports_1abc1c0b9e9fb18c326cffcd0c21030078)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsDynamicDelegate & Delegate)` | Request a list of player reports send by this player.
 `public inline TArray< `[`FRHAPI_PlayerReport`](models/RHAPI_PlayerReport.md#structFRHAPI__PlayerReport)` > `[`GetReportsSent`](#classURH__PlayerReports_1a143d1f8a21fec0136747bd53bfe85750)`() const` | Get the current cached list of player reports sent by this player.
-`public void `[`GetReportsReceivedAsync`](#classURH__PlayerReports_1a1f5420d091da13449807424a2151433c)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsBlock & Delegate)` | Request a list of player reports received by this player.
+`public virtual void `[`GetReportsReceivedAsync`](#classURH__PlayerReports_1ace60d12bc864d0546372df009c41f5f2)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsBlock & Delegate)` | Request a list of player reports received by this player.
 `public inline void `[`BLUEPRINT_GetReportsReceivedAsync`](#classURH__PlayerReports_1af22eebdd08e50bf32cb51c42712d42bd)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsDynamicDelegate & Delegate)` | Request a list of player reports received by this player.
-`public inline TArray< `[`FRHAPI_PlayerReport`](models/RHAPI_PlayerReport.md#structFRHAPI__PlayerReport)` > `[`GetReportsReceived`](#classURH__PlayerReports_1ae2797d22ab1d3dc0a492aefb8a9aa9ce)`() const` | Get the current cached list of player reports received by this player.
-`public void `[`CreateReport`](#classURH__PlayerReports_1ad3901abf329a8ad6400d68ee82e41678)`(const `[`FRHAPI_PlayerReportCreate`](models/RHAPI_PlayerReportCreate.md#structFRHAPI__PlayerReportCreate)` & Report,const FRH_PlayerInfoCreatePlayerReportBlock & Delegate)` | Create a new report for the target player.
+`public inline virtual TArray< `[`FRHAPI_PlayerReport`](models/RHAPI_PlayerReport.md#structFRHAPI__PlayerReport)` > `[`GetReportsReceived`](#classURH__PlayerReports_1a34372b78a48405bac1101576e9aaa256)`() const` | Get the current cached list of player reports received by this player.
+`public virtual void `[`CreateReport`](#classURH__PlayerReports_1a3a7db86764cfd8c2a83be10dd5d9d157)`(const `[`FRHAPI_PlayerReportCreate`](models/RHAPI_PlayerReportCreate.md#structFRHAPI__PlayerReportCreate)` & Report,const FRH_PlayerInfoCreatePlayerReportBlock & Delegate)` | Create a new report for the target player.
 `public inline void `[`BLUEPRINT_CreateReport`](#classURH__PlayerReports_1a6ed2cfcfa311ed6eaed59db909566e15)`(const `[`FRHAPI_PlayerReportCreate`](models/RHAPI_PlayerReportCreate.md#structFRHAPI__PlayerReportCreate)` & Report,const FRH_PlayerInfoCreatePlayerReportDynamicDelegate & Delegate)` | Create a new report for the target player.
-`public void `[`CreateReport`](#classURH__PlayerReports_1a675dcfb7ec0e5b4708da14bfaa419809)`(const `[`FRHAPI_PlayerReportCreate`](models/RHAPI_PlayerReportCreate.md#structFRHAPI__PlayerReportCreate)` & Report,FAuthContextPtr AuthContext,const FRH_PlayerInfoCreatePlayerReportBlock & Delegate)` | Create a new report for the target player with a specific auth context.
+`public virtual void `[`CreateReport`](#classURH__PlayerReports_1a33a8bdc35ba9d092820b6796dc9763bf)`(const `[`FRHAPI_PlayerReportCreate`](models/RHAPI_PlayerReportCreate.md#structFRHAPI__PlayerReportCreate)` & Report,FAuthContextPtr AuthContext,const FRH_PlayerInfoCreatePlayerReportBlock & Delegate)` | Create a new report for the target player with a specific auth context.
 `protected TArray< `[`FRHAPI_PlayerReport`](models/RHAPI_PlayerReport.md#structFRHAPI__PlayerReport)` > `[`ReportsSent`](#classURH__PlayerReports_1afa610002ff1c15ed7e6dfdfce53b2263) | 
 `protected TArray< `[`FRHAPI_PlayerReport`](models/RHAPI_PlayerReport.md#structFRHAPI__PlayerReport)` > `[`ReportsReceived`](#classURH__PlayerReports_1a3f561b683fa7026383b75e5494ca6959) | 
 `typedef `[`GetReportsSentType`](#classURH__PlayerReports_1a66e9b68dfeb75fe986b3f615385e80a7) | 
@@ -395,7 +395,7 @@ Player Reports class used to store and send player report information.
 
 #### Members
 
-#### `public void `[`GetReportsSentAsync`](#classURH__PlayerReports_1a998c9757f509c24745f705ee6f3152ec)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsBlock & Delegate)` <a id="classURH__PlayerReports_1a998c9757f509c24745f705ee6f3152ec"></a>
+#### `public virtual void `[`GetReportsSentAsync`](#classURH__PlayerReports_1a8286167a68b0b8f0dc9e57c394fd29fd)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsBlock & Delegate)` <a id="classURH__PlayerReports_1a8286167a68b0b8f0dc9e57c394fd29fd"></a>
 
 Request a list of player reports send by this player.
 
@@ -424,7 +424,7 @@ Request a list of player reports send by this player.
 Get the current cached list of player reports sent by this player.
 
 <br>
-#### `public void `[`GetReportsReceivedAsync`](#classURH__PlayerReports_1a1f5420d091da13449807424a2151433c)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsBlock & Delegate)` <a id="classURH__PlayerReports_1a1f5420d091da13449807424a2151433c"></a>
+#### `public virtual void `[`GetReportsReceivedAsync`](#classURH__PlayerReports_1ace60d12bc864d0546372df009c41f5f2)`(const FString & Cursor,const int32 PageSize,const FRH_PlayerInfoGetPlayerReportsBlock & Delegate)` <a id="classURH__PlayerReports_1ace60d12bc864d0546372df009c41f5f2"></a>
 
 Request a list of player reports received by this player.
 
@@ -448,12 +448,12 @@ Request a list of player reports received by this player.
 * `Delegate` Callback delegate for the request.
 
 <br>
-#### `public inline TArray< `[`FRHAPI_PlayerReport`](models/RHAPI_PlayerReport.md#structFRHAPI__PlayerReport)` > `[`GetReportsReceived`](#classURH__PlayerReports_1ae2797d22ab1d3dc0a492aefb8a9aa9ce)`() const` <a id="classURH__PlayerReports_1ae2797d22ab1d3dc0a492aefb8a9aa9ce"></a>
+#### `public inline virtual TArray< `[`FRHAPI_PlayerReport`](models/RHAPI_PlayerReport.md#structFRHAPI__PlayerReport)` > `[`GetReportsReceived`](#classURH__PlayerReports_1a34372b78a48405bac1101576e9aaa256)`() const` <a id="classURH__PlayerReports_1a34372b78a48405bac1101576e9aaa256"></a>
 
 Get the current cached list of player reports received by this player.
 
 <br>
-#### `public void `[`CreateReport`](#classURH__PlayerReports_1ad3901abf329a8ad6400d68ee82e41678)`(const `[`FRHAPI_PlayerReportCreate`](models/RHAPI_PlayerReportCreate.md#structFRHAPI__PlayerReportCreate)` & Report,const FRH_PlayerInfoCreatePlayerReportBlock & Delegate)` <a id="classURH__PlayerReports_1ad3901abf329a8ad6400d68ee82e41678"></a>
+#### `public virtual void `[`CreateReport`](#classURH__PlayerReports_1a3a7db86764cfd8c2a83be10dd5d9d157)`(const `[`FRHAPI_PlayerReportCreate`](models/RHAPI_PlayerReportCreate.md#structFRHAPI__PlayerReportCreate)` & Report,const FRH_PlayerInfoCreatePlayerReportBlock & Delegate)` <a id="classURH__PlayerReports_1a3a7db86764cfd8c2a83be10dd5d9d157"></a>
 
 Create a new report for the target player.
 
@@ -473,7 +473,7 @@ Create a new report for the target player.
 * `Delegate` Callback delegate for the request.
 
 <br>
-#### `public void `[`CreateReport`](#classURH__PlayerReports_1a675dcfb7ec0e5b4708da14bfaa419809)`(const `[`FRHAPI_PlayerReportCreate`](models/RHAPI_PlayerReportCreate.md#structFRHAPI__PlayerReportCreate)` & Report,FAuthContextPtr AuthContext,const FRH_PlayerInfoCreatePlayerReportBlock & Delegate)` <a id="classURH__PlayerReports_1a675dcfb7ec0e5b4708da14bfaa419809"></a>
+#### `public virtual void `[`CreateReport`](#classURH__PlayerReports_1a33a8bdc35ba9d092820b6796dc9763bf)`(const `[`FRHAPI_PlayerReportCreate`](models/RHAPI_PlayerReportCreate.md#structFRHAPI__PlayerReportCreate)` & Report,FAuthContextPtr AuthContext,const FRH_PlayerInfoCreatePlayerReportBlock & Delegate)` <a id="classURH__PlayerReports_1a33a8bdc35ba9d092820b6796dc9763bf"></a>
 
 Create a new report for the target player with a specific auth context.
 
@@ -515,10 +515,10 @@ Stores information a specific platform the player has linked to their account.
 --------------------------------|---------------------------------------------
 `public `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` `[`PlayerPlatformId`](#classURH__PlayerPlatformInfo_1ac0ef7725316040314b2488260850eabb) | Players Platform ID struct.
 `public FString `[`DisplayName`](#classURH__PlayerPlatformInfo_1a056f2023dd209b4807ac14a699cd594e) | Last seen display name for the player on the platform.
-`public inline FORCEINLINE `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` `[`GetPlayerPlatformId`](#classURH__PlayerPlatformInfo_1a01087e75b35b862c18d8579f9d84a7ba)`() const` | Gets the Platform Id struct for the player.
-`public inline FORCEINLINE FString `[`GetPlatformUserId`](#classURH__PlayerPlatformInfo_1abf743e9775a21e9526ec50775f9491c1)`() const` | Gets the Platform Id for the player.
-`public inline FORCEINLINE ERHAPI_Platform `[`GetPlatform`](#classURH__PlayerPlatformInfo_1a3dd011d8a3919bc528adc47cad307cf0)`() const` | Gets the Platform Type for the player.
-`public inline FORCEINLINE FString `[`GetLastKnownDisplayName`](#classURH__PlayerPlatformInfo_1ab91b2f7ba0378669bc1a2b756c2ba940)`() const` | Gets the display name stored the last time this player logged in to the Rally Here server.
+`public inline virtual `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` `[`GetPlayerPlatformId`](#classURH__PlayerPlatformInfo_1a521e63d00404a311a21c224d73001b0b)`() const` | Gets the Platform Id struct for the player.
+`public inline virtual FString `[`GetPlatformUserId`](#classURH__PlayerPlatformInfo_1aef5dad4953cf0c0edfb30119e6724bd9)`() const` | Gets the Platform Id for the player.
+`public inline virtual ERHAPI_Platform `[`GetPlatform`](#classURH__PlayerPlatformInfo_1ae004f09524c3e8be17dedc18ab220e51)`() const` | Gets the Platform Type for the player.
+`public inline virtual FString `[`GetLastKnownDisplayName`](#classURH__PlayerPlatformInfo_1a285f132c06d72cdb4876115765de9af2)`() const` | Gets the display name stored the last time this player logged in to the Rally Here server.
 
 #### Members
 
@@ -532,7 +532,7 @@ Players Platform ID struct.
 Last seen display name for the player on the platform.
 
 <br>
-#### `public inline FORCEINLINE `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` `[`GetPlayerPlatformId`](#classURH__PlayerPlatformInfo_1a01087e75b35b862c18d8579f9d84a7ba)`() const` <a id="classURH__PlayerPlatformInfo_1a01087e75b35b862c18d8579f9d84a7ba"></a>
+#### `public inline virtual `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` `[`GetPlayerPlatformId`](#classURH__PlayerPlatformInfo_1a521e63d00404a311a21c224d73001b0b)`() const` <a id="classURH__PlayerPlatformInfo_1a521e63d00404a311a21c224d73001b0b"></a>
 
 Gets the Platform Id struct for the player.
 
@@ -540,7 +540,7 @@ Gets the Platform Id struct for the player.
 The players Platform Id struct.
 
 <br>
-#### `public inline FORCEINLINE FString `[`GetPlatformUserId`](#classURH__PlayerPlatformInfo_1abf743e9775a21e9526ec50775f9491c1)`() const` <a id="classURH__PlayerPlatformInfo_1abf743e9775a21e9526ec50775f9491c1"></a>
+#### `public inline virtual FString `[`GetPlatformUserId`](#classURH__PlayerPlatformInfo_1aef5dad4953cf0c0edfb30119e6724bd9)`() const` <a id="classURH__PlayerPlatformInfo_1aef5dad4953cf0c0edfb30119e6724bd9"></a>
 
 Gets the Platform Id for the player.
 
@@ -548,7 +548,7 @@ Gets the Platform Id for the player.
 The players Platform Unique Id.
 
 <br>
-#### `public inline FORCEINLINE ERHAPI_Platform `[`GetPlatform`](#classURH__PlayerPlatformInfo_1a3dd011d8a3919bc528adc47cad307cf0)`() const` <a id="classURH__PlayerPlatformInfo_1a3dd011d8a3919bc528adc47cad307cf0"></a>
+#### `public inline virtual ERHAPI_Platform `[`GetPlatform`](#classURH__PlayerPlatformInfo_1ae004f09524c3e8be17dedc18ab220e51)`() const` <a id="classURH__PlayerPlatformInfo_1ae004f09524c3e8be17dedc18ab220e51"></a>
 
 Gets the Platform Type for the player.
 
@@ -556,7 +556,7 @@ Gets the Platform Type for the player.
 The players Platform Type.
 
 <br>
-#### `public inline FORCEINLINE FString `[`GetLastKnownDisplayName`](#classURH__PlayerPlatformInfo_1ab91b2f7ba0378669bc1a2b756c2ba940)`() const` <a id="classURH__PlayerPlatformInfo_1ab91b2f7ba0378669bc1a2b756c2ba940"></a>
+#### `public inline virtual FString `[`GetLastKnownDisplayName`](#classURH__PlayerPlatformInfo_1a285f132c06d72cdb4876115765de9af2)`() const` <a id="classURH__PlayerPlatformInfo_1a285f132c06d72cdb4876115765de9af2"></a>
 
 Gets the display name stored the last time this player logged in to the Rally Here server.
 
@@ -582,34 +582,34 @@ Stores and fetchs all the information about a given player.
 `public inline FORCEINLINE `[`URH_PlayerSessions`](PlayerInfo.md#classURH__PlayerSessions)` * `[`GetSessions`](#classURH__PlayerInfo_1a3a012da0a55d1edb09a80dcf658ae7f4)`() const` | Gets The players sessions class.
 `public inline FORCEINLINE `[`URH_PlayerMatches`](PlayerInfo.md#classURH__PlayerMatches)` * `[`GetMatches`](#classURH__PlayerInfo_1a18162aabb6b78affb52f918ae8517f84)`() const` | Gets The players matches class.
 `public inline FORCEINLINE `[`URH_PlayerReports`](PlayerInfo.md#classURH__PlayerReports)` * `[`GetReports`](#classURH__PlayerInfo_1a384f5b99113927ed0f47cf1278e45018)`() const` | Gets The players reports class.
-`public inline FORCEINLINE TArray< `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` > & `[`GetPlayerPlatformIds`](#classURH__PlayerInfo_1a6da64917c1815b0048dbf5b770a43480)`()` | Gets the associated platform ids of the player.
-`public inline FORCEINLINE const TArray< `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` > & `[`GetPlayerPlatformIds`](#classURH__PlayerInfo_1ab0617adb51499a0c8ce36ef60693e6d6)`() const` | Gets the associated platform ids of the player.
-`public TArray< `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * > `[`GetPlayerPlatforms`](#classURH__PlayerInfo_1a3896d84ba5481158ce3cfc62b39e064e)`() const` | Gets the associated platforms of the player.
-`public `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * `[`GetPlayerPlatformInfo`](#classURH__PlayerInfo_1a0e3a7df23b8a7a183d1b8c94c578e343)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` | Gets a specific platform for the player.
+`public inline virtual TArray< `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` > & `[`GetPlayerPlatformIds`](#classURH__PlayerInfo_1a07f7aedb216f1536718b152d384d7ba9)`()` | Gets the associated platform ids of the player.
+`public inline virtual const TArray< `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` > & `[`GetPlayerPlatformIds`](#classURH__PlayerInfo_1a28f6726b50d19d49895f5ef07a080625)`() const` | Gets the associated platform ids of the player.
+`public virtual TArray< `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * > `[`GetPlayerPlatforms`](#classURH__PlayerInfo_1a809c05d3726b297a8c9c1a5647e1b312)`() const` | Gets the associated platforms of the player.
+`public virtual `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * `[`GetPlayerPlatformInfo`](#classURH__PlayerInfo_1a739b91e94755670e614506e17ee468d8)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` | Gets a specific platform for the player.
 `public inline `[`URH_PlayerInventory`](Inventory.md#classURH__PlayerInventory)` * `[`GetPlayerInventory`](#classURH__PlayerInfo_1a430d123219813a6ba0c8100b367df6ec)`() const` | Gets the players Inventory Subsystem.
 `public inline `[`URH_PlayerNotifications`](Notifications.md#classURH__PlayerNotifications)` * `[`GetPlayerNotifications`](#classURH__PlayerInfo_1a6f1e1f6ef4d38ed87c2c2b920a5cd891)`() const` | Gets the players Notification Subsystem.
-`public void `[`StartStreamingNotifications`](#classURH__PlayerInfo_1a15c2a3c44c22cfb7461609fa5e5d45cc)`()` | Request to start streaming notifications for this player.
-`public void `[`StopStreamingNotifications`](#classURH__PlayerInfo_1a17cff21d266da2c72a4f200e316d45b6)`(bool bClearCache)` | Requests to stop streaming notifications.
-`public inline const TMap< FString, `[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` > & `[`GetAllStoredPlayerSettings`](#classURH__PlayerInfo_1a3eb1adffb0e0f4f503241ae5848818ce)`() const` | Gets all the players store settings data.
-`public inline const TMap< FString, `[`FRHAPI_PlayerRankResponseV2`](models/RHAPI_PlayerRankResponseV2.md#structFRHAPI__PlayerRankResponseV2)` > & `[`GetAllStoredPlayerRankings`](#classURH__PlayerInfo_1aa79ba1c1bcb06d02478ec145999b06a3)`() const` | Gets all the players stored ranking data.
-`public `[`URH_PlayerInfoSubsystem`](PlayerInfo.md#classURH__PlayerInfoSubsystem)` * `[`GetPlayerInfoSubsystem`](#classURH__PlayerInfo_1a0f038ae188d71729b19771f401bee34a)`() const` | Gets the players Info Subsystem that the Player Info is on.
-`public void `[`InitializeForPlayer`](#classURH__PlayerInfo_1a38608b8b57751e9db1c1dcfb818d0506)`(const FGuid & PlayerUuid)` | Initialized the player info from a given Player Unique Id.
-`public void `[`GetLastKnownDisplayNameAsync`](#classURH__PlayerInfo_1a748ec2c5cc1c2aa3f3a91d906c8ba04b)`(const FTimespan & StaleThreshold,bool bForceRefresh,ERHAPI_Platform PreferredPlatformType,const FRH_PlayerInfoGetDisplayNameBlock & Delegate,const class `[`URH_LocalPlayerSubsystem`](LocalPlayer.md#classURH__LocalPlayerSubsystem)` * LocalPlayerSubsystem)` | Gets the last known display name for the player, will make required API calls to retrieve the information if needed.
+`public virtual void `[`StartStreamingNotifications`](#classURH__PlayerInfo_1af0c9066d3c0b17440adfaf7e6b9cca9f)`()` | Request to start streaming notifications for this player.
+`public virtual void `[`StopStreamingNotifications`](#classURH__PlayerInfo_1a030ec9d94254cb742700d1c3947412dd)`(bool bClearCache)` | Requests to stop streaming notifications.
+`public inline virtual const TMap< FString, `[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` > & `[`GetAllStoredPlayerSettings`](#classURH__PlayerInfo_1a3eeb21bd2ebc5e074abc0de97d35ce9e)`() const` | Gets all the players store settings data.
+`public inline virtual const TMap< FString, `[`FRHAPI_PlayerRankResponseV2`](models/RHAPI_PlayerRankResponseV2.md#structFRHAPI__PlayerRankResponseV2)` > & `[`GetAllStoredPlayerRankings`](#classURH__PlayerInfo_1a2727915e9be4638dbd49310a6938645c)`() const` | Gets all the players stored ranking data.
+`public virtual `[`URH_PlayerInfoSubsystem`](PlayerInfo.md#classURH__PlayerInfoSubsystem)` * `[`GetPlayerInfoSubsystem`](#classURH__PlayerInfo_1a79f8f54e2bbda560cb138f54efbfd0ac)`() const` | Gets the players Info Subsystem that the Player Info is on.
+`public virtual void `[`InitializeForPlayer`](#classURH__PlayerInfo_1a95e3c7c6762abe6c801e98e708905d39)`(const FGuid & PlayerUuid)` | Initialized the player info from a given Player Unique Id.
+`public virtual void `[`GetLastKnownDisplayNameAsync`](#classURH__PlayerInfo_1a2294e1b29debae35974c1776ef703cfd)`(const FTimespan & StaleThreshold,bool bForceRefresh,ERHAPI_Platform PreferredPlatformType,const FRH_PlayerInfoGetDisplayNameBlock & Delegate,const class `[`URH_LocalPlayerSubsystem`](LocalPlayer.md#classURH__LocalPlayerSubsystem)` * LocalPlayerSubsystem)` | Gets the last known display name for the player, will make required API calls to retrieve the information if needed.
 `public inline void `[`BLUEPRINT_GetLastKnownDisplayNameAsync`](#classURH__PlayerInfo_1a2a5f9d31fb4c1096e06d68569d617257)`(const class `[`URH_LocalPlayerSubsystem`](LocalPlayer.md#classURH__LocalPlayerSubsystem)` * LocalPlayerSubsystem,const FTimespan & StaleThreshold,bool bForceRefresh,ERHAPI_Platform PreferredPlatformType,const FRH_PlayerInfoGetDisplayNameDynamicDelegate & Delegate)` | 
-`public bool `[`GetLastKnownDisplayName`](#classURH__PlayerInfo_1a1013650527f7be680adc07896e49d555)`(FString & OutDisplayName,ERHAPI_Platform PreferredPlatformType) const` | Gets the last known display name for the player.
+`public virtual bool `[`GetLastKnownDisplayName`](#classURH__PlayerInfo_1ac983a0c5b8e6e3df2f216b94b7fd249c)`(FString & OutDisplayName,ERHAPI_Platform PreferredPlatformType) const` | Gets the last known display name for the player.
 `public inline bool `[`BLUEPRINT_GetLastKnownDisplayName`](#classURH__PlayerInfo_1a4b096747849fe22e2c7934fb3212bb85)`(ERHAPI_Platform PreferredPlatformType,FString & OutDisplayName) const` | 
-`public void `[`GetLinkedPlatformInfo`](#classURH__PlayerInfo_1ac5a0056e3adcab2d8a5c65ea7d5e43ca)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlatformsBlock & Delegate)` | Gets the players linked platforms via API call.
+`public virtual void `[`GetLinkedPlatformInfo`](#classURH__PlayerInfo_1a3cdeb290b652d16aa44e5c6e1e4ae44c)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlatformsBlock & Delegate)` | Gets the players linked platforms via API call.
 `public inline void `[`BLUEPRINT_GetLinkedPlatformInfo`](#classURH__PlayerInfo_1a17dd835ef46a8418e6cf760eb076d01d)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlatformsDynamicDelegate & Delegate)` | 
-`public void `[`GetPlayerSettings`](#classURH__PlayerInfo_1aa9d33400032ef41067fbc52f72f092c2)`(const FString & SettingTypeId,const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerSettingsBlock & Delegate)` | Gets the players settings information for a given type.
+`public virtual void `[`GetPlayerSettings`](#classURH__PlayerInfo_1a6f0c823fb1c55bcf4ab2482092cfad2a)`(const FString & SettingTypeId,const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerSettingsBlock & Delegate)` | Gets the players settings information for a given type.
 `public inline void `[`BLUEPRINT_GetPlayerSettings`](#classURH__PlayerInfo_1a76e2f0a5ded932bc524553a9a2d43976)`(const FString & SettingTypeId,const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerSettingsDynamicDelegate & Delegate)` | 
-`public void `[`SetPlayerSettings`](#classURH__PlayerInfo_1a74ee0e82383414759503cc731086ab54)`(const FString & SettingTypeId,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` & SettingsData,const FRH_PlayerInfoSetPlayerSettingsBlock & Delegate)` | Sets the players settings information for a given type.
+`public virtual void `[`SetPlayerSettings`](#classURH__PlayerInfo_1ab8f4ba97458cb8df50445db8547bbc4c)`(const FString & SettingTypeId,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` & SettingsData,const FRH_PlayerInfoSetPlayerSettingsBlock & Delegate)` | Sets the players settings information for a given type.
 `public inline void `[`BLUEPRINT_SetPlayerSettings`](#classURH__PlayerInfo_1aebf4859d56d3fc772711fd1c8714d4f0)`(const FString & SettingTypeId,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` SettingsData,const FRH_PlayerInfoSetPlayerSettingsDynamicDelegate & Delegate)` | 
-`public void `[`GetPlayerRankings`](#classURH__PlayerInfo_1a7ff2423c28633ab7f4f62039aba32c8d)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` | Gets the players ranking information for a given type.
+`public virtual void `[`GetPlayerRankings`](#classURH__PlayerInfo_1a03b9bc9136601f64145bec69a5e9e9e8)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` | Gets the players ranking information for a given type.
 `public inline void `[`BLUEPRINT_GetPlayerRankings`](#classURH__PlayerInfo_1adbfa47a9d0df7dec931ce18fa7b4f8b4)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerRankingsDynamicDelegate & Delegate)` | 
-`public void `[`UpdatePlayerRanking`](#classURH__PlayerInfo_1a504494976ef115b48b620bcbfc914d17)`(const FString & RankId,const `[`FRHAPI_PlayerRankUpdateRequest`](models/RHAPI_PlayerRankUpdateRequest.md#structFRHAPI__PlayerRankUpdateRequest)` & RankData,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` | Sets the players settings information for a given type.
+`public virtual void `[`UpdatePlayerRanking`](#classURH__PlayerInfo_1afd6c1206e990ca64b9fa56a54e085094)`(const FString & RankId,const `[`FRHAPI_PlayerRankUpdateRequest`](models/RHAPI_PlayerRankUpdateRequest.md#structFRHAPI__PlayerRankUpdateRequest)` & RankData,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` | Sets the players settings information for a given type.
 `public inline void `[`BLUEPRINT_UpdatePlayerRanking`](#classURH__PlayerInfo_1a60648275bd880b33cfb78b403e0832ac)`(const FString & RankId,const `[`FRHAPI_PlayerRankUpdateRequest`](models/RHAPI_PlayerRankUpdateRequest.md#structFRHAPI__PlayerRankUpdateRequest)` & RankData,const FRH_PlayerInfoGetPlayerRankingsDynamicDelegate & Delegate)` | 
 `public FAuthContextPtr `[`GetAuthContext`](#classURH__PlayerInfo_1a38aa7a072a97be36bc623a9cda702cdf)`() const` | Gets the local Auth Context for making API calls.
-`public ERHAPI_Platform `[`GetLoggedInPlatform`](#classURH__PlayerInfo_1ad8fc7aea229a59d52a1c9e3491b8d168)`() const` | Gets the local users logged in platform type.
+`public virtual ERHAPI_Platform `[`GetLoggedInPlatform`](#classURH__PlayerInfo_1a12baa089a6981ccb98fba0dab3ea550b)`() const` | Gets the local users logged in platform type.
 `protected FGuid `[`RHPlayerUuid`](#classURH__PlayerInfo_1abd6b1bad2e1044b59af44d04f822cef1) | The Unique Player Id for the player.
 `protected TMap< FString, `[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` > `[`PlayerSettingsByTypeId`](#classURH__PlayerInfo_1a17fa2a55af8c7efa708db4871753ae07) | Cache of Player Settings Data by their settings types.
 `protected TMap< FString, `[`FRH_PlayerSettingKeySetWrapper`](PlayerInfo.md#structFRH__PlayerSettingKeySetWrapper)` > `[`PendingSettingRequestsByTypeId`](#classURH__PlayerInfo_1a65d3de9960e39b3dcacc0d885c14b016) | When requesting multiple Player Settings Updates at once, this keeps track of pending requests so we know when all requests are completed.
@@ -680,7 +680,7 @@ Gets The players reports class.
 The players reports class.
 
 <br>
-#### `public inline FORCEINLINE TArray< `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` > & `[`GetPlayerPlatformIds`](#classURH__PlayerInfo_1a6da64917c1815b0048dbf5b770a43480)`()` <a id="classURH__PlayerInfo_1a6da64917c1815b0048dbf5b770a43480"></a>
+#### `public inline virtual TArray< `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` > & `[`GetPlayerPlatformIds`](#classURH__PlayerInfo_1a07f7aedb216f1536718b152d384d7ba9)`()` <a id="classURH__PlayerInfo_1a07f7aedb216f1536718b152d384d7ba9"></a>
 
 Gets the associated platform ids of the player.
 
@@ -688,7 +688,7 @@ Gets the associated platform ids of the player.
 The players associated platforms ids.
 
 <br>
-#### `public inline FORCEINLINE const TArray< `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` > & `[`GetPlayerPlatformIds`](#classURH__PlayerInfo_1ab0617adb51499a0c8ce36ef60693e6d6)`() const` <a id="classURH__PlayerInfo_1ab0617adb51499a0c8ce36ef60693e6d6"></a>
+#### `public inline virtual const TArray< `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` > & `[`GetPlayerPlatformIds`](#classURH__PlayerInfo_1a28f6726b50d19d49895f5ef07a080625)`() const` <a id="classURH__PlayerInfo_1a28f6726b50d19d49895f5ef07a080625"></a>
 
 Gets the associated platform ids of the player.
 
@@ -696,7 +696,7 @@ Gets the associated platform ids of the player.
 The players associated platforms ids.
 
 <br>
-#### `public TArray< `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * > `[`GetPlayerPlatforms`](#classURH__PlayerInfo_1a3896d84ba5481158ce3cfc62b39e064e)`() const` <a id="classURH__PlayerInfo_1a3896d84ba5481158ce3cfc62b39e064e"></a>
+#### `public virtual TArray< `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * > `[`GetPlayerPlatforms`](#classURH__PlayerInfo_1a809c05d3726b297a8c9c1a5647e1b312)`() const` <a id="classURH__PlayerInfo_1a809c05d3726b297a8c9c1a5647e1b312"></a>
 
 Gets the associated platforms of the player.
 
@@ -704,7 +704,7 @@ Gets the associated platforms of the player.
 The players associated platforms.
 
 <br>
-#### `public `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * `[`GetPlayerPlatformInfo`](#classURH__PlayerInfo_1a0e3a7df23b8a7a183d1b8c94c578e343)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` <a id="classURH__PlayerInfo_1a0e3a7df23b8a7a183d1b8c94c578e343"></a>
+#### `public virtual `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * `[`GetPlayerPlatformInfo`](#classURH__PlayerInfo_1a739b91e94755670e614506e17ee468d8)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` <a id="classURH__PlayerInfo_1a739b91e94755670e614506e17ee468d8"></a>
 
 Gets a specific platform for the player.
 
@@ -731,12 +731,12 @@ Gets the players Notification Subsystem.
 The players Notification Subsystem.
 
 <br>
-#### `public void `[`StartStreamingNotifications`](#classURH__PlayerInfo_1a15c2a3c44c22cfb7461609fa5e5d45cc)`()` <a id="classURH__PlayerInfo_1a15c2a3c44c22cfb7461609fa5e5d45cc"></a>
+#### `public virtual void `[`StartStreamingNotifications`](#classURH__PlayerInfo_1af0c9066d3c0b17440adfaf7e6b9cca9f)`()` <a id="classURH__PlayerInfo_1af0c9066d3c0b17440adfaf7e6b9cca9f"></a>
 
 Request to start streaming notifications for this player.
 
 <br>
-#### `public void `[`StopStreamingNotifications`](#classURH__PlayerInfo_1a17cff21d266da2c72a4f200e316d45b6)`(bool bClearCache)` <a id="classURH__PlayerInfo_1a17cff21d266da2c72a4f200e316d45b6"></a>
+#### `public virtual void `[`StopStreamingNotifications`](#classURH__PlayerInfo_1a030ec9d94254cb742700d1c3947412dd)`(bool bClearCache)` <a id="classURH__PlayerInfo_1a030ec9d94254cb742700d1c3947412dd"></a>
 
 Requests to stop streaming notifications.
 
@@ -744,7 +744,7 @@ Requests to stop streaming notifications.
 * `[in[` bClearCache If true, the cache of notifications will be cleared.
 
 <br>
-#### `public inline const TMap< FString, `[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` > & `[`GetAllStoredPlayerSettings`](#classURH__PlayerInfo_1a3eb1adffb0e0f4f503241ae5848818ce)`() const` <a id="classURH__PlayerInfo_1a3eb1adffb0e0f4f503241ae5848818ce"></a>
+#### `public inline virtual const TMap< FString, `[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` > & `[`GetAllStoredPlayerSettings`](#classURH__PlayerInfo_1a3eeb21bd2ebc5e074abc0de97d35ce9e)`() const` <a id="classURH__PlayerInfo_1a3eeb21bd2ebc5e074abc0de97d35ce9e"></a>
 
 Gets all the players store settings data.
 
@@ -752,7 +752,7 @@ Gets all the players store settings data.
 The players stored settings data.
 
 <br>
-#### `public inline const TMap< FString, `[`FRHAPI_PlayerRankResponseV2`](models/RHAPI_PlayerRankResponseV2.md#structFRHAPI__PlayerRankResponseV2)` > & `[`GetAllStoredPlayerRankings`](#classURH__PlayerInfo_1aa79ba1c1bcb06d02478ec145999b06a3)`() const` <a id="classURH__PlayerInfo_1aa79ba1c1bcb06d02478ec145999b06a3"></a>
+#### `public inline virtual const TMap< FString, `[`FRHAPI_PlayerRankResponseV2`](models/RHAPI_PlayerRankResponseV2.md#structFRHAPI__PlayerRankResponseV2)` > & `[`GetAllStoredPlayerRankings`](#classURH__PlayerInfo_1a2727915e9be4638dbd49310a6938645c)`() const` <a id="classURH__PlayerInfo_1a2727915e9be4638dbd49310a6938645c"></a>
 
 Gets all the players stored ranking data.
 
@@ -760,7 +760,7 @@ Gets all the players stored ranking data.
 The players stored settings data.
 
 <br>
-#### `public `[`URH_PlayerInfoSubsystem`](PlayerInfo.md#classURH__PlayerInfoSubsystem)` * `[`GetPlayerInfoSubsystem`](#classURH__PlayerInfo_1a0f038ae188d71729b19771f401bee34a)`() const` <a id="classURH__PlayerInfo_1a0f038ae188d71729b19771f401bee34a"></a>
+#### `public virtual `[`URH_PlayerInfoSubsystem`](PlayerInfo.md#classURH__PlayerInfoSubsystem)` * `[`GetPlayerInfoSubsystem`](#classURH__PlayerInfo_1a79f8f54e2bbda560cb138f54efbfd0ac)`() const` <a id="classURH__PlayerInfo_1a79f8f54e2bbda560cb138f54efbfd0ac"></a>
 
 Gets the players Info Subsystem that the Player Info is on.
 
@@ -768,7 +768,7 @@ Gets the players Info Subsystem that the Player Info is on.
 The Player Info Subsystem.
 
 <br>
-#### `public void `[`InitializeForPlayer`](#classURH__PlayerInfo_1a38608b8b57751e9db1c1dcfb818d0506)`(const FGuid & PlayerUuid)` <a id="classURH__PlayerInfo_1a38608b8b57751e9db1c1dcfb818d0506"></a>
+#### `public virtual void `[`InitializeForPlayer`](#classURH__PlayerInfo_1a95e3c7c6762abe6c801e98e708905d39)`(const FGuid & PlayerUuid)` <a id="classURH__PlayerInfo_1a95e3c7c6762abe6c801e98e708905d39"></a>
 
 Initialized the player info from a given Player Unique Id.
 
@@ -776,7 +776,7 @@ Initialized the player info from a given Player Unique Id.
 * `PlayerUuid` The Unique Id of the player.
 
 <br>
-#### `public void `[`GetLastKnownDisplayNameAsync`](#classURH__PlayerInfo_1a748ec2c5cc1c2aa3f3a91d906c8ba04b)`(const FTimespan & StaleThreshold,bool bForceRefresh,ERHAPI_Platform PreferredPlatformType,const FRH_PlayerInfoGetDisplayNameBlock & Delegate,const class `[`URH_LocalPlayerSubsystem`](LocalPlayer.md#classURH__LocalPlayerSubsystem)` * LocalPlayerSubsystem)` <a id="classURH__PlayerInfo_1a748ec2c5cc1c2aa3f3a91d906c8ba04b"></a>
+#### `public virtual void `[`GetLastKnownDisplayNameAsync`](#classURH__PlayerInfo_1a2294e1b29debae35974c1776ef703cfd)`(const FTimespan & StaleThreshold,bool bForceRefresh,ERHAPI_Platform PreferredPlatformType,const FRH_PlayerInfoGetDisplayNameBlock & Delegate,const class `[`URH_LocalPlayerSubsystem`](LocalPlayer.md#classURH__LocalPlayerSubsystem)` * LocalPlayerSubsystem)` <a id="classURH__PlayerInfo_1a2294e1b29debae35974c1776ef703cfd"></a>
 
 Gets the last known display name for the player, will make required API calls to retrieve the information if needed.
 
@@ -795,7 +795,7 @@ Gets the last known display name for the player, will make required API calls to
 #### `public inline void `[`BLUEPRINT_GetLastKnownDisplayNameAsync`](#classURH__PlayerInfo_1a2a5f9d31fb4c1096e06d68569d617257)`(const class `[`URH_LocalPlayerSubsystem`](LocalPlayer.md#classURH__LocalPlayerSubsystem)` * LocalPlayerSubsystem,const FTimespan & StaleThreshold,bool bForceRefresh,ERHAPI_Platform PreferredPlatformType,const FRH_PlayerInfoGetDisplayNameDynamicDelegate & Delegate)` <a id="classURH__PlayerInfo_1a2a5f9d31fb4c1096e06d68569d617257"></a>
 
 <br>
-#### `public bool `[`GetLastKnownDisplayName`](#classURH__PlayerInfo_1a1013650527f7be680adc07896e49d555)`(FString & OutDisplayName,ERHAPI_Platform PreferredPlatformType) const` <a id="classURH__PlayerInfo_1a1013650527f7be680adc07896e49d555"></a>
+#### `public virtual bool `[`GetLastKnownDisplayName`](#classURH__PlayerInfo_1ac983a0c5b8e6e3df2f216b94b7fd249c)`(FString & OutDisplayName,ERHAPI_Platform PreferredPlatformType) const` <a id="classURH__PlayerInfo_1ac983a0c5b8e6e3df2f216b94b7fd249c"></a>
 
 Gets the last known display name for the player.
 
@@ -811,7 +811,7 @@ If the call successfully found a display name for the player already stored on t
 #### `public inline bool `[`BLUEPRINT_GetLastKnownDisplayName`](#classURH__PlayerInfo_1a4b096747849fe22e2c7934fb3212bb85)`(ERHAPI_Platform PreferredPlatformType,FString & OutDisplayName) const` <a id="classURH__PlayerInfo_1a4b096747849fe22e2c7934fb3212bb85"></a>
 
 <br>
-#### `public void `[`GetLinkedPlatformInfo`](#classURH__PlayerInfo_1ac5a0056e3adcab2d8a5c65ea7d5e43ca)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlatformsBlock & Delegate)` <a id="classURH__PlayerInfo_1ac5a0056e3adcab2d8a5c65ea7d5e43ca"></a>
+#### `public virtual void `[`GetLinkedPlatformInfo`](#classURH__PlayerInfo_1a3cdeb290b652d16aa44e5c6e1e4ae44c)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlatformsBlock & Delegate)` <a id="classURH__PlayerInfo_1a3cdeb290b652d16aa44e5c6e1e4ae44c"></a>
 
 Gets the players linked platforms via API call.
 
@@ -826,7 +826,7 @@ Gets the players linked platforms via API call.
 #### `public inline void `[`BLUEPRINT_GetLinkedPlatformInfo`](#classURH__PlayerInfo_1a17dd835ef46a8418e6cf760eb076d01d)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlatformsDynamicDelegate & Delegate)` <a id="classURH__PlayerInfo_1a17dd835ef46a8418e6cf760eb076d01d"></a>
 
 <br>
-#### `public void `[`GetPlayerSettings`](#classURH__PlayerInfo_1aa9d33400032ef41067fbc52f72f092c2)`(const FString & SettingTypeId,const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerSettingsBlock & Delegate)` <a id="classURH__PlayerInfo_1aa9d33400032ef41067fbc52f72f092c2"></a>
+#### `public virtual void `[`GetPlayerSettings`](#classURH__PlayerInfo_1a6f0c823fb1c55bcf4ab2482092cfad2a)`(const FString & SettingTypeId,const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerSettingsBlock & Delegate)` <a id="classURH__PlayerInfo_1a6f0c823fb1c55bcf4ab2482092cfad2a"></a>
 
 Gets the players settings information for a given type.
 
@@ -843,7 +843,7 @@ Gets the players settings information for a given type.
 #### `public inline void `[`BLUEPRINT_GetPlayerSettings`](#classURH__PlayerInfo_1a76e2f0a5ded932bc524553a9a2d43976)`(const FString & SettingTypeId,const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerSettingsDynamicDelegate & Delegate)` <a id="classURH__PlayerInfo_1a76e2f0a5ded932bc524553a9a2d43976"></a>
 
 <br>
-#### `public void `[`SetPlayerSettings`](#classURH__PlayerInfo_1a74ee0e82383414759503cc731086ab54)`(const FString & SettingTypeId,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` & SettingsData,const FRH_PlayerInfoSetPlayerSettingsBlock & Delegate)` <a id="classURH__PlayerInfo_1a74ee0e82383414759503cc731086ab54"></a>
+#### `public virtual void `[`SetPlayerSettings`](#classURH__PlayerInfo_1ab8f4ba97458cb8df50445db8547bbc4c)`(const FString & SettingTypeId,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` & SettingsData,const FRH_PlayerInfoSetPlayerSettingsBlock & Delegate)` <a id="classURH__PlayerInfo_1ab8f4ba97458cb8df50445db8547bbc4c"></a>
 
 Sets the players settings information for a given type.
 
@@ -858,7 +858,7 @@ Sets the players settings information for a given type.
 #### `public inline void `[`BLUEPRINT_SetPlayerSettings`](#classURH__PlayerInfo_1aebf4859d56d3fc772711fd1c8714d4f0)`(const FString & SettingTypeId,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` SettingsData,const FRH_PlayerInfoSetPlayerSettingsDynamicDelegate & Delegate)` <a id="classURH__PlayerInfo_1aebf4859d56d3fc772711fd1c8714d4f0"></a>
 
 <br>
-#### `public void `[`GetPlayerRankings`](#classURH__PlayerInfo_1a7ff2423c28633ab7f4f62039aba32c8d)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` <a id="classURH__PlayerInfo_1a7ff2423c28633ab7f4f62039aba32c8d"></a>
+#### `public virtual void `[`GetPlayerRankings`](#classURH__PlayerInfo_1a03b9bc9136601f64145bec69a5e9e9e8)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` <a id="classURH__PlayerInfo_1a03b9bc9136601f64145bec69a5e9e9e8"></a>
 
 Gets the players ranking information for a given type.
 
@@ -873,7 +873,7 @@ Gets the players ranking information for a given type.
 #### `public inline void `[`BLUEPRINT_GetPlayerRankings`](#classURH__PlayerInfo_1adbfa47a9d0df7dec931ce18fa7b4f8b4)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerRankingsDynamicDelegate & Delegate)` <a id="classURH__PlayerInfo_1adbfa47a9d0df7dec931ce18fa7b4f8b4"></a>
 
 <br>
-#### `public void `[`UpdatePlayerRanking`](#classURH__PlayerInfo_1a504494976ef115b48b620bcbfc914d17)`(const FString & RankId,const `[`FRHAPI_PlayerRankUpdateRequest`](models/RHAPI_PlayerRankUpdateRequest.md#structFRHAPI__PlayerRankUpdateRequest)` & RankData,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` <a id="classURH__PlayerInfo_1a504494976ef115b48b620bcbfc914d17"></a>
+#### `public virtual void `[`UpdatePlayerRanking`](#classURH__PlayerInfo_1afd6c1206e990ca64b9fa56a54e085094)`(const FString & RankId,const `[`FRHAPI_PlayerRankUpdateRequest`](models/RHAPI_PlayerRankUpdateRequest.md#structFRHAPI__PlayerRankUpdateRequest)` & RankData,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` <a id="classURH__PlayerInfo_1afd6c1206e990ca64b9fa56a54e085094"></a>
 
 Sets the players settings information for a given type.
 
@@ -896,7 +896,7 @@ Gets the local Auth Context for making API calls.
 Local auth context for the given player or instance
 
 <br>
-#### `public ERHAPI_Platform `[`GetLoggedInPlatform`](#classURH__PlayerInfo_1ad8fc7aea229a59d52a1c9e3491b8d168)`() const` <a id="classURH__PlayerInfo_1ad8fc7aea229a59d52a1c9e3491b8d168"></a>
+#### `public virtual ERHAPI_Platform `[`GetLoggedInPlatform`](#classURH__PlayerInfo_1a12baa089a6981ccb98fba0dab3ea550b)`() const` <a id="classURH__PlayerInfo_1a12baa089a6981ccb98fba0dab3ea550b"></a>
 
 Gets the local users logged in platform type.
 
@@ -1101,15 +1101,15 @@ Subsystem used to track and request information about players.
 `public inline const TMap< FGuid, `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * > & `[`GetPlayerInfos`](#classURH__PlayerInfoSubsystem_1abc456ab4d8ed5e310f4069cd412b7015)`() const` | Gets a map of all the player infos.
 `public virtual `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`GetOrCreatePlayerInfo`](#classURH__PlayerInfoSubsystem_1a86cbf48c7736df66c95719b2aa2e56df)`(const FGuid & PlayerUuid)` | Gets a Player Info object for a given Player Unique Id, creates if needed.
 `public virtual `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * `[`GetOrCreatePlayerPlatformInfo`](#classURH__PlayerInfoSubsystem_1afe3412c3393e536a6bfa3df5c32b1d30)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId)` | Gets a Player Info object for a given Player Platform Id, creates if needed.
-`public `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`FindPlayerInfoByPlatformId`](#classURH__PlayerInfoSubsystem_1accd9b150a34cf217253a503d2ade40f9)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` | Gets a Player Info object for a given Player Platform Id.
-`public inline `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`GetPlayerInfo`](#classURH__PlayerInfoSubsystem_1a7b424cc74c8113e946640262a255be78)`(const FGuid & PlayerUuid) const` | Gets a Player Info object for a given Unique Player Id.
-`public inline `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * `[`GetPlayerPlatformInfo`](#classURH__PlayerInfoSubsystem_1a14b5f2d5b7d3813fb765667f14395681)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` | Gets the platform info object for a player by the Platform Id.
-`public inline void `[`AddPlayerLink`](#classURH__PlayerInfoSubsystem_1a7dff591ef7779e9b7fc24f778c819ad4)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId,const FGuid & PlayerUuid)` | Adds a platform mapping for a given player.
-`public void `[`LookupPlayer`](#classURH__PlayerInfoSubsystem_1a2985421b191b211a64e28bc0a6f60d73)`(FString PlayerName,const FRH_PlayerInfoLookupPlayerBlock & Delegate)` | Searchs for all players who use the given display name via API Call.
+`public virtual `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`FindPlayerInfoByPlatformId`](#classURH__PlayerInfoSubsystem_1a0b93b7052abf97f65ac4e457585dd386)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` | Gets a Player Info object for a given Player Platform Id.
+`public inline virtual `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`GetPlayerInfo`](#classURH__PlayerInfoSubsystem_1a313afdb4e447c17e8bd9f44d789fd4c4)`(const FGuid & PlayerUuid) const` | Gets a Player Info object for a given Unique Player Id.
+`public inline virtual `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * `[`GetPlayerPlatformInfo`](#classURH__PlayerInfoSubsystem_1a078ceecb56513631701ed82bfbfbcbf4)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` | Gets the platform info object for a player by the Platform Id.
+`public inline virtual void `[`AddPlayerLink`](#classURH__PlayerInfoSubsystem_1a4036500640f2d33632faee6aa5c09755)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId,const FGuid & PlayerUuid)` | Adds a platform mapping for a given player.
+`public virtual void `[`LookupPlayer`](#classURH__PlayerInfoSubsystem_1a4440282ee5fee5dfee7e23cb905a87d7)`(FString PlayerName,const FRH_PlayerInfoLookupPlayerBlock & Delegate)` | Searchs for all players who use the given display name via API Call.
 `public inline void `[`BLUEPRINT_LookupPlayer`](#classURH__PlayerInfoSubsystem_1af49782e7e30900e743e026d08a5f991b)`(FString PlayerName,const FRH_PlayerInfoLookupPlayerDynamicDelegate & Delegate)` | 
-`public void `[`LookupPlayerByPlatformUserId`](#classURH__PlayerInfoSubsystem_1a919f9dce2894aa34b79e2a95387adc2e)`(`[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` PlayerPlatformId,const FRH_PlayerInfoLookupPlayerBlock & Delegate)` | Searchs for players associated with the given platform and platform user id via API Call.
+`public virtual void `[`LookupPlayerByPlatformUserId`](#classURH__PlayerInfoSubsystem_1a9f0630cd321711484630ba48a75cdef2)`(`[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` PlayerPlatformId,const FRH_PlayerInfoLookupPlayerBlock & Delegate)` | Searchs for players associated with the given platform and platform user id via API Call.
 `public inline void `[`BLUEPRINT_LookupPlayerByPlatformUserId`](#classURH__PlayerInfoSubsystem_1acf620014114fa3f12ec521960f84d779)`(`[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` PlayerPlatformId,const FRH_PlayerInfoLookupPlayerDynamicDelegate & Delegate)` | 
-`public `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`RemovePlayerInfoFromCache`](#classURH__PlayerInfoSubsystem_1a4ccb69f748014aa9baddae76250b7e31)`(const FGuid & PlayerUuid)` | Remove a specific Player Info from PlayerInfoSubsystem's cache.
+`public virtual `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`RemovePlayerInfoFromCache`](#classURH__PlayerInfoSubsystem_1ac2630ddd5570040bb68a69c94721d3a4)`(const FGuid & PlayerUuid)` | Remove a specific Player Info from PlayerInfoSubsystem's cache.
 `public virtual void `[`Tick`](#classURH__PlayerInfoSubsystem_1abf83de825c346653c1bc3cba1df75815)`(float DeltaTime)` | Unreals basic Tick function.
 `public inline virtual bool `[`IsTickable`](#classURH__PlayerInfoSubsystem_1a49b75fe691775b67c9af6a818d2e4592)`() const` | Gets if currently tickable.
 `public inline virtual TStatId `[`GetStatId`](#classURH__PlayerInfoSubsystem_1a159d3535c053aa721f87274f48742cfa)`() const` | Gets the stat to use for the tick time.
@@ -1165,7 +1165,7 @@ Gets a Player Info object for a given Player Platform Id, creates if needed.
 Player Info for the player
 
 <br>
-#### `public `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`FindPlayerInfoByPlatformId`](#classURH__PlayerInfoSubsystem_1accd9b150a34cf217253a503d2ade40f9)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` <a id="classURH__PlayerInfoSubsystem_1accd9b150a34cf217253a503d2ade40f9"></a>
+#### `public virtual `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`FindPlayerInfoByPlatformId`](#classURH__PlayerInfoSubsystem_1a0b93b7052abf97f65ac4e457585dd386)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` <a id="classURH__PlayerInfoSubsystem_1a0b93b7052abf97f65ac4e457585dd386"></a>
 
 Gets a Player Info object for a given Player Platform Id.
 
@@ -1176,7 +1176,7 @@ Gets a Player Info object for a given Player Platform Id.
 Player Info for the player if found
 
 <br>
-#### `public inline `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`GetPlayerInfo`](#classURH__PlayerInfoSubsystem_1a7b424cc74c8113e946640262a255be78)`(const FGuid & PlayerUuid) const` <a id="classURH__PlayerInfoSubsystem_1a7b424cc74c8113e946640262a255be78"></a>
+#### `public inline virtual `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`GetPlayerInfo`](#classURH__PlayerInfoSubsystem_1a313afdb4e447c17e8bd9f44d789fd4c4)`(const FGuid & PlayerUuid) const` <a id="classURH__PlayerInfoSubsystem_1a313afdb4e447c17e8bd9f44d789fd4c4"></a>
 
 Gets a Player Info object for a given Unique Player Id.
 
@@ -1187,7 +1187,7 @@ Gets a Player Info object for a given Unique Player Id.
 Player Info for the player if found
 
 <br>
-#### `public inline `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * `[`GetPlayerPlatformInfo`](#classURH__PlayerInfoSubsystem_1a14b5f2d5b7d3813fb765667f14395681)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` <a id="classURH__PlayerInfoSubsystem_1a14b5f2d5b7d3813fb765667f14395681"></a>
+#### `public inline virtual `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * `[`GetPlayerPlatformInfo`](#classURH__PlayerInfoSubsystem_1a078ceecb56513631701ed82bfbfbcbf4)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId) const` <a id="classURH__PlayerInfoSubsystem_1a078ceecb56513631701ed82bfbfbcbf4"></a>
 
 Gets the platform info object for a player by the Platform Id.
 
@@ -1198,7 +1198,7 @@ Gets the platform info object for a player by the Platform Id.
 Player Platform Info for the player if found
 
 <br>
-#### `public inline void `[`AddPlayerLink`](#classURH__PlayerInfoSubsystem_1a7dff591ef7779e9b7fc24f778c819ad4)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId,const FGuid & PlayerUuid)` <a id="classURH__PlayerInfoSubsystem_1a7dff591ef7779e9b7fc24f778c819ad4"></a>
+#### `public inline virtual void `[`AddPlayerLink`](#classURH__PlayerInfoSubsystem_1a4036500640f2d33632faee6aa5c09755)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlayerPlatformId,const FGuid & PlayerUuid)` <a id="classURH__PlayerInfoSubsystem_1a4036500640f2d33632faee6aa5c09755"></a>
 
 Adds a platform mapping for a given player.
 
@@ -1208,7 +1208,7 @@ Adds a platform mapping for a given player.
 * `PlayerPlatformId` Player Platform Id for the given player
 
 <br>
-#### `public void `[`LookupPlayer`](#classURH__PlayerInfoSubsystem_1a2985421b191b211a64e28bc0a6f60d73)`(FString PlayerName,const FRH_PlayerInfoLookupPlayerBlock & Delegate)` <a id="classURH__PlayerInfoSubsystem_1a2985421b191b211a64e28bc0a6f60d73"></a>
+#### `public virtual void `[`LookupPlayer`](#classURH__PlayerInfoSubsystem_1a4440282ee5fee5dfee7e23cb905a87d7)`(FString PlayerName,const FRH_PlayerInfoLookupPlayerBlock & Delegate)` <a id="classURH__PlayerInfoSubsystem_1a4440282ee5fee5dfee7e23cb905a87d7"></a>
 
 Searchs for all players who use the given display name via API Call.
 
@@ -1221,7 +1221,7 @@ Searchs for all players who use the given display name via API Call.
 #### `public inline void `[`BLUEPRINT_LookupPlayer`](#classURH__PlayerInfoSubsystem_1af49782e7e30900e743e026d08a5f991b)`(FString PlayerName,const FRH_PlayerInfoLookupPlayerDynamicDelegate & Delegate)` <a id="classURH__PlayerInfoSubsystem_1af49782e7e30900e743e026d08a5f991b"></a>
 
 <br>
-#### `public void `[`LookupPlayerByPlatformUserId`](#classURH__PlayerInfoSubsystem_1a919f9dce2894aa34b79e2a95387adc2e)`(`[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` PlayerPlatformId,const FRH_PlayerInfoLookupPlayerBlock & Delegate)` <a id="classURH__PlayerInfoSubsystem_1a919f9dce2894aa34b79e2a95387adc2e"></a>
+#### `public virtual void `[`LookupPlayerByPlatformUserId`](#classURH__PlayerInfoSubsystem_1a9f0630cd321711484630ba48a75cdef2)`(`[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` PlayerPlatformId,const FRH_PlayerInfoLookupPlayerBlock & Delegate)` <a id="classURH__PlayerInfoSubsystem_1a9f0630cd321711484630ba48a75cdef2"></a>
 
 Searchs for players associated with the given platform and platform user id via API Call.
 
@@ -1236,7 +1236,7 @@ Searchs for players associated with the given platform and platform user id via 
 #### `public inline void `[`BLUEPRINT_LookupPlayerByPlatformUserId`](#classURH__PlayerInfoSubsystem_1acf620014114fa3f12ec521960f84d779)`(`[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` PlayerPlatformId,const FRH_PlayerInfoLookupPlayerDynamicDelegate & Delegate)` <a id="classURH__PlayerInfoSubsystem_1acf620014114fa3f12ec521960f84d779"></a>
 
 <br>
-#### `public `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`RemovePlayerInfoFromCache`](#classURH__PlayerInfoSubsystem_1a4ccb69f748014aa9baddae76250b7e31)`(const FGuid & PlayerUuid)` <a id="classURH__PlayerInfoSubsystem_1a4ccb69f748014aa9baddae76250b7e31"></a>
+#### `public virtual `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` * `[`RemovePlayerInfoFromCache`](#classURH__PlayerInfoSubsystem_1ac2630ddd5570040bb68a69c94721d3a4)`(const FGuid & PlayerUuid)` <a id="classURH__PlayerInfoSubsystem_1ac2630ddd5570040bb68a69c94721d3a4"></a>
 
 Remove a specific Player Info from PlayerInfoSubsystem's cache.
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInfoSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInfoSubsystem.h
@@ -150,7 +150,7 @@ public:
 	/**
 	 * @brief Sets the last updated time to now.
 	 */
-	void MarkUpdated()
+	virtual void MarkUpdated()
 	{
 		LastUpdated = FDateTime::UtcNow();
 	}
@@ -158,7 +158,7 @@ public:
 	/**
 	 * @brief Clears the last updated time to force an update.
 	 */
-	void MarkDirty()
+	virtual void MarkDirty()
 	{
 		LastUpdated = FDateTime();
 	}
@@ -168,7 +168,7 @@ public:
 	* @param [in] bForceUpdate If true, immediately requests an update rather than waiting for the next poll time. WARNING: Use this sparingly
 	* @param [in] Delegate Callback delegate for the request.
 	*/
-	void RequestUpdate(bool bForceUpdate = false, const FRH_OnRequestPlayerInfoSubobjectDelegateBlock& Delegate = FRH_OnRequestPlayerInfoSubobjectDelegateBlock())
+	virtual void RequestUpdate(bool bForceUpdate = false, const FRH_OnRequestPlayerInfoSubobjectDelegateBlock& Delegate = FRH_OnRequestPlayerInfoSubobjectDelegateBlock())
 	{
 		TemporaryRequestDelegates.Add(Delegate);
 		CheckPollStatus(bForceUpdate);
@@ -180,7 +180,7 @@ public:
 	* @brief Updates the poll status to be active or inactive based on if it should currently be polling.
 	* @param [in] bForceUpdate If true, immediately requests an update rather than waiting for the next poll time. WARNING: Use this sparingly
 	*/
-	void CheckPollStatus(const bool bForceUpdate = false);
+	virtual void CheckPollStatus(const bool bForceUpdate = false);
 protected:
 	/**
 	 * @brief Poller for the players matches.
@@ -409,7 +409,7 @@ protected:
 	 * @brief Starts a poll of the object data
 	 * @param Delegate Callback delegate for the poll.
 	 */
-	void Poll(const FRH_PollCompleteFunc& Delegate);
+	virtual void Poll(const FRH_PollCompleteFunc& Delegate);
 
 	/**
 	 * @brief Starts a poll of the object data
@@ -491,7 +491,7 @@ public:
 	 * @param PageSize The size of the pages to poll, if 0, uses default
 	 * @param Delegate Callback delegate for the request.
 	 */
-	void GetReportsSentAsync(const FString& Cursor, const int32 PageSize = 0, const FRH_PlayerInfoGetPlayerReportsBlock& Delegate = FRH_PlayerInfoGetPlayerReportsBlock());
+	virtual void GetReportsSentAsync(const FString& Cursor, const int32 PageSize = 0, const FRH_PlayerInfoGetPlayerReportsBlock& Delegate = FRH_PlayerInfoGetPlayerReportsBlock());
 
 	/**
 	 * @brief Request a list of player reports send by this player
@@ -514,7 +514,7 @@ public:
 	 * @param PageSize The size of the pages to poll, if 0, uses default
 	 * @param Delegate Callback delegate for the request.
 	 */
-	void GetReportsReceivedAsync(const FString& Cursor, const int32 PageSize = 0, const FRH_PlayerInfoGetPlayerReportsBlock& Delegate = FRH_PlayerInfoGetPlayerReportsBlock());
+	virtual void GetReportsReceivedAsync(const FString& Cursor, const int32 PageSize = 0, const FRH_PlayerInfoGetPlayerReportsBlock& Delegate = FRH_PlayerInfoGetPlayerReportsBlock());
 
 	/**
 	 * @brief Request a list of player reports received by this player
@@ -529,14 +529,14 @@ public:
 	 * @brief Get the current cached list of player reports received by this player
 	 */
 	UFUNCTION(BlueprintGetter, Category = "Player Info Subsystem | Player Reports")
-	TArray<FRHAPI_PlayerReport> GetReportsReceived() const { return ReportsReceived; }
+	virtual TArray<FRHAPI_PlayerReport> GetReportsReceived() const { return ReportsReceived; }
 
 	/**
 	 * @brief Create a new report for the target player
 	 * @param Report The report to create.
 	 * @param Delegate Callback delegate for the request.
 	 */
-	void CreateReport(const FRHAPI_PlayerReportCreate& Report, const FRH_PlayerInfoCreatePlayerReportBlock& Delegate = FRH_PlayerInfoCreatePlayerReportBlock());
+	virtual void CreateReport(const FRHAPI_PlayerReportCreate& Report, const FRH_PlayerInfoCreatePlayerReportBlock& Delegate = FRH_PlayerInfoCreatePlayerReportBlock());
 
 	/**
 	 * @brief Create a new report for the target player
@@ -552,7 +552,7 @@ public:
 	 * @param AuthContext The auth context to use for the request.
 	 * @param Delegate Callback delegate for the request.
 	 */
-	void CreateReport(const FRHAPI_PlayerReportCreate& Report, FAuthContextPtr AuthContext, const FRH_PlayerInfoCreatePlayerReportBlock& Delegate = FRH_PlayerInfoCreatePlayerReportBlock());
+	virtual void CreateReport(const FRHAPI_PlayerReportCreate& Report, FAuthContextPtr AuthContext, const FRH_PlayerInfoCreatePlayerReportBlock& Delegate = FRH_PlayerInfoCreatePlayerReportBlock());
 
 protected:
 	UPROPERTY(BlueprintReadOnly, BlueprintGetter = GetReportsSent, Category = "Player Info Subsystem | Player Reports")
@@ -594,25 +594,25 @@ public:
 	* @return The players Platform Id struct.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Platform Info")
-	FORCEINLINE FRH_PlayerPlatformId GetPlayerPlatformId() const { return PlayerPlatformId; }
+	virtual FRH_PlayerPlatformId GetPlayerPlatformId() const { return PlayerPlatformId; }
 	/**
 	* @brief Gets the Platform Id for the player.
 	* @return The players Platform Unique Id.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Platform Info")
-	FORCEINLINE FString GetPlatformUserId() const { return PlayerPlatformId.UserId; }
+	virtual FString GetPlatformUserId() const { return PlayerPlatformId.UserId; }
 	/**
 	* @brief Gets the Platform Type for the player.
 	* @return The players Platform Type.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Platform Info")
-	FORCEINLINE ERHAPI_Platform GetPlatform() const { return PlayerPlatformId.PlatformType; }
+	virtual ERHAPI_Platform GetPlatform() const { return PlayerPlatformId.PlatformType; }
 	/**
 	* @brief Gets the display name stored the last time this player logged in to the Rally Here server.
 	* @return The players display name for the platform.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Platform Info")
-	FORCEINLINE FString GetLastKnownDisplayName() const { return DisplayName; }
+	virtual FString GetLastKnownDisplayName() const { return DisplayName; }
 
 	/**
 	 * @brief Players Platform ID struct.
@@ -681,19 +681,19 @@ public:
 	* @return The players associated platforms ids.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Info")
-	FORCEINLINE TArray<FRH_PlayerPlatformId>& GetPlayerPlatformIds() { return LinkedPlayerPlatforms; }
+	virtual TArray<FRH_PlayerPlatformId>& GetPlayerPlatformIds() { return LinkedPlayerPlatforms; }
 	/**
 	* @brief Gets the associated platform ids of the player.
 	* @return The players associated platforms ids.
 	*/
-	FORCEINLINE const TArray<FRH_PlayerPlatformId>& GetPlayerPlatformIds() const { return LinkedPlayerPlatforms; }
+	virtual const TArray<FRH_PlayerPlatformId>& GetPlayerPlatformIds() const { return LinkedPlayerPlatforms; }
 
 	/**
 	* @brief Gets the associated platforms of the player.
 	* @return The players associated platforms.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Info")
-	TArray<URH_PlayerPlatformInfo*> GetPlayerPlatforms() const;
+	virtual TArray<URH_PlayerPlatformInfo*> GetPlayerPlatforms() const;
 
 	/**
 	* @brief Gets a specific platform for the player.
@@ -701,7 +701,7 @@ public:
 	* @return The platform requested for the player if it exists.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Info")
-	URH_PlayerPlatformInfo* GetPlayerPlatformInfo(const FRH_PlayerPlatformId& PlayerPlatformId) const;
+	virtual URH_PlayerPlatformInfo* GetPlayerPlatformInfo(const FRH_PlayerPlatformId& PlayerPlatformId) const;
 
 	/**
 	* @brief Gets the players Inventory Subsystem.
@@ -720,40 +720,40 @@ public:
 	* @brief Request to start streaming notifications for this player
 	*/
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info")
-	void StartStreamingNotifications();
+	virtual void StartStreamingNotifications();
 	/**
 	* @brief Requests to stop streaming notifications
 	* @param [in[ bClearCache If true, the cache of notifications will be cleared.
 	*/
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info")
-	void StopStreamingNotifications(bool bClearCache = true);
+	virtual void StopStreamingNotifications(bool bClearCache = true);
 
 	/**
 	* @brief Gets all the players store settings data.
 	* @return The players stored settings data.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Info")
-	const TMap<FString, FRH_PlayerSettingsDataWrapper>& GetAllStoredPlayerSettings() const { return PlayerSettingsByTypeId; }
+	virtual const TMap<FString, FRH_PlayerSettingsDataWrapper>& GetAllStoredPlayerSettings() const { return PlayerSettingsByTypeId; }
 
 	/**
 	* @brief Gets all the players stored ranking data.
 	* @return The players stored settings data.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Info")
-	const TMap<FString, FRHAPI_PlayerRankResponseV2>& GetAllStoredPlayerRankings() const { return PlayerRankingsByRankingId; }
+	virtual const TMap<FString, FRHAPI_PlayerRankResponseV2>& GetAllStoredPlayerRankings() const { return PlayerRankingsByRankingId; }
 
 	/**
 	* @brief Gets the players Info Subsystem that the Player Info is on.
 	* @return The Player Info Subsystem.
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem")
-	URH_PlayerInfoSubsystem* GetPlayerInfoSubsystem() const;
+	virtual URH_PlayerInfoSubsystem* GetPlayerInfoSubsystem() const;
 
 	/**
 	* @brief Initialized the player info from a given Player Unique Id.
 	* @param PlayerUuid The Unique Id of the player.
 	*/
-	void InitializeForPlayer(const FGuid& PlayerUuid);
+	virtual void InitializeForPlayer(const FGuid& PlayerUuid);
 
 	/**
 	* @brief Gets the last known display name for the player, will make required API calls to retrieve the information if needed.
@@ -763,7 +763,7 @@ public:
 	* @param [in] PreferredPlatformType If set, then that specific platforms display name will be returned if possible, otherwise will use your local platforms, otherwise the first platform found for the player.
 	* @param [in] Delegate Callback with the players display name.
 	*/
-	void GetLastKnownDisplayNameAsync(const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, ERHAPI_Platform PreferredPlatformType = ERHAPI_Platform::Anon, const FRH_PlayerInfoGetDisplayNameBlock& Delegate = FRH_PlayerInfoGetDisplayNameBlock(), const class URH_LocalPlayerSubsystem* LocalPlayerSubsystem = nullptr);
+	virtual void GetLastKnownDisplayNameAsync(const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, ERHAPI_Platform PreferredPlatformType = ERHAPI_Platform::Anon, const FRH_PlayerInfoGetDisplayNameBlock& Delegate = FRH_PlayerInfoGetDisplayNameBlock(), const class URH_LocalPlayerSubsystem* LocalPlayerSubsystem = nullptr);
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Get Display Name Async", AutoCreateRefTerm = "Delegate"))
 	void BLUEPRINT_GetLastKnownDisplayNameAsync(const class URH_LocalPlayerSubsystem* LocalPlayerSubsystem, const FTimespan& StaleThreshold, bool bForceRefresh, ERHAPI_Platform PreferredPlatformType, const FRH_PlayerInfoGetDisplayNameDynamicDelegate& Delegate) { GetLastKnownDisplayNameAsync(StaleThreshold, bForceRefresh, PreferredPlatformType, Delegate, LocalPlayerSubsystem); }
 
@@ -773,7 +773,7 @@ public:
 	* @param [out] OutDisplayName The player's display name.
 	* @return If the call successfully found a display name for the player already stored on the client.
 	*/
-	bool GetLastKnownDisplayName(FString& OutDisplayName, ERHAPI_Platform PreferredPlatformType = ERHAPI_Platform::Anon) const;
+	virtual bool GetLastKnownDisplayName(FString& OutDisplayName, ERHAPI_Platform PreferredPlatformType = ERHAPI_Platform::Anon) const;
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Get Display Name"))
 	bool BLUEPRINT_GetLastKnownDisplayName(ERHAPI_Platform PreferredPlatformType, FString& OutDisplayName) const { return GetLastKnownDisplayName(OutDisplayName, PreferredPlatformType); }
 
@@ -783,7 +783,7 @@ public:
 	* @param [in] bForceRefresh If true, will force a re-request of the players information.
 	* @param [in] Delegate Callback with the players linked platforms.
 	*/
-	void GetLinkedPlatformInfo(const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, const FRH_PlayerInfoGetPlatformsBlock& Delegate = FRH_PlayerInfoGetPlatformsBlock());
+	virtual void GetLinkedPlatformInfo(const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, const FRH_PlayerInfoGetPlatformsBlock& Delegate = FRH_PlayerInfoGetPlatformsBlock());
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Get Linked Platform Info", AutoCreateRefTerm = "Delegate"))
 	void BLUEPRINT_GetLinkedPlatformInfo(const FTimespan& StaleThreshold, bool bForceRefresh, const FRH_PlayerInfoGetPlatformsDynamicDelegate& Delegate) { GetLinkedPlatformInfo(StaleThreshold, bForceRefresh, Delegate); }
 
@@ -794,7 +794,7 @@ public:
 	* @param [in] bForceRefresh If true, will force a re-request of the players information.
 	* @param [in] Delegate Callback with the players settings for the given type.
 	*/
-	void GetPlayerSettings(const FString& SettingTypeId, const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, const FRH_PlayerInfoGetPlayerSettingsBlock& Delegate = FRH_PlayerInfoGetPlayerSettingsBlock());
+	virtual void GetPlayerSettings(const FString& SettingTypeId, const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, const FRH_PlayerInfoGetPlayerSettingsBlock& Delegate = FRH_PlayerInfoGetPlayerSettingsBlock());
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Get Player Settings", AutoCreateRefTerm = "Delegate"))
 	void BLUEPRINT_GetPlayerSettings(const FString& SettingTypeId, const FTimespan& StaleThreshold, bool bForceRefresh, const FRH_PlayerInfoGetPlayerSettingsDynamicDelegate& Delegate) { GetPlayerSettings(SettingTypeId, StaleThreshold, bForceRefresh, Delegate); }
 
@@ -804,7 +804,7 @@ public:
 	* @param [in] SettingsData Data to be stored into the players settings.
 	* @param [in] Delegate Callback when the operation is complete with success information.
 	*/
-	void SetPlayerSettings(const FString& SettingTypeId, FRH_PlayerSettingsDataWrapper& SettingsData, const FRH_PlayerInfoSetPlayerSettingsBlock& Delegate = FRH_PlayerInfoSetPlayerSettingsBlock());
+	virtual void SetPlayerSettings(const FString& SettingTypeId, FRH_PlayerSettingsDataWrapper& SettingsData, const FRH_PlayerInfoSetPlayerSettingsBlock& Delegate = FRH_PlayerInfoSetPlayerSettingsBlock());
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Set Player Settings", AutoCreateRefTerm = "Delegate"))
 	void BLUEPRINT_SetPlayerSettings(const FString& SettingTypeId, FRH_PlayerSettingsDataWrapper SettingsData, const FRH_PlayerInfoSetPlayerSettingsDynamicDelegate& Delegate) { SetPlayerSettings(SettingTypeId, SettingsData, Delegate); }
 
@@ -814,7 +814,7 @@ public:
 	* @param [in] bForceRefresh If true, will force a re-request of the players information.
 	* @param [in] Delegate Callback with the players ranking for the given type.
 	*/
-	void GetPlayerRankings(const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, const FRH_PlayerInfoGetPlayerRankingsBlock& Delegate = FRH_PlayerInfoGetPlayerRankingsBlock());
+	virtual void GetPlayerRankings(const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, const FRH_PlayerInfoGetPlayerRankingsBlock& Delegate = FRH_PlayerInfoGetPlayerRankingsBlock());
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Get Player Rankings", AutoCreateRefTerm = "Delegate"))
 	void BLUEPRINT_GetPlayerRankings(const FTimespan& StaleThreshold, bool bForceRefresh, const FRH_PlayerInfoGetPlayerRankingsDynamicDelegate& Delegate) { GetPlayerRankings(StaleThreshold, bForceRefresh, Delegate); }
 
@@ -824,7 +824,7 @@ public:
 	* @param [in] SettingsData Data to be stored into the players settings.
 	* @param [in] Delegate Callback when the operation is complete with success information.
 	*/
-	void UpdatePlayerRanking(const FString& RankId, const FRHAPI_PlayerRankUpdateRequest& RankData, const FRH_PlayerInfoGetPlayerRankingsBlock& Delegate = FRH_PlayerInfoGetPlayerRankingsBlock());
+	virtual void UpdatePlayerRanking(const FString& RankId, const FRHAPI_PlayerRankUpdateRequest& RankData, const FRH_PlayerInfoGetPlayerRankingsBlock& Delegate = FRH_PlayerInfoGetPlayerRankingsBlock());
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Update Player Ranking", AutoCreateRefTerm = "RankData,Delegate"))
 	void BLUEPRINT_UpdatePlayerRanking(const FString& RankId, const FRHAPI_PlayerRankUpdateRequest& RankData, const FRH_PlayerInfoGetPlayerRankingsDynamicDelegate& Delegate) { UpdatePlayerRanking(RankId, RankData, Delegate); }
 	/**
@@ -836,7 +836,7 @@ public:
 	 * @brief Gets the local users logged in platform type.
 	 * @return The Platform type of the local user
 	 */
-	ERHAPI_Platform GetLoggedInPlatform() const;
+	virtual ERHAPI_Platform GetLoggedInPlatform() const;
 
 protected:
 	/**
@@ -1038,7 +1038,7 @@ public:
 	* @return Player Info for the player if found
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem")
-	URH_PlayerInfo* FindPlayerInfoByPlatformId(const FRH_PlayerPlatformId& PlayerPlatformId) const;
+	virtual URH_PlayerInfo* FindPlayerInfoByPlatformId(const FRH_PlayerPlatformId& PlayerPlatformId) const;
 
 	/**
 	* @brief Gets a Player Info object for a given Unique Player Id
@@ -1046,7 +1046,7 @@ public:
 	* @return Player Info for the player if found
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem")
-	URH_PlayerInfo* GetPlayerInfo(const FGuid& PlayerUuid) const { auto* Info = PlayerInfos.Find(PlayerUuid); return Info != nullptr ? *Info : nullptr; }
+	virtual URH_PlayerInfo* GetPlayerInfo(const FGuid& PlayerUuid) const { auto* Info = PlayerInfos.Find(PlayerUuid); return Info != nullptr ? *Info : nullptr; }
 
 	/**
 	* @brief Gets the platform info object for a player by the Platform Id
@@ -1054,21 +1054,21 @@ public:
 	* @return Player Platform Info for the player if found
 	*/
 	UFUNCTION(BlueprintPure, Category = "Player Info Subsystem")
-	URH_PlayerPlatformInfo* GetPlayerPlatformInfo(const FRH_PlayerPlatformId& PlayerPlatformId) const { auto* Info = PlayerPlatformInfos.Find(PlayerPlatformId); return Info != nullptr ? *Info : nullptr; }
+	virtual URH_PlayerPlatformInfo* GetPlayerPlatformInfo(const FRH_PlayerPlatformId& PlayerPlatformId) const { auto* Info = PlayerPlatformInfos.Find(PlayerPlatformId); return Info != nullptr ? *Info : nullptr; }
 
 	/**
 	* @brief Adds a platform mapping for a given player
 	* @param [in] PlayerUuid Unique Player Id for the given player
 	* @param [in] PlayerPlatformId Player Platform Id for the given player
 	*/
-	void AddPlayerLink(const FRH_PlayerPlatformId& PlayerPlatformId, const FGuid& PlayerUuid) { PlayerPlatformIdToUuidMap.Add(PlayerPlatformId, PlayerUuid); }
+	virtual void AddPlayerLink(const FRH_PlayerPlatformId& PlayerPlatformId, const FGuid& PlayerUuid) { PlayerPlatformIdToUuidMap.Add(PlayerPlatformId, PlayerUuid); }
 
 	/**
 	* @brief Searchs for all players who use the given display name via API Call
 	* @param [in] PlayerName The display name we want to search for
 	* @param [in] Delegate Callback with the all PlayerInfos that are found with that display name
 	*/
-	void LookupPlayer(FString PlayerName, const FRH_PlayerInfoLookupPlayerBlock& Delegate = FRH_PlayerInfoLookupPlayerBlock());
+	virtual void LookupPlayer(FString PlayerName, const FRH_PlayerInfoLookupPlayerBlock& Delegate = FRH_PlayerInfoLookupPlayerBlock());
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem", meta = (DisplayName = "Lookup Player", AutoCreateRefTerm = "Delegate"))
 	void BLUEPRINT_LookupPlayer(FString PlayerName, const FRH_PlayerInfoLookupPlayerDynamicDelegate& Delegate) { LookupPlayer(PlayerName, Delegate); }
 
@@ -1078,7 +1078,7 @@ public:
 	* @param [in] PlatformUserId The platform user id used for the lookup
 	* @param [in] Delegate Callback with the all PlayerInfos that are found with that display name
 	*/
-	void LookupPlayerByPlatformUserId(FRH_PlayerPlatformId PlayerPlatformId, const FRH_PlayerInfoLookupPlayerBlock& Delegate = FRH_PlayerInfoLookupPlayerBlock());
+	virtual void LookupPlayerByPlatformUserId(FRH_PlayerPlatformId PlayerPlatformId, const FRH_PlayerInfoLookupPlayerBlock& Delegate = FRH_PlayerInfoLookupPlayerBlock());
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem", meta = (DisplayName = "Lookup Player By Platform Id", AutoCreateRefTerm = "Delegate"))
 	void BLUEPRINT_LookupPlayerByPlatformUserId(FRH_PlayerPlatformId PlayerPlatformId, const FRH_PlayerInfoLookupPlayerDynamicDelegate& Delegate) { LookupPlayerByPlatformUserId(PlayerPlatformId, Delegate); }
 
@@ -1088,7 +1088,7 @@ public:
 	 * @return The Player Info that got removed
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem")
-	URH_PlayerInfo* RemovePlayerInfoFromCache(const FGuid& PlayerUuid);
+	virtual URH_PlayerInfo* RemovePlayerInfoFromCache(const FGuid& PlayerUuid);
 
 	// FTickableGameObject interface
 	/** @brief Unreals basic Tick function. */


### PR DESCRIPTION
Note: a few direct lookups for the player id and subobjects are non virtual for now