### PR TITLE
BREAKING CHANGE - Make active session no longer default to auto watching player presence (with option to restore old behavior)

### DIFF
--- a/Documentation/md/IntegrationSettings.md
+++ b/Documentation/md/IntegrationSettings.md
@@ -42,6 +42,7 @@ Main settings for the Integration.
 `public bool `[`bUseSecurityTokenForJoining`](#classURH__IntegrationSettings_1a782c0fd4f8a350128f7f686fad7e1af2) | If set, the connection attempt must have a valid security token to be allowed to connect.
 `public bool `[`bRequireImportedPlayerIdsForJoining`](#classURH__IntegrationSettings_1aa8eb456e2ac57561cf12b7c3c306327f) | If set, the Player Id must have been imported to the instance before being allowed to connect.
 `public bool `[`bRequireValidPlayerIdsForJoining`](#classURH__IntegrationSettings_1a6fad3a9359d98b325990c8723a48a4c9) | If set, the Player Id must be valid before being allowed to connect.
+`public bool `[`bAutoWatchPlayersOnSessionActive`](#classURH__IntegrationSettings_1aa4d71629822debb045583c01bbf2430a) | If set, automatically call SetWatchingPlayers() on the session when it is set as the active gameplay session, to enable presence polling for the session.
 `public int32 `[`PlayerMatchesPageSize`](#classURH__IntegrationSettings_1a5971d2f902ad05b49be9d9c21e20e6b1) | Sets the default page size when requesting a player's match history.
 `public int32 `[`PlayerMatchesMaxPageCount`](#classURH__IntegrationSettings_1a4a31dbbe3c82b41e88dcd3dfc9ff5ff4) | Sets the default page size when requesting a player's match history.
 `public FTimespan `[`PlayerMatchesMaxAge`](#classURH__IntegrationSettings_1a095b6baec0e5e9fb0be991db00ff975d) | Sets the default page size when requesting a player's match history.
@@ -277,6 +278,11 @@ If set, the Player Id must have been imported to the instance before being allow
 #### `public bool `[`bRequireValidPlayerIdsForJoining`](#classURH__IntegrationSettings_1a6fad3a9359d98b325990c8723a48a4c9) <a id="classURH__IntegrationSettings_1a6fad3a9359d98b325990c8723a48a4c9"></a>
 
 If set, the Player Id must be valid before being allowed to connect.
+
+<br>
+#### `public bool `[`bAutoWatchPlayersOnSessionActive`](#classURH__IntegrationSettings_1aa4d71629822debb045583c01bbf2430a) <a id="classURH__IntegrationSettings_1aa4d71629822debb045583c01bbf2430a"></a>
+
+If set, automatically call SetWatchingPlayers() on the session when it is set as the active gameplay session, to enable presence polling for the session.
 
 <br>
 #### `public int32 `[`PlayerMatchesPageSize`](#classURH__IntegrationSettings_1a5971d2f902ad05b49be9d9c21e20e6b1) <a id="classURH__IntegrationSettings_1a5971d2f902ad05b49be9d9c21e20e6b1"></a>

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
@@ -261,7 +261,10 @@ void URH_GameInstanceSessionSubsystem::SetActiveSession(URH_JoinedSession* Joine
 	{
 		check(OldSession->IsActive());
 		OldSession->SetActive(false);
-		OldSession->SetWatchingPlayers(false); // TODO - maybe should be incrementing/decrementing watch counter?
+		if (Settings->bAutoWatchPlayersOnSessionActive)
+		{
+			OldSession->SetWatchingPlayers(false); // TODO - maybe should be incrementing/decrementing watch counter?
+		}
 		OldSession = nullptr;
 
 		if (InstanceHealthPoller.IsValid())
@@ -322,7 +325,10 @@ void URH_GameInstanceSessionSubsystem::SetActiveSession(URH_JoinedSession* Joine
 		auto*& ActiveSession = ActiveSessionState.Session;
 
 		JoinedSession->SetActive(true);
-		JoinedSession->SetWatchingPlayers(true);
+		if (Settings->bAutoWatchPlayersOnSessionActive)
+		{
+			JoinedSession->SetWatchingPlayers(true);
+		}
 
 		// if this instance is locally hosted, set up host specific logic
 		if (ActiveSession->GetInstanceData() != nullptr && IsLocallyHostedInstance(*ActiveSession->GetInstanceData()))

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
@@ -32,6 +32,7 @@ URH_IntegrationSettings::URH_IntegrationSettings(const FObjectInitializer& Objec
 
 	bAutoStartSessionsAfterJoin = true;
 	bAutoJoinPlatformSessionsAfterUserChange = true;
+	bAutoWatchPlayersOnSessionActive = false;
 
 	bLocalPlayerSubsystemSandboxing = false;
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
@@ -143,6 +143,10 @@ public:
 	/** @brief If set, the Player Id must be valid before being allowed to connect. */
 	bool bRequireValidPlayerIdsForJoining;
 
+	UPROPERTY(EditAnywhere, Config, Category = "Sessions|Joining")
+	/** @brief If set, automatically call SetWatchingPlayers() on the session when it is set as the active gameplay session, to enable presence polling for the session. */
+	bool bAutoWatchPlayersOnSessionActive;
+
 	/** @brief Sets the default page size when requesting a player's match history */
 	UPROPERTY(EditAnywhere, Config, Category = "Matches|Player History")
 	int32 PlayerMatchesPageSize;


### PR DESCRIPTION
Add bAutoWatchPlayersOnSessionActive option that controls whether active gameplay sessions should automatically set a player watch.  Default to FALSE (previous behavior defaulted to equivalent of TRUE)