### PR TITLE
Override API generator to generate FileAPI as RemoteFileAPI to avoid naming conflicts

### DIFF
--- a/Documentation/md/Common.md
+++ b/Documentation/md/Common.md
@@ -15,7 +15,7 @@
 `public  `[`DECLARE_DELEGATE_OneParam`](#group__Common_1ga5bba8beab7e3653c4bfa887eaec48a87)`(FRH_CustomEndpointDelegate,const `[`FRH_CustomEndpointResponseWrapper`](Common.md#structFRH__CustomEndpointResponseWrapper)` &)`            | Native delegate used for custom endpoint calls.
 `public FORCEINLINE uint32 `[`GetTypeHash`](#group__Common_1ga51b3d76527de2fccacb53501f14c7991)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlatformId)`            | Helper function to convert an [FRH_PlayerPlatformId](Common.md#structFRH__PlayerPlatformId) into a hash value.
 `public static bool `[`RH_BreakApartURL`](#group__Common_1ga98aea8d69558cf3580e89e65d73256dd)`(const FString & URL,const FString & BaseURL,FString & APIName,TArray< FString > & APIParams)`            | Helper function to break a fully qualified URL into a base URL, API name, and an array of API parameters.
-`public FORCEINLINE uint32 `[`GetTypeHash`](#group__Common_1ga79b9226f7278d4943c4bb94982e4f78f)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory)`            | Helper function to convert an [FRH_FileApiDirectory](Common.md#structFRH__FileApiDirectory) into a hash value.
+`public FORCEINLINE uint32 `[`GetTypeHash`](#group__Common_1ga1f0dd0b6ea1d38b6a21ee6e7e87e9947)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory)`            | Helper function to convert an [FRH_RemoteFileApiDirectory](Common.md#structFRH__RemoteFileApiDirectory) into a hash value.
 `class `[`FRH_AsyncTaskHelper`](#classFRH__AsyncTaskHelper) | Base helper class for asynchronous RallyHere tasks.
 `class `[`FRH_SimpleQueryHelper`](#classFRH__SimpleQueryHelper) | Templated helper class for asynchronously executing basic RallyHere API queries.
 `struct `[`FRH_DelegateBlock`](#structFRH__DelegateBlock) | Templated helper class defining a native and blueprint friendly delegate as a single object.
@@ -23,7 +23,7 @@
 `struct `[`FRH_CustomEndpointRequestWrapper`](#structFRH__CustomEndpointRequestWrapper) | Wrapper calls for custom endpoint requests.
 `struct `[`FRH_CustomEndpointResponseWrapper`](#structFRH__CustomEndpointResponseWrapper) | Wrapper calls for custom endpoint responses.
 `struct `[`FRH_PlayerPlatformId`](#structFRH__PlayerPlatformId) | Common structure for identifying players on any known platform.
-`struct `[`FRH_FileApiDirectory`](#structFRH__FileApiDirectory) | A tuple specifying the directory of a file in the remote file storage.
+`struct `[`FRH_RemoteFileApiDirectory`](#structFRH__RemoteFileApiDirectory) | A tuple specifying the directory of a file in the remote file storage.
 
 ## Members
 
@@ -129,9 +129,9 @@ Helper function to break a fully qualified URL into a base URL, API name, and an
 #### Returns
 Semi-unique hash value for the given platform id
 
-#### `public FORCEINLINE uint32 `[`GetTypeHash`](#group__Common_1ga79b9226f7278d4943c4bb94982e4f78f)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory)` <a id="group__Common_1ga79b9226f7278d4943c4bb94982e4f78f"></a>
+#### `public FORCEINLINE uint32 `[`GetTypeHash`](#group__Common_1ga1f0dd0b6ea1d38b6a21ee6e7e87e9947)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory)` <a id="group__Common_1ga1f0dd0b6ea1d38b6a21ee6e7e87e9947"></a>
 
-Helper function to convert an [FRH_FileApiDirectory](Common.md#structFRH__FileApiDirectory) into a hash value.
+Helper function to convert an [FRH_RemoteFileApiDirectory](Common.md#structFRH__RemoteFileApiDirectory) into a hash value.
 
 #### Parameters
 * `Directory` The directory to generate a hash for 
@@ -621,7 +621,7 @@ Default constructor that leaves the user ID empty and sets the platform type to 
 Constructor for specifying user ID and platform type.
 
 <br>
-## struct `FRH_FileApiDirectory` <a id="structFRH__FileApiDirectory"></a>
+## struct `FRH_RemoteFileApiDirectory` <a id="structFRH__RemoteFileApiDirectory"></a>
 
 A tuple specifying the directory of a file in the remote file storage.
 
@@ -629,51 +629,51 @@ A tuple specifying the directory of a file in the remote file storage.
 
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
-`public ERHAPI_FileType `[`FileType`](#structFRH__FileApiDirectory_1a77323ab3538c7e32c8b56a412f268b46) | The type of file to upload/download
-`public ERHAPI_EntityType `[`EntityType`](#structFRH__FileApiDirectory_1aac99462459aa261273d91de0fb2b0dfd) | The type of entity the file is associated with
-`public FString `[`EntityId`](#structFRH__FileApiDirectory_1a8795141a686fa301e7581929fc380123) | The id of the entity the file is associated with
-`public  `[`GENERATED_USTRUCT_BODY`](#structFRH__FileApiDirectory_1abcf4c70c103ba0ddd3e575ab017fa2b4)`()` | 
-`public inline  `[`FRH_FileApiDirectory`](#structFRH__FileApiDirectory_1ace24851579074801f430c383a11b15c4)`()` | 
-`public inline  `[`FRH_FileApiDirectory`](#structFRH__FileApiDirectory_1a40fa7daa93cdd67ddd8bc39ebfbba930)`(ERHAPI_FileType InFileType,ERHAPI_EntityType InEntityType,const FString & InEntityId)` | 
-`public inline bool `[`operator==`](#structFRH__FileApiDirectory_1a38e70bc93869ceecfe41b230624cb107)`(const `[`FRH_FileApiDirectory`](#structFRH__FileApiDirectory)` & Other) const` | Comparison operator.
-`public inline bool `[`IsValid`](#structFRH__FileApiDirectory_1a4e4536b14585a6a60af55d9f0a9c376b)`() const` | 
-`public inline FString `[`ToDescriptionString`](#structFRH__FileApiDirectory_1a9a60e517b0bdce0be34c4084e8470724)`() const` | Get a string representation of the directory.
+`public ERHAPI_FileType `[`FileType`](#structFRH__RemoteFileApiDirectory_1a1986a05bf105acf8d7cb3ccb245c4b67) | The type of file to upload/download
+`public ERHAPI_EntityType `[`EntityType`](#structFRH__RemoteFileApiDirectory_1ac1fbbf236dd5683c0189b58ace4c546b) | The type of entity the file is associated with
+`public FString `[`EntityId`](#structFRH__RemoteFileApiDirectory_1a4065838f5ba174048afd65330a29409d) | The id of the entity the file is associated with
+`public  `[`GENERATED_USTRUCT_BODY`](#structFRH__RemoteFileApiDirectory_1acd97265b9b2a315fbe5eb2aa63c5e67d)`()` | 
+`public inline  `[`FRH_RemoteFileApiDirectory`](#structFRH__RemoteFileApiDirectory_1a56911df486ef89c7096aed2c11cbf837)`()` | 
+`public inline  `[`FRH_RemoteFileApiDirectory`](#structFRH__RemoteFileApiDirectory_1a2098f9e4b8b8b88060886f87d8e394d2)`(ERHAPI_FileType InFileType,ERHAPI_EntityType InEntityType,const FString & InEntityId)` | 
+`public inline bool `[`operator==`](#structFRH__RemoteFileApiDirectory_1a96fe3372945cbf4ffef30c1519bd1432)`(const `[`FRH_RemoteFileApiDirectory`](#structFRH__RemoteFileApiDirectory)` & Other) const` | Comparison operator.
+`public inline bool `[`IsValid`](#structFRH__RemoteFileApiDirectory_1aaae4e108ecd39fb74c4ce279e20304a3)`() const` | 
+`public inline FString `[`ToDescriptionString`](#structFRH__RemoteFileApiDirectory_1a2b39ae30546135d8802a1663893948bc)`() const` | Get a string representation of the directory.
 
 #### Members
 
-#### `public ERHAPI_FileType `[`FileType`](#structFRH__FileApiDirectory_1a77323ab3538c7e32c8b56a412f268b46) <a id="structFRH__FileApiDirectory_1a77323ab3538c7e32c8b56a412f268b46"></a>
+#### `public ERHAPI_FileType `[`FileType`](#structFRH__RemoteFileApiDirectory_1a1986a05bf105acf8d7cb3ccb245c4b67) <a id="structFRH__RemoteFileApiDirectory_1a1986a05bf105acf8d7cb3ccb245c4b67"></a>
 
 The type of file to upload/download
 
 <br>
-#### `public ERHAPI_EntityType `[`EntityType`](#structFRH__FileApiDirectory_1aac99462459aa261273d91de0fb2b0dfd) <a id="structFRH__FileApiDirectory_1aac99462459aa261273d91de0fb2b0dfd"></a>
+#### `public ERHAPI_EntityType `[`EntityType`](#structFRH__RemoteFileApiDirectory_1ac1fbbf236dd5683c0189b58ace4c546b) <a id="structFRH__RemoteFileApiDirectory_1ac1fbbf236dd5683c0189b58ace4c546b"></a>
 
 The type of entity the file is associated with
 
 <br>
-#### `public FString `[`EntityId`](#structFRH__FileApiDirectory_1a8795141a686fa301e7581929fc380123) <a id="structFRH__FileApiDirectory_1a8795141a686fa301e7581929fc380123"></a>
+#### `public FString `[`EntityId`](#structFRH__RemoteFileApiDirectory_1a4065838f5ba174048afd65330a29409d) <a id="structFRH__RemoteFileApiDirectory_1a4065838f5ba174048afd65330a29409d"></a>
 
 The id of the entity the file is associated with
 
 <br>
-#### `public  `[`GENERATED_USTRUCT_BODY`](#structFRH__FileApiDirectory_1abcf4c70c103ba0ddd3e575ab017fa2b4)`()` <a id="structFRH__FileApiDirectory_1abcf4c70c103ba0ddd3e575ab017fa2b4"></a>
+#### `public  `[`GENERATED_USTRUCT_BODY`](#structFRH__RemoteFileApiDirectory_1acd97265b9b2a315fbe5eb2aa63c5e67d)`()` <a id="structFRH__RemoteFileApiDirectory_1acd97265b9b2a315fbe5eb2aa63c5e67d"></a>
 
 <br>
-#### `public inline  `[`FRH_FileApiDirectory`](#structFRH__FileApiDirectory_1ace24851579074801f430c383a11b15c4)`()` <a id="structFRH__FileApiDirectory_1ace24851579074801f430c383a11b15c4"></a>
+#### `public inline  `[`FRH_RemoteFileApiDirectory`](#structFRH__RemoteFileApiDirectory_1a56911df486ef89c7096aed2c11cbf837)`()` <a id="structFRH__RemoteFileApiDirectory_1a56911df486ef89c7096aed2c11cbf837"></a>
 
 <br>
-#### `public inline  `[`FRH_FileApiDirectory`](#structFRH__FileApiDirectory_1a40fa7daa93cdd67ddd8bc39ebfbba930)`(ERHAPI_FileType InFileType,ERHAPI_EntityType InEntityType,const FString & InEntityId)` <a id="structFRH__FileApiDirectory_1a40fa7daa93cdd67ddd8bc39ebfbba930"></a>
+#### `public inline  `[`FRH_RemoteFileApiDirectory`](#structFRH__RemoteFileApiDirectory_1a2098f9e4b8b8b88060886f87d8e394d2)`(ERHAPI_FileType InFileType,ERHAPI_EntityType InEntityType,const FString & InEntityId)` <a id="structFRH__RemoteFileApiDirectory_1a2098f9e4b8b8b88060886f87d8e394d2"></a>
 
 <br>
-#### `public inline bool `[`operator==`](#structFRH__FileApiDirectory_1a38e70bc93869ceecfe41b230624cb107)`(const `[`FRH_FileApiDirectory`](#structFRH__FileApiDirectory)` & Other) const` <a id="structFRH__FileApiDirectory_1a38e70bc93869ceecfe41b230624cb107"></a>
+#### `public inline bool `[`operator==`](#structFRH__RemoteFileApiDirectory_1a96fe3372945cbf4ffef30c1519bd1432)`(const `[`FRH_RemoteFileApiDirectory`](#structFRH__RemoteFileApiDirectory)` & Other) const` <a id="structFRH__RemoteFileApiDirectory_1a96fe3372945cbf4ffef30c1519bd1432"></a>
 
 Comparison operator.
 
 <br>
-#### `public inline bool `[`IsValid`](#structFRH__FileApiDirectory_1a4e4536b14585a6a60af55d9f0a9c376b)`() const` <a id="structFRH__FileApiDirectory_1a4e4536b14585a6a60af55d9f0a9c376b"></a>
+#### `public inline bool `[`IsValid`](#structFRH__RemoteFileApiDirectory_1aaae4e108ecd39fb74c4ce279e20304a3)`() const` <a id="structFRH__RemoteFileApiDirectory_1aaae4e108ecd39fb74c4ce279e20304a3"></a>
 
 <br>
-#### `public inline FString `[`ToDescriptionString`](#structFRH__FileApiDirectory_1a9a60e517b0bdce0be34c4084e8470724)`() const` <a id="structFRH__FileApiDirectory_1a9a60e517b0bdce0be34c4084e8470724"></a>
+#### `public inline FString `[`ToDescriptionString`](#structFRH__RemoteFileApiDirectory_1a2b39ae30546135d8802a1663893948bc)`() const` <a id="structFRH__RemoteFileApiDirectory_1a2b39ae30546135d8802a1663893948bc"></a>
 
 Get a string representation of the directory.
 

--- a/Documentation/md/File.md
+++ b/Documentation/md/File.md
@@ -4,12 +4,12 @@
 
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
-`class `[`URH_FileSubsystem`](#classURH__FileSubsystem) | File Subsystem used for file API calls.
+`class `[`URH_RemoteFileSubsystem`](#classURH__RemoteFileSubsystem) | File Subsystem used for file API calls.
 
-## class `URH_FileSubsystem` <a id="classURH__FileSubsystem"></a>
+## class `URH_RemoteFileSubsystem` <a id="classURH__RemoteFileSubsystem"></a>
 
 ```
-class URH_FileSubsystem
+class URH_RemoteFileSubsystem
   : public URH_GameInstanceSubsystemPlugin
 ```
 
@@ -19,37 +19,37 @@ File Subsystem used for file API calls.
 
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
-`public virtual void `[`Initialize`](#classURH__FileSubsystem_1a00d230496f246f5914d9d4a867a0990a)`()` | Initialize the subsystem.
-`public virtual void `[`Deinitialize`](#classURH__FileSubsystem_1a83c13fc9b586f6de3936cc83b44edd6e)`()` | Safely tears down the subsystem.
-`public virtual void `[`UploadFile`](#classURH__FileSubsystem_1aba2e99f3a712d90bc42cee92ee77192d)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorBlock Delegate)` | Upload a local file to the remote file storage.
-`public inline void `[`BLUEPRINT_UploadFile`](#classURH__FileSubsystem_1ae402c1d50344fab33959babf6b7460a9)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` | Upload a local file to the remote file storage.
-`public virtual void `[`DeleteFile`](#classURH__FileSubsystem_1ad7b0fe2fe44ea07341c61f70068b2ce4)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_GenericSuccessWithErrorBlock Delegate)` | Delete a file from remote file storage.
-`public inline void `[`BLUEPRINT_DeleteFile`](#classURH__FileSubsystem_1aaa6da420a95028062b5c5253e1dbc05d)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` | Upload a local file to the remote file storage.
-`public virtual void `[`DownloadFile`](#classURH__FileSubsystem_1a827f8ef2df88eb239b59dcfeb26e42ea)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorBlock Delegate)` | Download a remote file to local file storage.
-`public virtual void `[`DownloadFile`](#classURH__FileSubsystem_1a46b151ed6178edb9790ffadfecb5ff08)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_FileDownloadDelegate Delegate)` | Download a remote file to memory.
-`public inline void `[`BLUEPRINT_DownloadFile`](#classURH__FileSubsystem_1a0225e3d415c12e734787b8729eaeb864)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` | Download a remote file to local file storage.
-`public virtual void `[`DownloadAllFiles`](#classURH__FileSubsystem_1af5c5e2bababfe5eef730974b183c8dab)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & LocalDirectory,bool bUseCachedList,const FRH_FileDirectoryDownloadDelegateBlock Delegate)` | Downloads all discoverable files in a remote directory to a local file directory.
-`public inline void `[`BLUEPRINT_DownloadAllFiles`](#classURH__FileSubsystem_1a8442a05b21f5c6d45bf1cc50d67fa912)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & LocalDirectory,bool bUseCachedList,const FRH_FileDirectoryDownloadDynamicDelegate & Delegate)` | Downloads all discoverable files in a remote directory to a local file directory.
-`public virtual void `[`LookupFileList`](#classURH__FileSubsystem_1a120827aa1ab74f82fd2641512695f1d9)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FRH_GenericSuccessWithErrorBlock Delegate)` | List the available remote files for an entity from the API and store results in cache.
-`public inline void `[`BLUEPRINT_LookupFileList`](#classURH__FileSubsystem_1a8d3408b1fad196e052584507a288fe2f)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` | List the available remote files for an entity from the API and store results in cache.
-`public inline const TMap< `[`FRH_FileApiDirectory](Common.md#structFRH__FileApiDirectory), [FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` > & `[`GetFileListCache`](#classURH__FileSubsystem_1a2a8a714f3451d24bce82e5321218b7ae)`() const` | Get the entire file list cache.
-`public inline virtual bool `[`ListFiles`](#classURH__FileSubsystem_1a9c0b817aea1fd5bce65fce3ae4d1d987)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,`[`FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` & OutFileList)` | List the available remote files for an entity from the cache.
-`protected TMap< `[`FRH_FileApiDirectory](Common.md#structFRH__FileApiDirectory), [FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` > `[`FileListCache`](#classURH__FileSubsystem_1a99fc59f1c9f4e173e6d014ffa84c445b) | 
-`protected virtual void `[`DownloadFileList`](#classURH__FileSubsystem_1a963feef939fd55f7930815bf4c435df2)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const TArray< FString > & RemoteFileNames,const FString & LocalDirectory,const FRH_FileDirectoryDownloadDelegateBlock Delegate)` | Downloads all discoverable files in a remote directory to a local file directory.
+`public virtual void `[`Initialize`](#classURH__RemoteFileSubsystem_1a249b11cac6ff5da3f516459532585108)`()` | Initialize the subsystem.
+`public virtual void `[`Deinitialize`](#classURH__RemoteFileSubsystem_1ab67cd31ba8af91bf5e23f9644770f495)`()` | Safely tears down the subsystem.
+`public virtual void `[`UploadFile`](#classURH__RemoteFileSubsystem_1a03467c88fad90070730fd59fd1e423b7)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorBlock Delegate)` | Upload a local file to the remote file storage.
+`public inline void `[`BLUEPRINT_UploadFile`](#classURH__RemoteFileSubsystem_1a1b0ce6d7fa455db7b234f52c3ef360b2)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` | Upload a local file to the remote file storage.
+`public virtual void `[`DeleteFile`](#classURH__RemoteFileSubsystem_1a2f1ee08e22476c88dff1cdedcd7cf2ef)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_GenericSuccessWithErrorBlock Delegate)` | Delete a file from remote file storage.
+`public inline void `[`BLUEPRINT_DeleteFile`](#classURH__RemoteFileSubsystem_1a13eb10c56b835fe594e88f118c681174)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` | Upload a local file to the remote file storage.
+`public virtual void `[`DownloadFile`](#classURH__RemoteFileSubsystem_1a700698d9f3f0cfa5c59312c67f7ae567)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorBlock Delegate)` | Download a remote file to local file storage.
+`public virtual void `[`DownloadFile`](#classURH__RemoteFileSubsystem_1a2c9407936abcef6097184a3634dbee46)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_FileDownloadDelegate Delegate)` | Download a remote file to memory.
+`public inline void `[`BLUEPRINT_DownloadFile`](#classURH__RemoteFileSubsystem_1a74b373397937c272b586d6785cc5e6b1)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` | Download a remote file to local file storage.
+`public virtual void `[`DownloadAllFiles`](#classURH__RemoteFileSubsystem_1aae6267a8ad1d709fd57b9b6007fd0a68)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & LocalDirectory,bool bUseCachedList,const FRH_FileDirectoryDownloadDelegateBlock Delegate)` | Downloads all discoverable files in a remote directory to a local file directory.
+`public inline void `[`BLUEPRINT_DownloadAllFiles`](#classURH__RemoteFileSubsystem_1a585db9eca7d95d6b68dd83a53527049d)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & LocalDirectory,bool bUseCachedList,const FRH_FileDirectoryDownloadDynamicDelegate & Delegate)` | Downloads all discoverable files in a remote directory to a local file directory.
+`public virtual void `[`LookupFileList`](#classURH__RemoteFileSubsystem_1a36fea83617549e77ed8ae584a72510c7)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FRH_GenericSuccessWithErrorBlock Delegate)` | List the available remote files for an entity from the API and store results in cache.
+`public inline void `[`BLUEPRINT_LookupFileList`](#classURH__RemoteFileSubsystem_1a6fe5fd4de179985acf299724bad96d07)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` | List the available remote files for an entity from the API and store results in cache.
+`public inline const TMap< `[`FRH_RemoteFileApiDirectory](Common.md#structFRH__RemoteFileApiDirectory), [FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` > & `[`GetFileListCache`](#classURH__RemoteFileSubsystem_1a10bf521503a066a0983a554b0011b412)`() const` | Get the entire file list cache.
+`public inline virtual bool `[`ListFiles`](#classURH__RemoteFileSubsystem_1a3d9dbd4f20220f82b8047db827c37777)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,`[`FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` & OutFileList)` | List the available remote files for an entity from the cache.
+`protected TMap< `[`FRH_RemoteFileApiDirectory](Common.md#structFRH__RemoteFileApiDirectory), [FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` > `[`FileListCache`](#classURH__RemoteFileSubsystem_1ad6229657ea8ef6c417c9ced173eebe85) | 
+`protected virtual void `[`DownloadFileList`](#classURH__RemoteFileSubsystem_1ac8ee5bc68fb208fb9c329c897b93eab9)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const TArray< FString > & RemoteFileNames,const FString & LocalDirectory,const FRH_FileDirectoryDownloadDelegateBlock Delegate)` | Downloads all discoverable files in a remote directory to a local file directory.
 
 #### Members
 
-#### `public virtual void `[`Initialize`](#classURH__FileSubsystem_1a00d230496f246f5914d9d4a867a0990a)`()` <a id="classURH__FileSubsystem_1a00d230496f246f5914d9d4a867a0990a"></a>
+#### `public virtual void `[`Initialize`](#classURH__RemoteFileSubsystem_1a249b11cac6ff5da3f516459532585108)`()` <a id="classURH__RemoteFileSubsystem_1a249b11cac6ff5da3f516459532585108"></a>
 
 Initialize the subsystem.
 
 <br>
-#### `public virtual void `[`Deinitialize`](#classURH__FileSubsystem_1a83c13fc9b586f6de3936cc83b44edd6e)`()` <a id="classURH__FileSubsystem_1a83c13fc9b586f6de3936cc83b44edd6e"></a>
+#### `public virtual void `[`Deinitialize`](#classURH__RemoteFileSubsystem_1ab67cd31ba8af91bf5e23f9644770f495)`()` <a id="classURH__RemoteFileSubsystem_1ab67cd31ba8af91bf5e23f9644770f495"></a>
 
 Safely tears down the subsystem.
 
 <br>
-#### `public virtual void `[`UploadFile`](#classURH__FileSubsystem_1aba2e99f3a712d90bc42cee92ee77192d)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorBlock Delegate)` <a id="classURH__FileSubsystem_1aba2e99f3a712d90bc42cee92ee77192d"></a>
+#### `public virtual void `[`UploadFile`](#classURH__RemoteFileSubsystem_1a03467c88fad90070730fd59fd1e423b7)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorBlock Delegate)` <a id="classURH__RemoteFileSubsystem_1a03467c88fad90070730fd59fd1e423b7"></a>
 
 Upload a local file to the remote file storage.
 
@@ -63,7 +63,7 @@ Upload a local file to the remote file storage.
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public inline void `[`BLUEPRINT_UploadFile`](#classURH__FileSubsystem_1ae402c1d50344fab33959babf6b7460a9)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` <a id="classURH__FileSubsystem_1ae402c1d50344fab33959babf6b7460a9"></a>
+#### `public inline void `[`BLUEPRINT_UploadFile`](#classURH__RemoteFileSubsystem_1a1b0ce6d7fa455db7b234f52c3ef360b2)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` <a id="classURH__RemoteFileSubsystem_1a1b0ce6d7fa455db7b234f52c3ef360b2"></a>
 
 Upload a local file to the remote file storage.
 
@@ -77,7 +77,7 @@ Upload a local file to the remote file storage.
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public virtual void `[`DeleteFile`](#classURH__FileSubsystem_1ad7b0fe2fe44ea07341c61f70068b2ce4)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_GenericSuccessWithErrorBlock Delegate)` <a id="classURH__FileSubsystem_1ad7b0fe2fe44ea07341c61f70068b2ce4"></a>
+#### `public virtual void `[`DeleteFile`](#classURH__RemoteFileSubsystem_1a2f1ee08e22476c88dff1cdedcd7cf2ef)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_GenericSuccessWithErrorBlock Delegate)` <a id="classURH__RemoteFileSubsystem_1a2f1ee08e22476c88dff1cdedcd7cf2ef"></a>
 
 Delete a file from remote file storage.
 
@@ -89,7 +89,7 @@ Delete a file from remote file storage.
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public inline void `[`BLUEPRINT_DeleteFile`](#classURH__FileSubsystem_1aaa6da420a95028062b5c5253e1dbc05d)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` <a id="classURH__FileSubsystem_1aaa6da420a95028062b5c5253e1dbc05d"></a>
+#### `public inline void `[`BLUEPRINT_DeleteFile`](#classURH__RemoteFileSubsystem_1a13eb10c56b835fe594e88f118c681174)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` <a id="classURH__RemoteFileSubsystem_1a13eb10c56b835fe594e88f118c681174"></a>
 
 Upload a local file to the remote file storage.
 
@@ -101,7 +101,7 @@ Upload a local file to the remote file storage.
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public virtual void `[`DownloadFile`](#classURH__FileSubsystem_1a827f8ef2df88eb239b59dcfeb26e42ea)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorBlock Delegate)` <a id="classURH__FileSubsystem_1a827f8ef2df88eb239b59dcfeb26e42ea"></a>
+#### `public virtual void `[`DownloadFile`](#classURH__RemoteFileSubsystem_1a700698d9f3f0cfa5c59312c67f7ae567)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorBlock Delegate)` <a id="classURH__RemoteFileSubsystem_1a700698d9f3f0cfa5c59312c67f7ae567"></a>
 
 Download a remote file to local file storage.
 
@@ -115,7 +115,7 @@ Download a remote file to local file storage.
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public virtual void `[`DownloadFile`](#classURH__FileSubsystem_1a46b151ed6178edb9790ffadfecb5ff08)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_FileDownloadDelegate Delegate)` <a id="classURH__FileSubsystem_1a46b151ed6178edb9790ffadfecb5ff08"></a>
+#### `public virtual void `[`DownloadFile`](#classURH__RemoteFileSubsystem_1a2c9407936abcef6097184a3634dbee46)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FRH_FileDownloadDelegate Delegate)` <a id="classURH__RemoteFileSubsystem_1a2c9407936abcef6097184a3634dbee46"></a>
 
 Download a remote file to memory.
 
@@ -127,7 +127,7 @@ Download a remote file to memory.
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public inline void `[`BLUEPRINT_DownloadFile`](#classURH__FileSubsystem_1a0225e3d415c12e734787b8729eaeb864)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` <a id="classURH__FileSubsystem_1a0225e3d415c12e734787b8729eaeb864"></a>
+#### `public inline void `[`BLUEPRINT_DownloadFile`](#classURH__RemoteFileSubsystem_1a74b373397937c272b586d6785cc5e6b1)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & RemoteFileName,const FString & LocalFilePath,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` <a id="classURH__RemoteFileSubsystem_1a74b373397937c272b586d6785cc5e6b1"></a>
 
 Download a remote file to local file storage.
 
@@ -141,7 +141,7 @@ Download a remote file to local file storage.
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public virtual void `[`DownloadAllFiles`](#classURH__FileSubsystem_1af5c5e2bababfe5eef730974b183c8dab)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & LocalDirectory,bool bUseCachedList,const FRH_FileDirectoryDownloadDelegateBlock Delegate)` <a id="classURH__FileSubsystem_1af5c5e2bababfe5eef730974b183c8dab"></a>
+#### `public virtual void `[`DownloadAllFiles`](#classURH__RemoteFileSubsystem_1aae6267a8ad1d709fd57b9b6007fd0a68)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & LocalDirectory,bool bUseCachedList,const FRH_FileDirectoryDownloadDelegateBlock Delegate)` <a id="classURH__RemoteFileSubsystem_1aae6267a8ad1d709fd57b9b6007fd0a68"></a>
 
 Downloads all discoverable files in a remote directory to a local file directory.
 
@@ -155,7 +155,7 @@ Downloads all discoverable files in a remote directory to a local file directory
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public inline void `[`BLUEPRINT_DownloadAllFiles`](#classURH__FileSubsystem_1a8442a05b21f5c6d45bf1cc50d67fa912)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FString & LocalDirectory,bool bUseCachedList,const FRH_FileDirectoryDownloadDynamicDelegate & Delegate)` <a id="classURH__FileSubsystem_1a8442a05b21f5c6d45bf1cc50d67fa912"></a>
+#### `public inline void `[`BLUEPRINT_DownloadAllFiles`](#classURH__RemoteFileSubsystem_1a585db9eca7d95d6b68dd83a53527049d)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FString & LocalDirectory,bool bUseCachedList,const FRH_FileDirectoryDownloadDynamicDelegate & Delegate)` <a id="classURH__RemoteFileSubsystem_1a585db9eca7d95d6b68dd83a53527049d"></a>
 
 Downloads all discoverable files in a remote directory to a local file directory.
 
@@ -169,7 +169,7 @@ Downloads all discoverable files in a remote directory to a local file directory
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public virtual void `[`LookupFileList`](#classURH__FileSubsystem_1a120827aa1ab74f82fd2641512695f1d9)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FRH_GenericSuccessWithErrorBlock Delegate)` <a id="classURH__FileSubsystem_1a120827aa1ab74f82fd2641512695f1d9"></a>
+#### `public virtual void `[`LookupFileList`](#classURH__RemoteFileSubsystem_1a36fea83617549e77ed8ae584a72510c7)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FRH_GenericSuccessWithErrorBlock Delegate)` <a id="classURH__RemoteFileSubsystem_1a36fea83617549e77ed8ae584a72510c7"></a>
 
 List the available remote files for an entity from the API and store results in cache.
 
@@ -179,7 +179,7 @@ List the available remote files for an entity from the API and store results in 
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public inline void `[`BLUEPRINT_LookupFileList`](#classURH__FileSubsystem_1a8d3408b1fad196e052584507a288fe2f)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` <a id="classURH__FileSubsystem_1a8d3408b1fad196e052584507a288fe2f"></a>
+#### `public inline void `[`BLUEPRINT_LookupFileList`](#classURH__RemoteFileSubsystem_1a6fe5fd4de179985acf299724bad96d07)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const FRH_GenericSuccessWithErrorDynamicDelegate & Delegate)` <a id="classURH__RemoteFileSubsystem_1a6fe5fd4de179985acf299724bad96d07"></a>
 
 List the available remote files for an entity from the API and store results in cache.
 
@@ -189,12 +189,12 @@ List the available remote files for an entity from the API and store results in 
 * `Delegate` The delegate to call when the operation completes.
 
 <br>
-#### `public inline const TMap< `[`FRH_FileApiDirectory](Common.md#structFRH__FileApiDirectory), [FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` > & `[`GetFileListCache`](#classURH__FileSubsystem_1a2a8a714f3451d24bce82e5321218b7ae)`() const` <a id="classURH__FileSubsystem_1a2a8a714f3451d24bce82e5321218b7ae"></a>
+#### `public inline const TMap< `[`FRH_RemoteFileApiDirectory](Common.md#structFRH__RemoteFileApiDirectory), [FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` > & `[`GetFileListCache`](#classURH__RemoteFileSubsystem_1a10bf521503a066a0983a554b0011b412)`() const` <a id="classURH__RemoteFileSubsystem_1a10bf521503a066a0983a554b0011b412"></a>
 
 Get the entire file list cache.
 
 <br>
-#### `public inline virtual bool `[`ListFiles`](#classURH__FileSubsystem_1a9c0b817aea1fd5bce65fce3ae4d1d987)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,`[`FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` & OutFileList)` <a id="classURH__FileSubsystem_1a9c0b817aea1fd5bce65fce3ae4d1d987"></a>
+#### `public inline virtual bool `[`ListFiles`](#classURH__RemoteFileSubsystem_1a3d9dbd4f20220f82b8047db827c37777)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,`[`FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` & OutFileList)` <a id="classURH__RemoteFileSubsystem_1a3d9dbd4f20220f82b8047db827c37777"></a>
 
 List the available remote files for an entity from the cache.
 
@@ -202,10 +202,10 @@ List the available remote files for an entity from the cache.
 * `Directory` The directory of the file on the remote storage.
 
 <br>
-#### `protected TMap< `[`FRH_FileApiDirectory](Common.md#structFRH__FileApiDirectory), [FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` > `[`FileListCache`](#classURH__FileSubsystem_1a99fc59f1c9f4e173e6d014ffa84c445b) <a id="classURH__FileSubsystem_1a99fc59f1c9f4e173e6d014ffa84c445b"></a>
+#### `protected TMap< `[`FRH_RemoteFileApiDirectory](Common.md#structFRH__RemoteFileApiDirectory), [FRHAPI_FileListResponse`](models/RHAPI_FileListResponse.md#structFRHAPI__FileListResponse)` > `[`FileListCache`](#classURH__RemoteFileSubsystem_1ad6229657ea8ef6c417c9ced173eebe85) <a id="classURH__RemoteFileSubsystem_1ad6229657ea8ef6c417c9ced173eebe85"></a>
 
 <br>
-#### `protected virtual void `[`DownloadFileList`](#classURH__FileSubsystem_1a963feef939fd55f7930815bf4c435df2)`(const `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` & Directory,const TArray< FString > & RemoteFileNames,const FString & LocalDirectory,const FRH_FileDirectoryDownloadDelegateBlock Delegate)` <a id="classURH__FileSubsystem_1a963feef939fd55f7930815bf4c435df2"></a>
+#### `protected virtual void `[`DownloadFileList`](#classURH__RemoteFileSubsystem_1ac8ee5bc68fb208fb9c329c897b93eab9)`(const `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` & Directory,const TArray< FString > & RemoteFileNames,const FString & LocalDirectory,const FRH_FileDirectoryDownloadDelegateBlock Delegate)` <a id="classURH__RemoteFileSubsystem_1ac8ee5bc68fb208fb9c329c897b93eab9"></a>
 
 Downloads all discoverable files in a remote directory to a local file directory.
 

--- a/Documentation/md/GameInstance.md
+++ b/Documentation/md/GameInstance.md
@@ -131,7 +131,7 @@ Server Bootstrapper for the Game Instance.
 `public inline virtual TOptional< FString > `[`GetBoundAllocationId`](#classURH__GameInstanceServerBootstrapper_1afc0a4f4f72556a0b713b0bf5f1442eb7)`() const` | Gets the allocation id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
 `public inline virtual TOptional< FString > `[`GetBoundInstanceId`](#classURH__GameInstanceServerBootstrapper_1a33402e7dd26b4a226f7615749184303b)`() const` | Gets the instance id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
 `public virtual bool `[`CanAutoUploadServerFiles`](#classURH__GameInstanceServerBootstrapper_1a9cfd09c543c9435af1a994d400d5c564)`() const` | Gets the directory to use for uploading files for this bootstrapper.
-`public virtual `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` `[`GetAutoUploadDirectory`](#classURH__GameInstanceServerBootstrapper_1a2066c747ca1576959890b28020255072)`(bool bDeveloperFile) const` | Gets the directory to use for uploading files for this bootstrapper.
+`public virtual `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` `[`GetAutoUploadDirectory`](#classURH__GameInstanceServerBootstrapper_1a482bf6b82fcc70879d897f4de4fbc21b)`(bool bDeveloperFile) const` | Gets the directory to use for uploading files for this bootstrapper.
 `public virtual void `[`ConditionalAutoUploadLogFile`](#classURH__GameInstanceServerBootstrapper_1a77257d8a5d5c426286fbf301fec96171)`() const` | Capture and upload log file based on settings.
 `public virtual void `[`ConditionalAutoUploadTraceFile`](#classURH__GameInstanceServerBootstrapper_1af74b0fa8ecac1183cfd34c7c1b3f69ed)`(const FString & TraceFile) const` | Capture and upload trace file based on settings.
 `protected `[`ERH_ServerBootstrapMode`](undefined.md#group__GameInstance_1ga9dd612a2285258b977ec4c21d7a64196)` `[`BootstrapMode`](#classURH__GameInstanceServerBootstrapper_1a437398cd4da11b39dbba5624ac0d4503) | Bootstrap Mode being used
@@ -400,7 +400,7 @@ Gets the instance id this session owner is bound to, if any. Needed for some spe
 Gets the directory to use for uploading files for this bootstrapper.
 
 <br>
-#### `public virtual `[`FRH_FileApiDirectory`](Common.md#structFRH__FileApiDirectory)` `[`GetAutoUploadDirectory`](#classURH__GameInstanceServerBootstrapper_1a2066c747ca1576959890b28020255072)`(bool bDeveloperFile) const` <a id="classURH__GameInstanceServerBootstrapper_1a2066c747ca1576959890b28020255072"></a>
+#### `public virtual `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` `[`GetAutoUploadDirectory`](#classURH__GameInstanceServerBootstrapper_1a482bf6b82fcc70879d897f4de4fbc21b)`(bool bDeveloperFile) const` <a id="classURH__GameInstanceServerBootstrapper_1a482bf6b82fcc70879d897f4de4fbc21b"></a>
 
 Gets the directory to use for uploading files for this bootstrapper.
 
@@ -753,7 +753,7 @@ Subsystem for the Game Instance.
 `public inline `[`URH_ConfigSubsystem`](Config.md#classURH__ConfigSubsystem)` * `[`GetConfigSubsystem`](#classURH__GameInstanceSubsystem_1a7d68319809db5ea58fc8cd87eeeca7a7)`() const` | Gets the config subsystem on the instance.
 `public inline `[`URH_SettingsSubsystem`](Settings.md#classURH__SettingsSubsystem)` * `[`GetSettingsSubsystem`](#classURH__GameInstanceSubsystem_1afafed40a588921b712548ce5071bf4cb)`() const` | Gets the settings subsystem on the instance.
 `public inline `[`URH_MatchSubsystem`](Match.md#classURH__MatchSubsystem)` * `[`GetMatchSubsystem`](#classURH__GameInstanceSubsystem_1aa5048780cc5ed5836e03be9d7780706e)`() const` | Gets the match subsystem on the instance.
-`public inline `[`URH_FileSubsystem`](File.md#classURH__FileSubsystem)` * `[`GetFileSubsystem`](#classURH__GameInstanceSubsystem_1a83b23cbc8e10f6f11c3b44842cb47c18)`() const` | Gets the file subsystem on the instance.
+`public inline `[`URH_RemoteFileSubsystem`](File.md#classURH__RemoteFileSubsystem)` * `[`GetRemoteFileSubsystem`](#classURH__GameInstanceSubsystem_1aafa066f39f2a1aedeb992a2b7c52164d)`() const` | Gets the remote file subsystem on the instance.
 `public void `[`CustomEndpoint`](#classURH__GameInstanceSubsystem_1a1a8dcae5a5642315c8ba20f07aebd162)`(const `[`FRH_CustomEndpointRequestWrapper`](Common.md#structFRH__CustomEndpointRequestWrapper)` & Request,const RallyHereAPI::FDelegate_CustomEndpointSend & Delegate)` | Custom Endpoint wrapper (for custom endpoints that require authentication)
 `public void `[`CustomEndpoint`](#classURH__GameInstanceSubsystem_1aeb1056507af99208ee7397e1b0d23112)`(const `[`FRH_CustomEndpointRequestWrapper`](Common.md#structFRH__CustomEndpointRequestWrapper)` & Request,const FRH_CustomEndpointDelegateBlock & Delegate)` | Custom Endpoint wrapper (for custom endpoints that require authentication)
 `public inline void `[`BLUEPRINT_CustomEndpoint`](#classURH__GameInstanceSubsystem_1a42e7af944e181795ad0a71169e588e92)`(const `[`FRH_CustomEndpointRequestWrapper`](Common.md#structFRH__CustomEndpointRequestWrapper)` & Request,const FRH_CustomEndpointDynamicDelegate & Delegate)` | Custom Endpoint wrapper (for custom endpoints that require authentication)
@@ -770,7 +770,7 @@ Subsystem for the Game Instance.
 `protected `[`URH_ConfigSubsystem`](Config.md#classURH__ConfigSubsystem)` * `[`ConfigSubsystem`](#classURH__GameInstanceSubsystem_1abe30d81653383a1aaf1a454ee67b27ce) | The Config Subsystem.
 `protected `[`URH_SettingsSubsystem`](Settings.md#classURH__SettingsSubsystem)` * `[`SettingsSubsystem`](#classURH__GameInstanceSubsystem_1a0faf95129232d8f19571e9ebdc7b13e1) | The Settings Subsystem.
 `protected `[`URH_MatchSubsystem`](Match.md#classURH__MatchSubsystem)` * `[`MatchSubsystem`](#classURH__GameInstanceSubsystem_1a3d15c09c7d7205f9e38ccc368ffaf62a) | The Match Subsystem.
-`protected `[`URH_FileSubsystem`](File.md#classURH__FileSubsystem)` * `[`FileSubsystem`](#classURH__GameInstanceSubsystem_1aee12d5be87908d3d3cba2884a2f53777) | The File Subsystem.
+`protected `[`URH_RemoteFileSubsystem`](File.md#classURH__RemoteFileSubsystem)` * `[`RemoteFileSubsystem`](#classURH__GameInstanceSubsystem_1a02dcdefba948191414723ca5a5770190) | The File Subsystem.
 `protected bool `[`bEnabled`](#classURH__GameInstanceSubsystem_1aec940d2a189827f2ffea8b8248f9be12) | If the Game Instance Subsystem is enabled.
 `protected bool `[`bEnableSessionBrowser`](#classURH__GameInstanceSubsystem_1a05992b3ee9dc7cc018f9f424069c4748) | If the Session Browser is enabled.
 `protected bool `[`bEnableMatchmakingBrowser`](#classURH__GameInstanceSubsystem_1a65744cd5c8afb2596503251f63a7cf0f) | If the Matchmaking Browser is enabled.
@@ -876,9 +876,9 @@ Gets the settings subsystem on the instance.
 Gets the match subsystem on the instance.
 
 <br>
-#### `public inline `[`URH_FileSubsystem`](File.md#classURH__FileSubsystem)` * `[`GetFileSubsystem`](#classURH__GameInstanceSubsystem_1a83b23cbc8e10f6f11c3b44842cb47c18)`() const` <a id="classURH__GameInstanceSubsystem_1a83b23cbc8e10f6f11c3b44842cb47c18"></a>
+#### `public inline `[`URH_RemoteFileSubsystem`](File.md#classURH__RemoteFileSubsystem)` * `[`GetRemoteFileSubsystem`](#classURH__GameInstanceSubsystem_1aafa066f39f2a1aedeb992a2b7c52164d)`() const` <a id="classURH__GameInstanceSubsystem_1aafa066f39f2a1aedeb992a2b7c52164d"></a>
 
-Gets the file subsystem on the instance.
+Gets the remote file subsystem on the instance.
 
 <br>
 #### `public void `[`CustomEndpoint`](#classURH__GameInstanceSubsystem_1a1a8dcae5a5642315c8ba20f07aebd162)`(const `[`FRH_CustomEndpointRequestWrapper`](Common.md#structFRH__CustomEndpointRequestWrapper)` & Request,const RallyHereAPI::FDelegate_CustomEndpointSend & Delegate)` <a id="classURH__GameInstanceSubsystem_1a1a8dcae5a5642315c8ba20f07aebd162"></a>
@@ -976,7 +976,7 @@ The Settings Subsystem.
 The Match Subsystem.
 
 <br>
-#### `protected `[`URH_FileSubsystem`](File.md#classURH__FileSubsystem)` * `[`FileSubsystem`](#classURH__GameInstanceSubsystem_1aee12d5be87908d3d3cba2884a2f53777) <a id="classURH__GameInstanceSubsystem_1aee12d5be87908d3d3cba2884a2f53777"></a>
+#### `protected `[`URH_RemoteFileSubsystem`](File.md#classURH__RemoteFileSubsystem)` * `[`RemoteFileSubsystem`](#classURH__GameInstanceSubsystem_1a02dcdefba948191414723ca5a5770190) <a id="classURH__GameInstanceSubsystem_1a02dcdefba948191414723ca5a5770190"></a>
 
 The File Subsystem.
 

--- a/Documentation/md/IntegrationSettings.md
+++ b/Documentation/md/IntegrationSettings.md
@@ -75,7 +75,7 @@ Main settings for the Integration.
 `public FSoftClassPath `[`SessionBrowserCacheClass`](#classURH__IntegrationSettings_1af5ecb3103ab065d38eed4634e6916817) | Extensible SessionBrowserCache class path.
 `public FSoftClassPath `[`MatchmakingBrowserCacheClass`](#classURH__IntegrationSettings_1a035a0b0d29e2ed12a2663446c60d811c) | Extensible MatchmakingBrowserCache class path.
 `public FSoftClassPath `[`MatchSubsystemClass`](#classURH__IntegrationSettings_1a2e753925aea5df2e1f47add2fa970097) | Extensible MatchSubsystem class path.
-`public FSoftClassPath `[`FileSubsystemClass`](#classURH__IntegrationSettings_1aa27b645522462f317a83eb154eaa9997) | Extensible FileSubsystem class path.
+`public FSoftClassPath `[`RemoteFileSubsystemClass`](#classURH__IntegrationSettings_1a0388ca75a831a5c4873fe07dd8b638dc) | Extensible RemoteFileSubsystem class path.
 `public bool `[`bLocalPlayerSubsystemSandboxing`](#classURH__IntegrationSettings_1a5826903f6e88cefabe7d9c2ede15e9af) | Flag to determine if the local player subsystem should use its own subsystems instead of relying on GameInstanceSubsystem shared caches.
 `public bool `[`bAutoUploadServerFiles`](#classURH__IntegrationSettings_1aad9767260d4d60a8f378c4543c03f92a) | Whether to automatically upload files to the RallyHere API from Dedicated Servers.
 `public bool `[`bAutoUploadLogFiles`](#classURH__IntegrationSettings_1a8adfac6c3249bca907a1fa051db8d0b5) | Whether to automatically upload files to the RallyHere API. Requires bAutoUploadServerFiles to have an effect.
@@ -451,9 +451,9 @@ Extensible MatchmakingBrowserCache class path.
 Extensible MatchSubsystem class path.
 
 <br>
-#### `public FSoftClassPath `[`FileSubsystemClass`](#classURH__IntegrationSettings_1aa27b645522462f317a83eb154eaa9997) <a id="classURH__IntegrationSettings_1aa27b645522462f317a83eb154eaa9997"></a>
+#### `public FSoftClassPath `[`RemoteFileSubsystemClass`](#classURH__IntegrationSettings_1a0388ca75a831a5c4873fe07dd8b638dc) <a id="classURH__IntegrationSettings_1a0388ca75a831a5c4873fe07dd8b638dc"></a>
 
-Extensible FileSubsystem class path.
+Extensible RemoteFileSubsystem class path.
 
 <br>
 #### `public bool `[`bLocalPlayerSubsystemSandboxing`](#classURH__IntegrationSettings_1a5826903f6e88cefabe7d9c2ede15e9af) <a id="classURH__IntegrationSettings_1a5826903f6e88cefabe7d9c2ede15e9af"></a>

--- a/RallyHereAPI/Source/RallyHereAPI/.openapi-generator/FILES
+++ b/RallyHereAPI/Source/RallyHereAPI/.openapi-generator/FILES
@@ -66,7 +66,6 @@ Private/EventParamsSchemaResponse.cpp
 Private/EventsAPI.cpp
 Private/ExternalKeyEntitlement.cpp
 Private/FastapicommonPlatformsPortal.cpp
-Private/FileAPI.cpp
 Private/FileListResponse.cpp
 Private/FileResponse.cpp
 Private/FileType.cpp
@@ -285,6 +284,7 @@ Private/RankedTeam.cpp
 Private/Region.cpp
 Private/RegionsAPI.cpp
 Private/RegionsResponse.cpp
+Private/RemoteFileAPI.cpp
 Private/ReportReason.cpp
 Private/ReportsAPI.cpp
 Private/Restriction.cpp
@@ -409,7 +409,6 @@ Public/EventParamsSchemaResponse.h
 Public/EventsAPI.h
 Public/ExternalKeyEntitlement.h
 Public/FastapicommonPlatformsPortal.h
-Public/FileAPI.h
 Public/FileListResponse.h
 Public/FileResponse.h
 Public/FileType.h
@@ -628,6 +627,7 @@ Public/RankedTeam.h
 Public/Region.h
 Public/RegionsAPI.h
 Public/RegionsResponse.h
+Public/RemoteFileAPI.h
 Public/ReportReason.h
 Public/ReportsAPI.h
 Public/Restriction.h

--- a/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIAll.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIAll.cpp
@@ -17,7 +17,7 @@ FRallyHereAPIAll::FRallyHereAPIAll()
 	, Entitlements(MakeShareable(new FEntitlementsAPI()))
 	, Environment(MakeShareable(new FEnvironmentAPI()))
 	, Events(MakeShareable(new FEventsAPI()))
-	, File(MakeShareable(new FFileAPI()))
+	, RemoteFile(MakeShareable(new FRemoteFileAPI()))
 	, FriendsV1(MakeShareable(new FFriendsV1API()))
 	, FriendsV2(MakeShareable(new FFriendsV2API()))
 	, InstanceNotification(MakeShareable(new FInstanceNotificationAPI()))
@@ -53,7 +53,7 @@ FRallyHereAPIAll::FRallyHereAPIAll()
 	AllAPIs.Add(Entitlements);
 	AllAPIs.Add(Environment);
 	AllAPIs.Add(Events);
-	AllAPIs.Add(File);
+	AllAPIs.Add(RemoteFile);
 	AllAPIs.Add(FriendsV1);
 	AllAPIs.Add(FriendsV2);
 	AllAPIs.Add(InstanceNotification);
@@ -193,14 +193,14 @@ const TSharedRef<FEventsAPI> FRallyHereAPIAll::GetEvents() const
 	return Events;
 }
 
-TSharedRef<FFileAPI> FRallyHereAPIAll::GetFile()
+TSharedRef<FRemoteFileAPI> FRallyHereAPIAll::GetRemoteFile()
 {
-	return File;
+	return RemoteFile;
 }
 
-const TSharedRef<FFileAPI> FRallyHereAPIAll::GetFile() const
+const TSharedRef<FRemoteFileAPI> FRallyHereAPIAll::GetRemoteFile() const
 {
-	return File;
+	return RemoteFile;
 }
 
 TSharedRef<FFriendsV1API> FRallyHereAPIAll::GetFriendsV1()

--- a/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIBaseModel.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIBaseModel.cpp
@@ -111,7 +111,7 @@ bool FResponse::ParseJsonTypeContent()
 
 	TSharedPtr<FJsonValue> JsonValue;
 	const FString ContentAsString = HttpResponse->GetContentAsString();
-	
+
 	if (ContentAsString.Len() == 0 || ContentAsString.TrimStart().Len() == 0)
 	{
 		// if the response was empty or all whitespace, do not create a json object, but return as non-error

--- a/RallyHereAPI/Source/RallyHereAPI/Private/RemoteFileAPI.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/RemoteFileAPI.cpp
@@ -5,7 +5,7 @@
 // Copyright 2022-2023 RallyHere Interactive
 // SPDX-License-Identifier: Apache-2.0
 
-#include "FileAPI.h"
+#include "RemoteFileAPI.h"
 #include "RallyHereAPIModule.h"
 #include "RallyHereAPIAuthContext.h"
 #include "RallyHereAPIHttpRequester.h"
@@ -15,15 +15,15 @@
 namespace RallyHereAPI
 {
 
-FFileAPI::FFileAPI() : FAPI()
+FRemoteFileAPI::FRemoteFileAPI() : FAPI()
 {
 	Url = TEXT("http://localhost");
 	Name = FName(TEXT("File"));
 }
 
-FFileAPI::~FFileAPI() {}
+FRemoteFileAPI::~FRemoteFileAPI() {}
 
-FHttpRequestPtr FFileAPI::CreateEntityDirectoryFile(const FRequest_CreateEntityDirectoryFile& Request, const FDelegate_CreateEntityDirectoryFile& Delegate /*= FDelegate_CreateEntityDirectoryFile()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
+FHttpRequestPtr FRemoteFileAPI::CreateEntityDirectoryFile(const FRequest_CreateEntityDirectoryFile& Request, const FDelegate_CreateEntityDirectoryFile& Delegate /*= FDelegate_CreateEntityDirectoryFile()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
 {
 	if (!IsValid())
 		return nullptr;
@@ -56,7 +56,7 @@ FHttpRequestPtr FFileAPI::CreateEntityDirectoryFile(const FRequest_CreateEntityD
 
 	// bind response handler
 	FHttpRequestCompleteDelegate ResponseDelegate;
-	ResponseDelegate.BindSP(this, &FFileAPI::OnCreateEntityDirectoryFileResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
+	ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnCreateEntityDirectoryFileResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
 	RequestData->SetDelegate(ResponseDelegate);
 
 	// submit request to http system
@@ -68,7 +68,7 @@ FHttpRequestPtr FFileAPI::CreateEntityDirectoryFile(const FRequest_CreateEntityD
 	return RequestData->HttpRequest;
 }
 
-void FFileAPI::OnCreateEntityDirectoryFileResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_CreateEntityDirectoryFile Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
+void FRemoteFileAPI::OnCreateEntityDirectoryFileResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_CreateEntityDirectoryFile Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
 {
 	FHttpRequestCompleteDelegate ResponseDelegate;
 
@@ -76,7 +76,7 @@ void FFileAPI::OnCreateEntityDirectoryFileResponse(FHttpRequestPtr HttpRequest, 
 	{
 		// An included auth context indicates we should auth-retry this request, we only want to do that at most once per call.
 		// So, we set the callback to use a null context for the retry
-		ResponseDelegate.BindSP(this, &FFileAPI::OnCreateEntityDirectoryFileResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
+		ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnCreateEntityDirectoryFileResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
 	}
 
 	FResponse_CreateEntityDirectoryFile Response{ RequestMetadata };
@@ -220,7 +220,7 @@ FResponse_CreateEntityDirectoryFile::FResponse_CreateEntityDirectoryFile(FReques
 
 FString Traits_CreateEntityDirectoryFile::Name = TEXT("CreateEntityDirectoryFile");
 
-FHttpRequestPtr FFileAPI::DeleteEntityDirectory(const FRequest_DeleteEntityDirectory& Request, const FDelegate_DeleteEntityDirectory& Delegate /*= FDelegate_DeleteEntityDirectory()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
+FHttpRequestPtr FRemoteFileAPI::DeleteEntityDirectory(const FRequest_DeleteEntityDirectory& Request, const FDelegate_DeleteEntityDirectory& Delegate /*= FDelegate_DeleteEntityDirectory()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
 {
 	if (!IsValid())
 		return nullptr;
@@ -253,7 +253,7 @@ FHttpRequestPtr FFileAPI::DeleteEntityDirectory(const FRequest_DeleteEntityDirec
 
 	// bind response handler
 	FHttpRequestCompleteDelegate ResponseDelegate;
-	ResponseDelegate.BindSP(this, &FFileAPI::OnDeleteEntityDirectoryResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
+	ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnDeleteEntityDirectoryResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
 	RequestData->SetDelegate(ResponseDelegate);
 
 	// submit request to http system
@@ -265,7 +265,7 @@ FHttpRequestPtr FFileAPI::DeleteEntityDirectory(const FRequest_DeleteEntityDirec
 	return RequestData->HttpRequest;
 }
 
-void FFileAPI::OnDeleteEntityDirectoryResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_DeleteEntityDirectory Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
+void FRemoteFileAPI::OnDeleteEntityDirectoryResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_DeleteEntityDirectory Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
 {
 	FHttpRequestCompleteDelegate ResponseDelegate;
 
@@ -273,7 +273,7 @@ void FFileAPI::OnDeleteEntityDirectoryResponse(FHttpRequestPtr HttpRequest, FHtt
 	{
 		// An included auth context indicates we should auth-retry this request, we only want to do that at most once per call.
 		// So, we set the callback to use a null context for the retry
-		ResponseDelegate.BindSP(this, &FFileAPI::OnDeleteEntityDirectoryResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
+		ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnDeleteEntityDirectoryResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
 	}
 
 	FResponse_DeleteEntityDirectory Response{ RequestMetadata };
@@ -415,7 +415,7 @@ FResponse_DeleteEntityDirectory::FResponse_DeleteEntityDirectory(FRequestMetadat
 
 FString Traits_DeleteEntityDirectory::Name = TEXT("DeleteEntityDirectory");
 
-FHttpRequestPtr FFileAPI::DeleteEntityDirectoryFile(const FRequest_DeleteEntityDirectoryFile& Request, const FDelegate_DeleteEntityDirectoryFile& Delegate /*= FDelegate_DeleteEntityDirectoryFile()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
+FHttpRequestPtr FRemoteFileAPI::DeleteEntityDirectoryFile(const FRequest_DeleteEntityDirectoryFile& Request, const FDelegate_DeleteEntityDirectoryFile& Delegate /*= FDelegate_DeleteEntityDirectoryFile()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
 {
 	if (!IsValid())
 		return nullptr;
@@ -448,7 +448,7 @@ FHttpRequestPtr FFileAPI::DeleteEntityDirectoryFile(const FRequest_DeleteEntityD
 
 	// bind response handler
 	FHttpRequestCompleteDelegate ResponseDelegate;
-	ResponseDelegate.BindSP(this, &FFileAPI::OnDeleteEntityDirectoryFileResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
+	ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnDeleteEntityDirectoryFileResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
 	RequestData->SetDelegate(ResponseDelegate);
 
 	// submit request to http system
@@ -460,7 +460,7 @@ FHttpRequestPtr FFileAPI::DeleteEntityDirectoryFile(const FRequest_DeleteEntityD
 	return RequestData->HttpRequest;
 }
 
-void FFileAPI::OnDeleteEntityDirectoryFileResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_DeleteEntityDirectoryFile Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
+void FRemoteFileAPI::OnDeleteEntityDirectoryFileResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_DeleteEntityDirectoryFile Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
 {
 	FHttpRequestCompleteDelegate ResponseDelegate;
 
@@ -468,7 +468,7 @@ void FFileAPI::OnDeleteEntityDirectoryFileResponse(FHttpRequestPtr HttpRequest, 
 	{
 		// An included auth context indicates we should auth-retry this request, we only want to do that at most once per call.
 		// So, we set the callback to use a null context for the retry
-		ResponseDelegate.BindSP(this, &FFileAPI::OnDeleteEntityDirectoryFileResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
+		ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnDeleteEntityDirectoryFileResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
 	}
 
 	FResponse_DeleteEntityDirectoryFile Response{ RequestMetadata };
@@ -602,7 +602,7 @@ FResponse_DeleteEntityDirectoryFile::FResponse_DeleteEntityDirectoryFile(FReques
 
 FString Traits_DeleteEntityDirectoryFile::Name = TEXT("DeleteEntityDirectoryFile");
 
-FHttpRequestPtr FFileAPI::DownloadEntityDirectoryFile(const FRequest_DownloadEntityDirectoryFile& Request, const FDelegate_DownloadEntityDirectoryFile& Delegate /*= FDelegate_DownloadEntityDirectoryFile()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
+FHttpRequestPtr FRemoteFileAPI::DownloadEntityDirectoryFile(const FRequest_DownloadEntityDirectoryFile& Request, const FDelegate_DownloadEntityDirectoryFile& Delegate /*= FDelegate_DownloadEntityDirectoryFile()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
 {
 	if (!IsValid())
 		return nullptr;
@@ -635,7 +635,7 @@ FHttpRequestPtr FFileAPI::DownloadEntityDirectoryFile(const FRequest_DownloadEnt
 
 	// bind response handler
 	FHttpRequestCompleteDelegate ResponseDelegate;
-	ResponseDelegate.BindSP(this, &FFileAPI::OnDownloadEntityDirectoryFileResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
+	ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnDownloadEntityDirectoryFileResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
 	RequestData->SetDelegate(ResponseDelegate);
 
 	// submit request to http system
@@ -647,7 +647,7 @@ FHttpRequestPtr FFileAPI::DownloadEntityDirectoryFile(const FRequest_DownloadEnt
 	return RequestData->HttpRequest;
 }
 
-void FFileAPI::OnDownloadEntityDirectoryFileResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_DownloadEntityDirectoryFile Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
+void FRemoteFileAPI::OnDownloadEntityDirectoryFileResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_DownloadEntityDirectoryFile Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
 {
 	FHttpRequestCompleteDelegate ResponseDelegate;
 
@@ -655,7 +655,7 @@ void FFileAPI::OnDownloadEntityDirectoryFileResponse(FHttpRequestPtr HttpRequest
 	{
 		// An included auth context indicates we should auth-retry this request, we only want to do that at most once per call.
 		// So, we set the callback to use a null context for the retry
-		ResponseDelegate.BindSP(this, &FFileAPI::OnDownloadEntityDirectoryFileResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
+		ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnDownloadEntityDirectoryFileResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
 	}
 
 	FResponse_DownloadEntityDirectoryFile Response{ RequestMetadata };
@@ -811,7 +811,7 @@ FResponse_DownloadEntityDirectoryFile::FResponse_DownloadEntityDirectoryFile(FRe
 
 FString Traits_DownloadEntityDirectoryFile::Name = TEXT("DownloadEntityDirectoryFile");
 
-FHttpRequestPtr FFileAPI::GetEntityDirectoryInformation(const FRequest_GetEntityDirectoryInformation& Request, const FDelegate_GetEntityDirectoryInformation& Delegate /*= FDelegate_GetEntityDirectoryInformation()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
+FHttpRequestPtr FRemoteFileAPI::GetEntityDirectoryInformation(const FRequest_GetEntityDirectoryInformation& Request, const FDelegate_GetEntityDirectoryInformation& Delegate /*= FDelegate_GetEntityDirectoryInformation()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
 {
 	if (!IsValid())
 		return nullptr;
@@ -844,7 +844,7 @@ FHttpRequestPtr FFileAPI::GetEntityDirectoryInformation(const FRequest_GetEntity
 
 	// bind response handler
 	FHttpRequestCompleteDelegate ResponseDelegate;
-	ResponseDelegate.BindSP(this, &FFileAPI::OnGetEntityDirectoryInformationResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
+	ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnGetEntityDirectoryInformationResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
 	RequestData->SetDelegate(ResponseDelegate);
 
 	// submit request to http system
@@ -856,7 +856,7 @@ FHttpRequestPtr FFileAPI::GetEntityDirectoryInformation(const FRequest_GetEntity
 	return RequestData->HttpRequest;
 }
 
-void FFileAPI::OnGetEntityDirectoryInformationResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_GetEntityDirectoryInformation Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
+void FRemoteFileAPI::OnGetEntityDirectoryInformationResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_GetEntityDirectoryInformation Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
 {
 	FHttpRequestCompleteDelegate ResponseDelegate;
 
@@ -864,7 +864,7 @@ void FFileAPI::OnGetEntityDirectoryInformationResponse(FHttpRequestPtr HttpReque
 	{
 		// An included auth context indicates we should auth-retry this request, we only want to do that at most once per call.
 		// So, we set the callback to use a null context for the retry
-		ResponseDelegate.BindSP(this, &FFileAPI::OnGetEntityDirectoryInformationResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
+		ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnGetEntityDirectoryInformationResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
 	}
 
 	FResponse_GetEntityDirectoryInformation Response{ RequestMetadata };
@@ -1006,7 +1006,7 @@ FResponse_GetEntityDirectoryInformation::FResponse_GetEntityDirectoryInformation
 
 FString Traits_GetEntityDirectoryInformation::Name = TEXT("GetEntityDirectoryInformation");
 
-FHttpRequestPtr FFileAPI::ListEntityDirectoryFiles(const FRequest_ListEntityDirectoryFiles& Request, const FDelegate_ListEntityDirectoryFiles& Delegate /*= FDelegate_ListEntityDirectoryFiles()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
+FHttpRequestPtr FRemoteFileAPI::ListEntityDirectoryFiles(const FRequest_ListEntityDirectoryFiles& Request, const FDelegate_ListEntityDirectoryFiles& Delegate /*= FDelegate_ListEntityDirectoryFiles()*/, int32 Priority /*= DefaultRallyHereAPIPriority*/)
 {
 	if (!IsValid())
 		return nullptr;
@@ -1039,7 +1039,7 @@ FHttpRequestPtr FFileAPI::ListEntityDirectoryFiles(const FRequest_ListEntityDire
 
 	// bind response handler
 	FHttpRequestCompleteDelegate ResponseDelegate;
-	ResponseDelegate.BindSP(this, &FFileAPI::OnListEntityDirectoryFilesResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
+	ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnListEntityDirectoryFilesResponse, Delegate, Request.GetRequestMetadata(), Request.GetAuthContext(), Priority);
 	RequestData->SetDelegate(ResponseDelegate);
 
 	// submit request to http system
@@ -1051,7 +1051,7 @@ FHttpRequestPtr FFileAPI::ListEntityDirectoryFiles(const FRequest_ListEntityDire
 	return RequestData->HttpRequest;
 }
 
-void FFileAPI::OnListEntityDirectoryFilesResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_ListEntityDirectoryFiles Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
+void FRemoteFileAPI::OnListEntityDirectoryFilesResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDelegate_ListEntityDirectoryFiles Delegate, FRequestMetadata RequestMetadata, TSharedPtr<FAuthContext> AuthContextForRetry, int32 Priority)
 {
 	FHttpRequestCompleteDelegate ResponseDelegate;
 
@@ -1059,7 +1059,7 @@ void FFileAPI::OnListEntityDirectoryFilesResponse(FHttpRequestPtr HttpRequest, F
 	{
 		// An included auth context indicates we should auth-retry this request, we only want to do that at most once per call.
 		// So, we set the callback to use a null context for the retry
-		ResponseDelegate.BindSP(this, &FFileAPI::OnListEntityDirectoryFilesResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
+		ResponseDelegate.BindSP(this, &FRemoteFileAPI::OnListEntityDirectoryFilesResponse, Delegate, RequestMetadata, TSharedPtr<FAuthContext>(), Priority);
 	}
 
 	FResponse_ListEntityDirectoryFiles Response{ RequestMetadata };

--- a/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIAll.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIAll.h
@@ -20,7 +20,7 @@
 #include "EntitlementsAPI.h"
 #include "EnvironmentAPI.h"
 #include "EventsAPI.h"
-#include "FileAPI.h"
+#include "RemoteFileAPI.h"
 #include "FriendsV1API.h"
 #include "FriendsV2API.h"
 #include "InstanceNotificationAPI.h"
@@ -90,8 +90,8 @@ public:
 	TSharedRef<FEventsAPI> GetEvents();
 	const TSharedRef<FEventsAPI> GetEvents() const;
 
-	TSharedRef<FFileAPI> GetFile();
-	const TSharedRef<FFileAPI> GetFile() const;
+	TSharedRef<FRemoteFileAPI> GetRemoteFile();
+	const TSharedRef<FRemoteFileAPI> GetRemoteFile() const;
 
 	TSharedRef<FFriendsV1API> GetFriendsV1();
 	const TSharedRef<FFriendsV1API> GetFriendsV1() const;
@@ -172,7 +172,7 @@ private:
 	TSharedRef<FEntitlementsAPI> Entitlements;
 	TSharedRef<FEnvironmentAPI> Environment;
 	TSharedRef<FEventsAPI> Events;
-	TSharedRef<FFileAPI> File;
+	TSharedRef<FRemoteFileAPI> RemoteFile;
 	TSharedRef<FFriendsV1API> FriendsV1;
 	TSharedRef<FFriendsV2API> FriendsV2;
 	TSharedRef<FInstanceNotificationAPI> InstanceNotification;

--- a/RallyHereAPI/Source/RallyHereAPI/Public/RemoteFileAPI.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/RemoteFileAPI.h
@@ -43,11 +43,11 @@ DECLARE_DELEGATE_OneParam(FDelegate_DownloadEntityDirectoryFile, const FResponse
 DECLARE_DELEGATE_OneParam(FDelegate_GetEntityDirectoryInformation, const FResponse_GetEntityDirectoryInformation&);
 DECLARE_DELEGATE_OneParam(FDelegate_ListEntityDirectoryFiles, const FResponse_ListEntityDirectoryFiles&);
 
-class RALLYHEREAPI_API FFileAPI : public FAPI
+class RALLYHEREAPI_API FRemoteFileAPI : public FAPI
 {
 public:
-	FFileAPI();
-	virtual ~FFileAPI();
+	FRemoteFileAPI();
+	virtual ~FRemoteFileAPI();
 
 	FHttpRequestPtr CreateEntityDirectoryFile(const FRequest_CreateEntityDirectoryFile& Request, const FDelegate_CreateEntityDirectoryFile& Delegate = FDelegate_CreateEntityDirectoryFile(), int32 Priority = DefaultRallyHereAPIPriority);
 	FHttpRequestPtr DeleteEntityDirectory(const FRequest_DeleteEntityDirectory& Request, const FDelegate_DeleteEntityDirectory& Delegate = FDelegate_DeleteEntityDirectory(), int32 Priority = DefaultRallyHereAPIPriority);
@@ -120,7 +120,7 @@ struct RALLYHEREAPI_API Traits_CreateEntityDirectoryFile
 	typedef FRequest_CreateEntityDirectoryFile Request;
 	typedef FResponse_CreateEntityDirectoryFile Response;
 	typedef FDelegate_CreateEntityDirectoryFile Delegate;
-	typedef FFileAPI API;
+	typedef FRemoteFileAPI API;
 	static FString Name;
 
 	static FHttpRequestPtr DoCall(TSharedRef<API> InAPI, const Request& InRequest, Delegate InDelegate = Delegate(), int32 Priority = DefaultRallyHereAPIPriority) { return InAPI->CreateEntityDirectoryFile(InRequest, InDelegate, Priority); }
@@ -176,7 +176,7 @@ struct RALLYHEREAPI_API Traits_DeleteEntityDirectory
 	typedef FRequest_DeleteEntityDirectory Request;
 	typedef FResponse_DeleteEntityDirectory Response;
 	typedef FDelegate_DeleteEntityDirectory Delegate;
-	typedef FFileAPI API;
+	typedef FRemoteFileAPI API;
 	static FString Name;
 
 	static FHttpRequestPtr DoCall(TSharedRef<API> InAPI, const Request& InRequest, Delegate InDelegate = Delegate(), int32 Priority = DefaultRallyHereAPIPriority) { return InAPI->DeleteEntityDirectory(InRequest, InDelegate, Priority); }
@@ -233,7 +233,7 @@ struct RALLYHEREAPI_API Traits_DeleteEntityDirectoryFile
 	typedef FRequest_DeleteEntityDirectoryFile Request;
 	typedef FResponse_DeleteEntityDirectoryFile Response;
 	typedef FDelegate_DeleteEntityDirectoryFile Delegate;
-	typedef FFileAPI API;
+	typedef FRemoteFileAPI API;
 	static FString Name;
 
 	static FHttpRequestPtr DoCall(TSharedRef<API> InAPI, const Request& InRequest, Delegate InDelegate = Delegate(), int32 Priority = DefaultRallyHereAPIPriority) { return InAPI->DeleteEntityDirectoryFile(InRequest, InDelegate, Priority); }
@@ -296,7 +296,7 @@ struct RALLYHEREAPI_API Traits_DownloadEntityDirectoryFile
 	typedef FRequest_DownloadEntityDirectoryFile Request;
 	typedef FResponse_DownloadEntityDirectoryFile Response;
 	typedef FDelegate_DownloadEntityDirectoryFile Delegate;
-	typedef FFileAPI API;
+	typedef FRemoteFileAPI API;
 	static FString Name;
 
 	static FHttpRequestPtr DoCall(TSharedRef<API> InAPI, const Request& InRequest, Delegate InDelegate = Delegate(), int32 Priority = DefaultRallyHereAPIPriority) { return InAPI->DownloadEntityDirectoryFile(InRequest, InDelegate, Priority); }
@@ -354,7 +354,7 @@ struct RALLYHEREAPI_API Traits_GetEntityDirectoryInformation
 	typedef FRequest_GetEntityDirectoryInformation Request;
 	typedef FResponse_GetEntityDirectoryInformation Response;
 	typedef FDelegate_GetEntityDirectoryInformation Delegate;
-	typedef FFileAPI API;
+	typedef FRemoteFileAPI API;
 	static FString Name;
 
 	static FHttpRequestPtr DoCall(TSharedRef<API> InAPI, const Request& InRequest, Delegate InDelegate = Delegate(), int32 Priority = DefaultRallyHereAPIPriority) { return InAPI->GetEntityDirectoryInformation(InRequest, InDelegate, Priority); }
@@ -411,7 +411,7 @@ struct RALLYHEREAPI_API Traits_ListEntityDirectoryFiles
 	typedef FRequest_ListEntityDirectoryFiles Request;
 	typedef FResponse_ListEntityDirectoryFiles Response;
 	typedef FDelegate_ListEntityDirectoryFiles Delegate;
-	typedef FFileAPI API;
+	typedef FRemoteFileAPI API;
 	static FString Name;
 
 	static FHttpRequestPtr DoCall(TSharedRef<API> InAPI, const Request& InRequest, Delegate InDelegate = Delegate(), int32 Priority = DefaultRallyHereAPIPriority) { return InAPI->ListEntityDirectoryFiles(InRequest, InDelegate, Priority); }

--- a/RallyHereDebugTool/Source/Private/RHDTW_Match.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Match.cpp
@@ -8,7 +8,7 @@
 #include "Engine/GameInstance.h"
 #include "RH_GameInstanceSubsystem.h"
 #include "RH_MatchSubsystem.h"
-#include "RH_FileSubsystem.h"
+#include "RH_RemoteFileSubsystem.h"
 #include "RH_PlayerInfoSubsystem.h"
 
 #include "RH_ImGuiUtilities.h"
@@ -502,7 +502,7 @@ void FRHDTW_Match::DoFilesBlock(const FString& MatchId, bool bDownload, bool bUp
 		return;
 	}
 
-	auto FileSubsystem = pGISS->GetFileSubsystem();
+	auto FileSubsystem = pGISS->GetRemoteFileSubsystem();
 
 	if (FileSubsystem != nullptr)
 	{

--- a/RallyHereDebugTool/Source/Private/RHDTW_RemoteFile.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_RemoteFile.cpp
@@ -7,7 +7,7 @@
 #include "imgui.h"
 #include "Engine/GameInstance.h"
 #include "RH_GameInstanceSubsystem.h"
-#include "RH_FileSubsystem.h"
+#include "RH_RemoteFileSubsystem.h"
 
 #include "RH_ImGuiUtilities.h"
 
@@ -36,10 +36,10 @@ void FRHDTW_RemoteFile::Do()
 		return;
 	}
 
-	auto* pRH_FileSubsystem = pGISS->GetFileSubsystem();
-	if (pRH_FileSubsystem == nullptr)
+	auto* pRH_RemoteFileSubsystem = pGISS->GetRemoteFileSubsystem();
+	if (pRH_RemoteFileSubsystem == nullptr)
 	{
-		ImGui::Text("%s", "URH_FileSubsystem not available.");
+		ImGui::Text("%s", "URH_RemoteFileSubsystem not available.");
 		return;
 	}
 
@@ -59,19 +59,19 @@ void FRHDTW_RemoteFile::Do()
 	{
 		if (ImGui::BeginTabItem("List Files"))
 		{
-			DoListFiles(pRH_FileSubsystem);
+			DoListFiles(pRH_RemoteFileSubsystem);
 			ImGui::EndTabItem();
 		}
 
 		if (ImGui::BeginTabItem("Upload"))
 		{
-			DoUploadFile(pRH_FileSubsystem);
+			DoUploadFile(pRH_RemoteFileSubsystem);
 			ImGui::EndTabItem();
 		}
 
 		if (ImGui::BeginTabItem("Download"))
 		{
-			DoDownloadFile(pRH_FileSubsystem);
+			DoDownloadFile(pRH_RemoteFileSubsystem);
 			ImGui::EndTabItem();
 		}
 
@@ -80,22 +80,22 @@ void FRHDTW_RemoteFile::Do()
 }
 
 
-void FRHDTW_RemoteFile::DoListFiles(URH_FileSubsystem* pFileSubsystem)
+void FRHDTW_RemoteFile::DoListFiles(URH_RemoteFileSubsystem* pRemoteFileSubsystem)
 {
 	ImGui::InputText("(TO) Local Download Directory", &BrowseDownloadDirectory);
 
 	if (ImGui::Button("Lookup File List"))
 	{
-		pFileSubsystem->LookupFileList(RemoteDirectory);
+		pRemoteFileSubsystem->LookupFileList(RemoteDirectory);
 	}
 
 	FRHAPI_FileListResponse FileList;
-	if (pFileSubsystem->ListFiles(RemoteDirectory, FileList))
+	if (pRemoteFileSubsystem->ListFiles(RemoteDirectory, FileList))
 	{
 		ImGui::Text("%d Files Found", FileList.GetFiles().Num());
 
 		// define delete file modal, since it must be defined at each level of the hierarchy
-		auto DefineDeleteFileModal = [this, pFileSubsystem, FileList]() -> void
+		auto DefineDeleteFileModal = [this, pRemoteFileSubsystem, FileList]() -> void
 			{
 				if (ImGui::BeginPopupModal("Confirm Delete File"))
 				{
@@ -109,16 +109,16 @@ void FRHDTW_RemoteFile::DoListFiles(URH_FileSubsystem* pFileSubsystem)
 						ImGui::Text("%s", TCHAR_TO_UTF8(*ModalText));
 						if (ImGui::Button("Yes"))
 						{
-							TWeakObjectPtr<URH_FileSubsystem> pFileSubsystemWeak = pFileSubsystem;
+							TWeakObjectPtr<URH_RemoteFileSubsystem> pRemoteFileSubsystemWeak = pRemoteFileSubsystem;
 							const auto RemoteDirectoryRef = RemoteDirectory;
 
-							auto OnComplete = FRH_GenericSuccessWithErrorDelegate::CreateSPLambda(this, [this, pFileSubsystemWeak, RemoteDirectoryRef](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
+							auto OnComplete = FRH_GenericSuccessWithErrorDelegate::CreateSPLambda(this, [this, pRemoteFileSubsystemWeak, RemoteDirectoryRef](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
 								{
 									// if we successfully deleted file the, refresh the list view to reflect it
 									PendingDeleteResult = bSuccess ? TEXT("Success") : ErrorInfo.ResponseContent;
-									if (bSuccess && pFileSubsystemWeak.IsValid())
+									if (bSuccess && pRemoteFileSubsystemWeak.IsValid())
 									{
-										pFileSubsystemWeak->LookupFileList(RemoteDirectoryRef);
+										pRemoteFileSubsystemWeak->LookupFileList(RemoteDirectoryRef);
 									}
 								});
 
@@ -127,13 +127,13 @@ void FRHDTW_RemoteFile::DoListFiles(URH_FileSubsystem* pFileSubsystem)
 							{
 								for (auto& File : FileList.GetFiles())
 								{
-									pFileSubsystem->DeleteFile(RemoteDirectory, File.GetName(), OnComplete);
+									pRemoteFileSubsystem->DeleteFile(RemoteDirectory, File.GetName(), OnComplete);
 								}
 							}
 							// otherwise, just delete the one file and refresh on completion
 							else
 							{
-								pFileSubsystem->DeleteFile(RemoteDirectory, PendingDeleteFileName, OnComplete);
+								pRemoteFileSubsystem->DeleteFile(RemoteDirectory, PendingDeleteFileName, OnComplete);
 							}
 							PendingDeleteFileName.Empty();
 							ImGui::CloseCurrentPopup();
@@ -154,7 +154,7 @@ void FRHDTW_RemoteFile::DoListFiles(URH_FileSubsystem* pFileSubsystem)
 		if (ImGui::Button("Download All Files"))
 		{
 			// download all files specified by the cache
-			pFileSubsystem->DownloadAllFiles(RemoteDirectory, BrowseDownloadDirectory, true);
+			pRemoteFileSubsystem->DownloadAllFiles(RemoteDirectory, BrowseDownloadDirectory, true);
 		}
 		if (ImGui::Button("Delete All Files"))
 		{
@@ -169,7 +169,7 @@ void FRHDTW_RemoteFile::DoListFiles(URH_FileSubsystem* pFileSubsystem)
 				ImGui::BeginDisabled(BrowseDownloadDirectory.IsEmpty());
 				if (ImGui::Button("Download"))
 				{
-					pFileSubsystem->DownloadFile(RemoteDirectory, File.GetName(), BrowseDownloadDirectory / File.GetName());
+					pRemoteFileSubsystem->DownloadFile(RemoteDirectory, File.GetName(), BrowseDownloadDirectory / File.GetName());
 				}
 				ImGui::EndDisabled();
 				ImGui::SameLine();
@@ -192,7 +192,7 @@ void FRHDTW_RemoteFile::DoListFiles(URH_FileSubsystem* pFileSubsystem)
 		ImGui::Text("RemoteDirectory not found in cache.");
 	}
 }
-void FRHDTW_RemoteFile::DoDownloadFile(URH_FileSubsystem* pFileSubsystem)
+void FRHDTW_RemoteFile::DoDownloadFile(URH_RemoteFileSubsystem* pRemoteFileSubsystem)
 {
 	ImGui::InputText("(FROM) Remote File Name", &DownloadRemoteFileName);
 	ImGui::InputText("(TO) Local File Path", &DownloadLocalFilePath);
@@ -200,7 +200,7 @@ void FRHDTW_RemoteFile::DoDownloadFile(URH_FileSubsystem* pFileSubsystem)
 	ImGui::BeginDisabled(!RemoteDirectory.IsValid() || DownloadRemoteFileName.IsEmpty() || DownloadLocalFilePath.IsEmpty());
 	if (ImGui::Button("Download"))
 	{
-		pFileSubsystem->DownloadFile(RemoteDirectory, DownloadRemoteFileName, DownloadLocalFilePath, FRH_GenericSuccessWithErrorDelegate::CreateSPLambda(this, [this](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
+		pRemoteFileSubsystem->DownloadFile(RemoteDirectory, DownloadRemoteFileName, DownloadLocalFilePath, FRH_GenericSuccessWithErrorDelegate::CreateSPLambda(this, [this](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
 			{
 				DownloadResult = bSuccess ? TEXT("Success") : ErrorInfo.ResponseContent;
 			})
@@ -210,7 +210,7 @@ void FRHDTW_RemoteFile::DoDownloadFile(URH_FileSubsystem* pFileSubsystem)
 
 	ImGui::Text("Result: %s", TCHAR_TO_UTF8(*DownloadResult));
 }
-void FRHDTW_RemoteFile::DoUploadFile(URH_FileSubsystem* pFileSubsystem)
+void FRHDTW_RemoteFile::DoUploadFile(URH_RemoteFileSubsystem* pRemoteFileSubsystem)
 {
 	ImGui::InputText("(FROM) Local File Path", &UploadLocalFilePath);
 	ImGui::InputText("(TO) Remote File Name", &UploadRemoteFileName);
@@ -218,7 +218,7 @@ void FRHDTW_RemoteFile::DoUploadFile(URH_FileSubsystem* pFileSubsystem)
 	ImGui::BeginDisabled(!RemoteDirectory.IsValid() || UploadLocalFilePath.IsEmpty() || UploadRemoteFileName.IsEmpty());
 	if (ImGui::Button("Upload"))
 	{
-		pFileSubsystem->UploadFile(RemoteDirectory, UploadRemoteFileName, UploadLocalFilePath, FRH_GenericSuccessWithErrorDelegate::CreateSPLambda(this, [this](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
+		pRemoteFileSubsystem->UploadFile(RemoteDirectory, UploadRemoteFileName, UploadLocalFilePath, FRH_GenericSuccessWithErrorDelegate::CreateSPLambda(this, [this](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
 			{
 				UploadResult = bSuccess ? TEXT("Success") : ErrorInfo.ResponseContent;
 			})

--- a/RallyHereDebugTool/Source/Public/RHDTW_RemoteFile.h
+++ b/RallyHereDebugTool/Source/Public/RHDTW_RemoteFile.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "RH_DebugToolWindow.h"
-#include "RH_FileSubsystem.h"
+#include "RH_RemoteFileSubsystem.h"
 
 struct FRHDTW_RemoteFile : public FRH_DebugToolWindow
 {
@@ -15,13 +15,13 @@ public:
 
 	virtual void Do() override;
 
-	virtual void DoListFiles(URH_FileSubsystem* pFileSubsystem);
-	virtual void DoDownloadFile(URH_FileSubsystem* pFileSubsystem);
-	virtual void DoUploadFile(URH_FileSubsystem* pFileSubsystem);
+	virtual void DoListFiles(URH_RemoteFileSubsystem* pRemoteFileSubsystem);
+	virtual void DoDownloadFile(URH_RemoteFileSubsystem* pRemoteFileSubsystem);
+	virtual void DoUploadFile(URH_RemoteFileSubsystem* pRemoteFileSubsystem);
 
 protected:
 
-	FRH_FileApiDirectory RemoteDirectory;
+	FRH_RemoteFileApiDirectory RemoteDirectory;
 
 	FString BrowseDownloadDirectory;
 	FString PendingDeleteFileName;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_FileSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_FileSubsystem.cpp
@@ -59,7 +59,7 @@ void URH_FileSubsystem::UploadFile(const FRH_FileApiDirectory& Directory, const 
 		GetDefault<URH_IntegrationSettings>()->FileUploadPriority
 	);
 
-	Helper->Start(RH_APIs::GetFileAPI(), Request);
+	Helper->Start(RH_APIs::GetRemoteFileAPI(), Request);
 }
 
 void URH_FileSubsystem::DeleteFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FRH_GenericSuccessWithErrorBlock Delegate)
@@ -91,7 +91,7 @@ void URH_FileSubsystem::DeleteFile(const FRH_FileApiDirectory& Directory, const 
 		GetDefault<URH_IntegrationSettings>()->FileDeletePriority
 	);
 
-	Helper->Start(RH_APIs::GetFileAPI(), Request);
+	Helper->Start(RH_APIs::GetRemoteFileAPI(), Request);
 }
 
 void URH_FileSubsystem::DownloadFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorBlock Delegate)
@@ -135,7 +135,7 @@ void URH_FileSubsystem::DownloadFile(const FRH_FileApiDirectory& Directory, cons
 		GetDefault<URH_IntegrationSettings>()->FileDownloadPriority
 	);
 
-	Helper->Start(RH_APIs::GetFileAPI(), Request);
+	Helper->Start(RH_APIs::GetRemoteFileAPI(), Request);
 }
 
 
@@ -170,7 +170,7 @@ void URH_FileSubsystem::DownloadFile(const FRH_FileApiDirectory& Directory, cons
 		GetDefault<URH_IntegrationSettings>()->FileDownloadPriority
 	);
 
-	Helper->Start(RH_APIs::GetFileAPI(), Request);
+	Helper->Start(RH_APIs::GetRemoteFileAPI(), Request);
 }
 
 void URH_FileSubsystem::DownloadAllFiles(const FRH_FileApiDirectory& Directory, const FString& LocalDirectory, bool bUseCachedList, const FRH_FileDirectoryDownloadDelegateBlock Delegate)
@@ -305,5 +305,5 @@ void URH_FileSubsystem::LookupFileList(const FRH_FileApiDirectory& Directory, co
 		GetDefault<URH_IntegrationSettings>()->FileBrowsePriority
 	);
 
-	Helper->Start(RH_APIs::GetFileAPI(), Request);
+	Helper->Start(RH_APIs::GetRemoteFileAPI(), Request);
 }

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -6,7 +6,7 @@
 #include "RH_GameInstanceSessionSubsystem.h"
 #include "RH_LocalPlayerSubsystem.h"
 #include "RH_LocalPlayerSessionSubsystem.h"
-#include "RH_FileSubsystem.h"
+#include "RH_RemoteFileSubsystem.h"
 #include "RH_MatchSubsystem.h"
 #include "RH_Events.h"
 #include "RH_PlayerInfoSubsystem.h"
@@ -1515,7 +1515,7 @@ bool URH_GameInstanceServerBootstrapper::CanAutoUploadServerFiles() const
 	return Settings->bAutoUploadServerFiles;
 }
 
-FRH_FileApiDirectory URH_GameInstanceServerBootstrapper::GetAutoUploadDirectory(bool bDeveloperFile) const
+FRH_RemoteFileApiDirectory URH_GameInstanceServerBootstrapper::GetAutoUploadDirectory(bool bDeveloperFile) const
 {
 	auto GISS = GetGameInstanceSubsystem();
 	if (GISS != nullptr && GISS->GetMatchSubsystem() != nullptr)
@@ -1526,7 +1526,7 @@ FRH_FileApiDirectory URH_GameInstanceServerBootstrapper::GetAutoUploadDirectory(
 		}
 		return GISS->GetMatchSubsystem()->GetMatchFileDirectory(GISS->GetMatchSubsystem()->GetActiveMatchId());
 	}
-	return FRH_FileApiDirectory();
+	return FRH_RemoteFileApiDirectory();
 }
 void URH_GameInstanceServerBootstrapper::ConditionalAutoUploadLogFile() const
 {
@@ -1535,12 +1535,12 @@ void URH_GameInstanceServerBootstrapper::ConditionalAutoUploadLogFile() const
 	{
 		auto Directory = GetAutoUploadDirectory();
 		auto GISS = GetGameInstanceSubsystem();
-		if (GISS != nullptr && GISS->GetFileSubsystem() != nullptr && Directory.IsValid())
+		if (GISS != nullptr && GISS->GetRemoteFileSubsystem() != nullptr && Directory.IsValid())
 		{
 			const FString LogSrcAbsolute = FPlatformOutputDevices::GetAbsoluteLogFilename();
 			FString LogFilename = FPaths::GetCleanFilename(LogSrcAbsolute);
 
-			return GISS->GetFileSubsystem()->UploadFile(Directory, LogFilename, LogSrcAbsolute);
+			return GISS->GetRemoteFileSubsystem()->UploadFile(Directory, LogFilename, LogSrcAbsolute);
 		}
 	}
 }
@@ -1551,11 +1551,11 @@ void URH_GameInstanceServerBootstrapper::ConditionalAutoUploadTraceFile(const FS
 	{
 		auto Directory = GetAutoUploadDirectory();
 		auto GISS = GetGameInstanceSubsystem();
-		if (GISS != nullptr && GISS->GetFileSubsystem() != nullptr && Directory.IsValid())
+		if (GISS != nullptr && GISS->GetRemoteFileSubsystem() != nullptr && Directory.IsValid())
 		{
 			FString LogFilename = FPaths::GetCleanFilename(TraceFile);
 
-			return GISS->GetFileSubsystem()->UploadFile(Directory, LogFilename, TraceFile);
+			return GISS->GetRemoteFileSubsystem()->UploadFile(Directory, LogFilename, TraceFile);
 		}
 	}
 }

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSubsystem.cpp
@@ -19,7 +19,7 @@
 #include "RH_ConfigSubsystem.h"
 #include "RH_SettingsSubsystem.h"
 #include "RH_MatchSubsystem.h"
-#include "RH_FileSubsystem.h"
+#include "RH_RemoteFileSubsystem.h"
 
 #include "RH_SessionBrowser.h"
 #include "RH_MatchmakingBrowser.h"
@@ -61,7 +61,7 @@ void URH_GameInstanceSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	ConfigSubsystem = AddSubsystemPlugin<URH_ConfigSubsystem>(Settings->ConfigSubsystemClass);
 	SettingsSubsystem = AddSubsystemPlugin<URH_SettingsSubsystem>(Settings->SettingsSubsystemClass);
 	MatchSubsystem = AddSubsystemPlugin<URH_MatchSubsystem>(Settings->MatchSubsystemClass);
-	FileSubsystem = AddSubsystemPlugin<URH_FileSubsystem>(Settings->FileSubsystemClass);
+	RemoteFileSubsystem = AddSubsystemPlugin<URH_RemoteFileSubsystem>(Settings->RemoteFileSubsystemClass);
 
 	if (bEnableSessionBrowser)
 	{
@@ -98,7 +98,7 @@ void URH_GameInstanceSubsystem::Deinitialize()
 	ConfigSubsystem = nullptr;
 	SettingsSubsystem = nullptr;
 	MatchSubsystem = nullptr;
-	FileSubsystem = nullptr;
+	RemoteFileSubsystem = nullptr;
 	SessionSearchCache = nullptr;
 	MatchmakingCache = nullptr;
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_MatchSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_MatchSubsystem.cpp
@@ -5,7 +5,7 @@
 
 #include "RallyHereIntegrationModule.h"
 #include "RH_Common.h"
-#include "RH_FileSubsystem.h"
+#include "RH_RemoteFileSubsystem.h"
 
 
 URH_MatchSubsystem::URH_MatchSubsystem(const FObjectInitializer& ObjectInitializer)
@@ -654,8 +654,8 @@ void FRH_MatchCreateSimple::Define()
 								return;
 							}
 
-							auto FileSubsystem = GISubsystem->GetFileSubsystem();
-							if (!TestNotNull(TEXT("FileSubsystem"), FileSubsystem))
+							auto RemoteFileSubsystem = GISubsystem->GetRemoteFileSubsystem();
+							if (!TestNotNull(TEXT("RemoteFileSubsystem"), RemoteFileSubsystem))
 							{
 								Done.Execute();
 								return;
@@ -672,7 +672,7 @@ void FRH_MatchCreateSimple::Define()
 							// upload the file
 							const auto RemoteFileDirectory = URH_MatchSubsystem::GetMatchFileDirectory(MatchId);
 							const auto RemoteFileName = TEXT("TestFile.txt");
-							FileSubsystem->UploadFile(RemoteFileDirectory, RemoteFileName, TempFile, 
+							RemoteFileSubsystem->UploadFile(RemoteFileDirectory, RemoteFileName, TempFile,
 								FRH_GenericSuccessWithErrorDelegate::CreateLambda([this, RemoteFileDirectory, RemoteFileName, TempFileContents, MatchId, Done](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
 								{
 									if (!TestTrue(TEXT("Success"), bSuccess))
@@ -694,8 +694,8 @@ void FRH_MatchCreateSimple::Define()
 										return;
 									}
 
-									auto FileSubsystem = GISubsystem->GetFileSubsystem();
-									if (!TestNotNull(TEXT("FileSubsystem"), FileSubsystem))
+									auto RemoteFileSubsystem = GISubsystem->GetRemoteFileSubsystem();
+									if (!TestNotNull(TEXT("RemoteFileSubsystem"), RemoteFileSubsystem))
 									{
 										Done.Execute();
 										return;
@@ -704,7 +704,7 @@ void FRH_MatchCreateSimple::Define()
 									const FString DownloadMatchDir = FPaths::ProjectPersistentDownloadDir();
 									FString DestFile = DownloadMatchDir / FString::Printf(TEXT("Match_%s.txt"), *MatchId);
 
-									FileSubsystem->DownloadFile(RemoteFileDirectory, RemoteFileName, DestFile, FRH_GenericSuccessWithErrorDelegate::CreateLambda([this, DestFile, TempFileContents, Done](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
+									RemoteFileSubsystem->DownloadFile(RemoteFileDirectory, RemoteFileName, DestFile, FRH_GenericSuccessWithErrorDelegate::CreateLambda([this, DestFile, TempFileContents, Done](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
 										{
 											if (!TestTrue(TEXT("Success"), bSuccess))
 											{

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_RemoteFileSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_RemoteFileSubsystem.cpp
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 RallyHere Interactive
 // SPDX-License-Identifier: Apache-2.0
 
-#include "RH_FileSubsystem.h"
+#include "RH_RemoteFileSubsystem.h"
 
 #include "RallyHereIntegrationModule.h"
 #include "RH_Common.h"
@@ -10,22 +10,22 @@
 #include "HAL/PlatformFileManager.h"
 
 
-URH_FileSubsystem::URH_FileSubsystem(const FObjectInitializer& ObjectInitializer)
+URH_RemoteFileSubsystem::URH_RemoteFileSubsystem(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
 }
 
-void URH_FileSubsystem::Initialize()
+void URH_RemoteFileSubsystem::Initialize()
 {
 	Super::Initialize();
 }
 
-void URH_FileSubsystem::Deinitialize()
+void URH_RemoteFileSubsystem::Deinitialize()
 {
 	Super::Deinitialize();
 }
 
-void URH_FileSubsystem::UploadFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorBlock Delegate)
+void URH_RemoteFileSubsystem::UploadFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorBlock Delegate)
 {
 	UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] Request to upload file %s to %s::%s"), ANSI_TO_TCHAR(__FUNCTION__), *LocalFilePath, *Directory.ToDescriptionString(), *RemoteFileName);
 	typedef RallyHereAPI::Traits_CreateEntityDirectoryFile BaseType;
@@ -62,7 +62,7 @@ void URH_FileSubsystem::UploadFile(const FRH_FileApiDirectory& Directory, const 
 	Helper->Start(RH_APIs::GetRemoteFileAPI(), Request);
 }
 
-void URH_FileSubsystem::DeleteFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FRH_GenericSuccessWithErrorBlock Delegate)
+void URH_RemoteFileSubsystem::DeleteFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FRH_GenericSuccessWithErrorBlock Delegate)
 {
 	UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] Request to delete file %s::%s"), ANSI_TO_TCHAR(__FUNCTION__), *Directory.ToDescriptionString(), *RemoteFileName);
 	typedef RallyHereAPI::Traits_DeleteEntityDirectoryFile BaseType;
@@ -94,7 +94,7 @@ void URH_FileSubsystem::DeleteFile(const FRH_FileApiDirectory& Directory, const 
 	Helper->Start(RH_APIs::GetRemoteFileAPI(), Request);
 }
 
-void URH_FileSubsystem::DownloadFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorBlock Delegate)
+void URH_RemoteFileSubsystem::DownloadFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorBlock Delegate)
 {
 	UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] Request to download file %s::%s to %s"), ANSI_TO_TCHAR(__FUNCTION__), *Directory.ToDescriptionString(), *RemoteFileName, *LocalFilePath);
 	typedef RallyHereAPI::Traits_DownloadEntityDirectoryFile BaseType;
@@ -139,7 +139,7 @@ void URH_FileSubsystem::DownloadFile(const FRH_FileApiDirectory& Directory, cons
 }
 
 
-void URH_FileSubsystem::DownloadFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FRH_FileDownloadDelegate Delegate)
+void URH_RemoteFileSubsystem::DownloadFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FRH_FileDownloadDelegate Delegate)
 {
 	UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] Request to download file %s::%s to memory"), ANSI_TO_TCHAR(__FUNCTION__), *Directory.ToDescriptionString(), *RemoteFileName);
 	typedef RallyHereAPI::Traits_DownloadEntityDirectoryFile BaseType;
@@ -173,7 +173,7 @@ void URH_FileSubsystem::DownloadFile(const FRH_FileApiDirectory& Directory, cons
 	Helper->Start(RH_APIs::GetRemoteFileAPI(), Request);
 }
 
-void URH_FileSubsystem::DownloadAllFiles(const FRH_FileApiDirectory& Directory, const FString& LocalDirectory, bool bUseCachedList, const FRH_FileDirectoryDownloadDelegateBlock Delegate)
+void URH_RemoteFileSubsystem::DownloadAllFiles(const FRH_RemoteFileApiDirectory& Directory, const FString& LocalDirectory, bool bUseCachedList, const FRH_FileDirectoryDownloadDelegateBlock Delegate)
 {
 	if (bUseCachedList)
 	{
@@ -216,7 +216,7 @@ void URH_FileSubsystem::DownloadAllFiles(const FRH_FileApiDirectory& Directory, 
 		}));
 }
 
-void URH_FileSubsystem::DownloadFileList(const FRH_FileApiDirectory& Directory, const TArray<FString>& RemoteFileNames, const FString& LocalDirectory, const FRH_FileDirectoryDownloadDelegateBlock Delegate)
+void URH_RemoteFileSubsystem::DownloadFileList(const FRH_RemoteFileApiDirectory& Directory, const TArray<FString>& RemoteFileNames, const FString& LocalDirectory, const FRH_FileDirectoryDownloadDelegateBlock Delegate)
 {
 	// trivial success case, no files to download
 	if (RemoteFileNames.IsEmpty())
@@ -276,7 +276,7 @@ void URH_FileSubsystem::DownloadFileList(const FRH_FileApiDirectory& Directory, 
 	}
 }
 
-void URH_FileSubsystem::LookupFileList(const FRH_FileApiDirectory& Directory, const FRH_GenericSuccessWithErrorBlock Delegate)
+void URH_RemoteFileSubsystem::LookupFileList(const FRH_RemoteFileApiDirectory& Directory, const FRH_GenericSuccessWithErrorBlock Delegate)
 {
 	typedef RallyHereAPI::Traits_ListEntityDirectoryFiles BaseType;
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
@@ -753,7 +753,7 @@ static bool RH_BreakApartURL(const FString& URL, const FString& BaseURL, FString
  * @brief A tuple specifying the directory of a file in the remote file storage.
  */
 USTRUCT(BlueprintType)
-struct FRH_FileApiDirectory
+struct FRH_RemoteFileApiDirectory
 {
 	GENERATED_USTRUCT_BODY();
 
@@ -767,14 +767,14 @@ struct FRH_FileApiDirectory
 	UPROPERTY(BlueprintReadWrite, Category = "File")
 	FString EntityId;
 
-	FRH_FileApiDirectory()
+	FRH_RemoteFileApiDirectory()
 		: FileType(ERHAPI_FileType::File)
 		, EntityType(ERHAPI_EntityType::Unknown)
 		, EntityId()
 	{
 	}
 
-	FRH_FileApiDirectory(ERHAPI_FileType InFileType, ERHAPI_EntityType InEntityType, const FString& InEntityId)
+	FRH_RemoteFileApiDirectory(ERHAPI_FileType InFileType, ERHAPI_EntityType InEntityType, const FString& InEntityId)
 		: FileType(InFileType)
 		, EntityType(InEntityType)
 		, EntityId(InEntityId)
@@ -782,7 +782,7 @@ struct FRH_FileApiDirectory
 	}
 
 	/** @brief Comparison operator */
-	bool operator== (const FRH_FileApiDirectory& Other) const
+	bool operator== (const FRH_RemoteFileApiDirectory& Other) const
 	{
 		return	FileType == Other.FileType
 			&& EntityType == Other.EntityType
@@ -806,11 +806,11 @@ struct FRH_FileApiDirectory
 };
 
 /**
- * @brief Helper function to convert an FRH_FileApiDirectory into a hash value
+ * @brief Helper function to convert an FRH_RemoteFileApiDirectory into a hash value
  * @param [in] Directory The directory to generate a hash for
  * @return Semi-unique hash value for the given directory
  */
-FORCEINLINE uint32 GetTypeHash(const FRH_FileApiDirectory& Directory)
+FORCEINLINE uint32 GetTypeHash(const FRH_RemoteFileApiDirectory& Directory)
 {
 	return HashCombine((uint32)Directory.FileType, HashCombine(GetTypeHash((uint32)Directory.EntityType), GetTypeHash(Directory.EntityId)));
 }

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_FileSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_FileSubsystem.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include "FileAPI.h"
+#include "RemoteFileAPI.h"
 #include "RH_Common.h"
 #include "RH_SubsystemPluginBase.h"
 #include "RH_FileSubsystem.generated.h"

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
@@ -536,7 +536,7 @@ public:
 	/**
 	* @brief Gets the directory to use for uploading files for this bootstrapper
 	*/
-	virtual FRH_FileApiDirectory GetAutoUploadDirectory(bool bDeveloperFile = true) const;
+	virtual FRH_RemoteFileApiDirectory GetAutoUploadDirectory(bool bDeveloperFile = true) const;
 	/**
 	* @brief Capture and upload log file based on settings
 	*/

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceSubsystem.h
@@ -24,7 +24,7 @@ class URH_CatalogSubsystem;
 class URH_ConfigSubsystem;
 class URH_SettingsSubsystem;
 class URH_MatchSubsystem;
-class URH_FileSubsystem;
+class URH_RemoteFileSubsystem;
 
 /** @defgroup GameInstance RallyHere Game Instance
  *  @{
@@ -121,10 +121,10 @@ public:
 	UFUNCTION(BlueprintGetter, Category = "Match")
 	inline URH_MatchSubsystem* GetMatchSubsystem() const { return MatchSubsystem; };
 	/**
-	* @brief Gets the file subsystem on the instance.
+	* @brief Gets the remote file subsystem on the instance.
 	*/
 	UFUNCTION(BlueprintGetter, Category = "File")
-	inline URH_FileSubsystem* GetFileSubsystem() const { return FileSubsystem; };
+	inline URH_RemoteFileSubsystem* GetRemoteFileSubsystem() const { return RemoteFileSubsystem; };
 
 	/**
 	* @brief Gets if server boostrapping is enabled, by inspecting state of default object before game instance is initialized, once it is initialized use the above
@@ -225,8 +225,8 @@ protected:
 	UPROPERTY(VisibleInstanceOnly, BlueprintGetter = GetMatchSubsystem, Category = "Match")
 	URH_MatchSubsystem* MatchSubsystem;
 	/** @brief The File Subsystem */
-	UPROPERTY(VisibleInstanceOnly, BlueprintGetter = GetFileSubsystem, Category = "Match")
-	URH_FileSubsystem* FileSubsystem;
+	UPROPERTY(VisibleInstanceOnly, BlueprintGetter = GetRemoteFileSubsystem, Category = "Match")
+	URH_RemoteFileSubsystem* RemoteFileSubsystem;
 
 	// control flags
 	/** @brief If the Game Instance Subsystem is enabled. */

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_IntegrationSettings.h
@@ -267,9 +267,9 @@ public:
 	/** @brief Extensible MatchSubsystem class path */
 	UPROPERTY(EditAnywhere, Config, Category = "Subsystem Classes")
 	FSoftClassPath MatchSubsystemClass;
-	/** @brief Extensible FileSubsystem class path */
+	/** @brief Extensible RemoteFileSubsystem class path */
 	UPROPERTY(EditAnywhere, Config, Category = "Subsystem Classes")
-	FSoftClassPath FileSubsystemClass;
+	FSoftClassPath RemoteFileSubsystemClass;
 
 	/** @brief Flag to determine if the local player subsystem should use its own subsystems instead of relying on GameInstanceSubsystem shared caches. */
 	UPROPERTY(EditAnywhere, Config, Category = "Subsystem Classes")

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_MatchSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_MatchSubsystem.h
@@ -309,12 +309,12 @@ public:
 	 * @brief Get the file directory structure to be used with File API requests for a given match id
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Matches")
-	static FRH_FileApiDirectory GetMatchFileDirectory(const FString& MatchId) { return FRH_FileApiDirectory(ERHAPI_FileType::File, ERHAPI_EntityType::Match, MatchId); }
+	static FRH_RemoteFileApiDirectory GetMatchFileDirectory(const FString& MatchId) { return FRH_RemoteFileApiDirectory(ERHAPI_FileType::File, ERHAPI_EntityType::Match, MatchId); }
 	/**
 	 * @brief Get the file directory structure to be used with File API requests for a given match id (Developer Files)
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Matches")
-	static FRH_FileApiDirectory GetMatchDeveloperFileDirectory(const FString& MatchId) { return FRH_FileApiDirectory(ERHAPI_FileType::DeveloperFile, ERHAPI_EntityType::Match, MatchId); }
+	static FRH_RemoteFileApiDirectory GetMatchDeveloperFileDirectory(const FString& MatchId) { return FRH_RemoteFileApiDirectory(ERHAPI_FileType::DeveloperFile, ERHAPI_EntityType::Match, MatchId); }
 
 protected:
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_RemoteFileSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_RemoteFileSubsystem.h
@@ -5,7 +5,7 @@
 #include "RemoteFileAPI.h"
 #include "RH_Common.h"
 #include "RH_SubsystemPluginBase.h"
-#include "RH_FileSubsystem.generated.h"
+#include "RH_RemoteFileSubsystem.generated.h"
 
 /** @brief Delegate for file download operations that returns raw payload */
 DECLARE_DELEGATE_ThreeParams(FRH_FileDownloadDelegate, bool, TArrayView<const uint8>, const FRH_ErrorInfo&);
@@ -27,7 +27,7 @@ DECLARE_RH_DELEGATE_BLOCK(FRH_FileDirectoryDownloadDelegateBlock, FRH_FileDirect
  * @brief File Subsystem used for file API calls.
  */
 UCLASS(Config=RallyHereIntegration)
-class RALLYHEREINTEGRATION_API URH_FileSubsystem : public URH_GameInstanceSubsystemPlugin
+class RALLYHEREINTEGRATION_API URH_RemoteFileSubsystem : public URH_GameInstanceSubsystemPlugin
 {
 	GENERATED_UCLASS_BODY()
 public:
@@ -48,7 +48,7 @@ public:
 	 * @param LocalFilePath The path of the file on the local storage to upload.
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
-	virtual void UploadFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorBlock Delegate = FRH_GenericSuccessWithErrorBlock());
+	virtual void UploadFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorBlock Delegate = FRH_GenericSuccessWithErrorBlock());
 	/**
 	 * @brief Upload a local file to the remote file storage.
 	 * @param Directory The directory of the file on the remote storage.
@@ -57,7 +57,7 @@ public:
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "File", meta=(DisplayName="Upload File", AutoCreateRefTerm = "Delegate"))
-	void BLUEPRINT_UploadFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorDynamicDelegate& Delegate)
+	void BLUEPRINT_UploadFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorDynamicDelegate& Delegate)
 	{
 		UploadFile(Directory, RemoteFileName, LocalFilePath, Delegate);
 	}
@@ -68,7 +68,7 @@ public:
 	 * @param RemoteFileName The name of the file on the remote storage.
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
-	virtual void DeleteFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FRH_GenericSuccessWithErrorBlock Delegate = FRH_GenericSuccessWithErrorBlock());
+	virtual void DeleteFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FRH_GenericSuccessWithErrorBlock Delegate = FRH_GenericSuccessWithErrorBlock());
 	/**
 	 * @brief Upload a local file to the remote file storage.
 	 * @param Directory The directory of the file on the remote storage.
@@ -76,7 +76,7 @@ public:
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "File", meta=(DisplayName="Upload File", AutoCreateRefTerm = "Delegate"))
-	void BLUEPRINT_DeleteFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FRH_GenericSuccessWithErrorDynamicDelegate& Delegate)
+	void BLUEPRINT_DeleteFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FRH_GenericSuccessWithErrorDynamicDelegate& Delegate)
 	{
 		DeleteFile(Directory, RemoteFileName, Delegate);
 	}
@@ -88,14 +88,14 @@ public:
 	 * @param LocalFilePath The path of the file on the local storage to save to.
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
-	virtual void DownloadFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorBlock Delegate = FRH_GenericSuccessWithErrorBlock());
+	virtual void DownloadFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorBlock Delegate = FRH_GenericSuccessWithErrorBlock());
 	/**
 	 * @brief Download a remote file to memory
 	 * @param Directory The directory of the file on the remote storage.
 	 * @param RemoteFileName The name of the file on the remote storage to download.
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
-	virtual void DownloadFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FRH_FileDownloadDelegate Delegate);
+	virtual void DownloadFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FRH_FileDownloadDelegate Delegate);
 	/**
 	 * @brief Download a remote file to local file storage.
 	 * @param Directory The directory of the file on the remote storage.
@@ -104,7 +104,7 @@ public:
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "File", meta = (DisplayName = "Download File", AutoCreateRefTerm = "Delegate"))
-	void BLUEPRINT_DownloadFile(const FRH_FileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorDynamicDelegate& Delegate)
+	void BLUEPRINT_DownloadFile(const FRH_RemoteFileApiDirectory& Directory, const FString& RemoteFileName, const FString& LocalFilePath, const FRH_GenericSuccessWithErrorDynamicDelegate& Delegate)
 	{
 		DownloadFile(Directory, RemoteFileName, LocalFilePath, Delegate);
 	}
@@ -116,7 +116,7 @@ public:
 	 * @param bUseCachedList If true, use the cached file list instead of fetching a new one.
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
-	virtual void DownloadAllFiles(const FRH_FileApiDirectory& Directory, const FString& LocalDirectory, bool bUseCachedList = false, const FRH_FileDirectoryDownloadDelegateBlock Delegate = FRH_FileDirectoryDownloadDelegateBlock());
+	virtual void DownloadAllFiles(const FRH_RemoteFileApiDirectory& Directory, const FString& LocalDirectory, bool bUseCachedList = false, const FRH_FileDirectoryDownloadDelegateBlock Delegate = FRH_FileDirectoryDownloadDelegateBlock());
 	/**
 	 * @brief Downloads all discoverable files in a remote directory to a local file directory.
 	 * @param Directory The directory of the file on the remote storage.
@@ -125,7 +125,7 @@ public:
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "File", meta = (DisplayName = "Download All Files", AutoCreateRefTerm = "Delegate"))
-	void BLUEPRINT_DownloadAllFiles(const FRH_FileApiDirectory& Directory, const FString& LocalDirectory, bool bUseCachedList, const FRH_FileDirectoryDownloadDynamicDelegate& Delegate)
+	void BLUEPRINT_DownloadAllFiles(const FRH_RemoteFileApiDirectory& Directory, const FString& LocalDirectory, bool bUseCachedList, const FRH_FileDirectoryDownloadDynamicDelegate& Delegate)
 	{
 		DownloadAllFiles(Directory, LocalDirectory, bUseCachedList, Delegate);
 	}
@@ -135,14 +135,14 @@ public:
 	 * @param Directory The directory of the file on the remote storage.
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
-	virtual void LookupFileList(const FRH_FileApiDirectory& Directory, const FRH_GenericSuccessWithErrorBlock Delegate = FRH_GenericSuccessWithErrorBlock());
+	virtual void LookupFileList(const FRH_RemoteFileApiDirectory& Directory, const FRH_GenericSuccessWithErrorBlock Delegate = FRH_GenericSuccessWithErrorBlock());
 	/**
 	 * @brief List the available remote files for an entity from the API and store results in cache
 	 * @param Directory The directory of the file on the remote storage.
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "File", meta = (DisplayName = "Lookup File List", AutoCreateRefTerm = "Delegate"))
-	void BLUEPRINT_LookupFileList(const FRH_FileApiDirectory& Directory, const FRH_GenericSuccessWithErrorDynamicDelegate& Delegate)
+	void BLUEPRINT_LookupFileList(const FRH_RemoteFileApiDirectory& Directory, const FRH_GenericSuccessWithErrorDynamicDelegate& Delegate)
 	{
 		LookupFileList(Directory, Delegate);
 	}
@@ -151,7 +151,7 @@ public:
 	 * @brief Get the entire file list cache
 	 */
 	UFUNCTION(BlueprintCallable, Category = "File", meta = (DisplayName = "List Files Async", AutoCreateRefTerm = "Delegate"))
-	const TMap<FRH_FileApiDirectory, FRHAPI_FileListResponse>& GetFileListCache() const
+	const TMap<FRH_RemoteFileApiDirectory, FRHAPI_FileListResponse>& GetFileListCache() const
 	{
 		return FileListCache;
 	}
@@ -161,7 +161,7 @@ public:
 	 * @param Directory The directory of the file on the remote storage.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "File", meta = (DisplayName = "List Files Async", AutoCreateRefTerm = "Delegate"))
-	virtual bool ListFiles(const FRH_FileApiDirectory& Directory, FRHAPI_FileListResponse& OutFileList)
+	virtual bool ListFiles(const FRH_RemoteFileApiDirectory& Directory, FRHAPI_FileListResponse& OutFileList)
 	{
 		auto* Cached = FileListCache.Find(Directory);
 		if (Cached)
@@ -174,7 +174,7 @@ public:
 
 
 protected:
-	TMap<FRH_FileApiDirectory, FRHAPI_FileListResponse> FileListCache;
+	TMap<FRH_RemoteFileApiDirectory, FRHAPI_FileListResponse> FileListCache;
 
 	/**
 	 * @brief Downloads all discoverable files in a remote directory to a local file directory.
@@ -183,7 +183,7 @@ protected:
 	 * @param bUseCachedList If true, use the cached file list instead of fetching a new one.
 	 * @param Delegate The delegate to call when the operation completes.
 	 */
-	virtual void DownloadFileList(const FRH_FileApiDirectory& Directory, const TArray<FString>& RemoteFileNames, const FString& LocalDirectory, const FRH_FileDirectoryDownloadDelegateBlock Delegate);
+	virtual void DownloadFileList(const FRH_RemoteFileApiDirectory& Directory, const TArray<FString>& RemoteFileNames, const FString& LocalDirectory, const FRH_FileDirectoryDownloadDelegateBlock Delegate);
 };
 
 /** @} */

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RallyHereIntegrationModule.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RallyHereIntegrationModule.h
@@ -72,7 +72,7 @@ namespace RH_APIs
 	FORCEINLINE static TSharedRef<RallyHereAPI::FInventoryAPI> GetInventoryAPI() { return GetAPIs().GetInventory(); }
 	FORCEINLINE static TSharedRef<RallyHereAPI::FCatalogAPI> GetCatalogAPI() { return GetAPIs().GetCatalog(); }
 	FORCEINLINE static TSharedRef<RallyHereAPI::FEventsAPI> GetEventsAPI() { return GetAPIs().GetEvents(); }
-	FORCEINLINE static TSharedRef<RallyHereAPI::FFileAPI> GetFileAPI() { return GetAPIs().GetFile(); }
+	FORCEINLINE static TSharedRef<RallyHereAPI::FRemoteFileAPI> GetRemoteFileAPI() { return GetAPIs().GetRemoteFile(); }
 }
 
 /** @} */

--- a/openapi-generator-rh-cpp-unreal/src/main/java/com/rallyhere/codegen/RhCppUe4Generator.java
+++ b/openapi-generator-rh-cpp-unreal/src/main/java/com/rallyhere/codegen/RhCppUe4Generator.java
@@ -55,6 +55,7 @@ public class RhCppUe4Generator extends AbstractCppCodegen {
     protected Set<String> systemIncludes = new HashSet<>();
     protected Set<String> prefixedModels = new HashSet<>();
     private Map<String, String> schemaKeyToModelNameCache = new HashMap<>();
+    protected Map<String, String> apiNameMapping = new HashMap<>();
 
     public RhCppUe4Generator() {
         super();
@@ -182,6 +183,9 @@ public class RhCppUe4Generator extends AbstractCppCodegen {
         importMapping = new HashMap<>();
         importMapping.put("TSet", "#include \"Containers/Set.h\"");
         importMapping.put("TVariant", "#include \"Misc/TVariant.h\"");
+
+        apiNameMapping = new HashMap<>();
+        apiNameMapping.put("File", "RemoteFile");
 
         namespaces = new HashMap<>();
         prefixedModels = new HashSet<>();
@@ -723,27 +727,24 @@ public class RhCppUe4Generator extends AbstractCppCodegen {
 
     @Override
     public String toApiName(String type) {
-        if (type.equals("File")) {
-			System.out.println("Overriding File to RemoteFile in toApiName("+type+")");
-            type = "RemoteFile";
+        if (apiNameMapping.containsKey(type)) {
+            type = apiNameMapping.get(type);
         }
         return "F" + camelize(type) + "API";
     }
 
     @Override
     public String toApiVarName(String name) {
-        if (name.equals("File")) {
-			System.out.println("Overriding File to RemoteFile in toApiVarName("+name+")");
-            name = "RemoteFile";
+        if (apiNameMapping.containsKey(name)) {
+            name = apiNameMapping.get(name);
         }
         return camelize(super.toApiVarName(name));
     }
 
     @Override
     public String toApiFilename(String name) {
-        if (name.equals("File")) {
-			System.out.println("Overriding File to RemoteFile in toApiFilename("+name+")");
-            name = "RemoteFile";
+        if (apiNameMapping.containsKey(name)) {
+            name = apiNameMapping.get(name);
         }
         return camelize(name) + "API";
     }

--- a/openapi-generator-rh-cpp-unreal/src/main/java/com/rallyhere/codegen/RhCppUe4Generator.java
+++ b/openapi-generator-rh-cpp-unreal/src/main/java/com/rallyhere/codegen/RhCppUe4Generator.java
@@ -723,11 +723,28 @@ public class RhCppUe4Generator extends AbstractCppCodegen {
 
     @Override
     public String toApiName(String type) {
+        if (type.equals("File")) {
+			System.out.println("Overriding File to RemoteFile in toApiName("+type+")");
+            type = "RemoteFile";
+        }
         return "F" + camelize(type) + "API";
     }
 
     @Override
+    public String toApiVarName(String name) {
+        if (name.equals("File")) {
+			System.out.println("Overriding File to RemoteFile in toApiVarName("+name+")");
+            name = "RemoteFile";
+        }
+        return camelize(super.toApiVarName(name));
+    }
+
+    @Override
     public String toApiFilename(String name) {
+        if (name.equals("File")) {
+			System.out.println("Overriding File to RemoteFile in toApiFilename("+name+")");
+            name = "RemoteFile";
+        }
         return camelize(name) + "API";
     }
 

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/all-api-header.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/all-api-header.mustache
@@ -42,8 +42,8 @@ public:
 
 	{{#apiInfo}}
 	{{#apis}}
-	TSharedRef<{{{classname}}}> Get{{{baseName}}}();
-	const TSharedRef<{{{classname}}}> Get{{{baseName}}}() const;
+	TSharedRef<{{{classname}}}> Get{{{classVarName}}}();
+	const TSharedRef<{{{classname}}}> Get{{{classVarName}}}() const;
 
 	{{/apis}}
 	{{/apiInfo}}
@@ -51,7 +51,7 @@ private:
 	TArray<TSharedRef<FAPI>> AllAPIs;
 	{{#apiInfo}}
 	{{#apis}}
-	TSharedRef<{{{classname}}}> {{{baseName}}};
+	TSharedRef<{{{classname}}}> {{{classVarName}}};
 	{{/apis}}
 	{{/apiInfo}}
 };

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/all-api-source.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/all-api-source.mustache
@@ -26,14 +26,14 @@ F{{unrealModuleName}}All::F{{unrealModuleName}}All()
 	: DummyValue(0)
 	{{#apiInfo}}
 	{{#apis}}
-	, {{{baseName}}}(MakeShareable(new {{{classname}}}()))
+	, {{{classVarName}}}(MakeShareable(new {{{classname}}}()))
 	{{/apis}}
 	{{/apiInfo}}
 
 {
 	{{#apiInfo}}
 	{{#apis}}
-	AllAPIs.Add({{{baseName}}});
+	AllAPIs.Add({{{classVarName}}});
 	{{/apis}}
 	{{/apiInfo}}
 }
@@ -45,14 +45,14 @@ TArray<TSharedRef<FAPI>> F{{unrealModuleName}}All::GetAllAPIs() const
 {{#apiInfo}}
 {{#apis}}
 
-TSharedRef<{{{classname}}}> F{{unrealModuleName}}All::Get{{{baseName}}}()
+TSharedRef<{{{classname}}}> F{{unrealModuleName}}All::Get{{{classVarName}}}()
 {
-	return {{{baseName}}};
+	return {{{classVarName}}};
 }
 
-const TSharedRef<{{{classname}}}> F{{unrealModuleName}}All::Get{{{baseName}}}() const
+const TSharedRef<{{{classname}}}> F{{unrealModuleName}}All::Get{{{classVarName}}}() const
 {
-	return {{{baseName}}};
+	return {{{classVarName}}};
 }
 {{/apis}}
 {{/apiInfo}}


### PR DESCRIPTION
This is to avoid FileAPI.h conflicting with windows api fileapi.h for includes in modules that access both.