### PR TITLE
Make TerminateBackfill send a DeleteBackfillRequest, to clean up backfill state immediately

### DIFF
--- a/Documentation/md/GameInstance.md
+++ b/Documentation/md/GameInstance.md
@@ -129,6 +129,7 @@ Server Bootstrapper for the Game Instance.
 `public inline virtual `[`URH_PlatformSessionSyncer`](Session.md#classURH__PlatformSessionSyncer)` * `[`GetPlatformSyncerByPlatformSessionId`](#classURH__GameInstanceServerBootstrapper_1a2c2d7c9b2b38fca62aba5ba8e642797b)`(const FUniqueNetIdRepl & PlatformSessionId) const` | Gets the platform synchronization object using the platform session id.
 `public inline const `[`FRH_BootstrappingResult`](GameInstance.md#structFRH__BootstrappingResult)` & `[`GetBootstrappingResult`](#classURH__GameInstanceServerBootstrapper_1aa61e1f51c28e5437d220362e652e4156)`() const` | Gets the bootstrapping result from this bootstrapper.
 `public inline virtual TOptional< FString > `[`GetBoundAllocationId`](#classURH__GameInstanceServerBootstrapper_1afc0a4f4f72556a0b713b0bf5f1442eb7)`() const` | Gets the allocation id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
+`public inline virtual TOptional< FString > `[`GetBoundSessionId`](#classURH__GameInstanceServerBootstrapper_1ac98b9870f8bd64413cf72f4d00d38447)`() const` | Gets the session id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
 `public inline virtual TOptional< FString > `[`GetBoundInstanceId`](#classURH__GameInstanceServerBootstrapper_1a33402e7dd26b4a226f7615749184303b)`() const` | Gets the instance id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
 `public virtual bool `[`CanAutoUploadServerFiles`](#classURH__GameInstanceServerBootstrapper_1a9cfd09c543c9435af1a994d400d5c564)`() const` | Gets the directory to use for uploading files for this bootstrapper.
 `public virtual `[`FRH_RemoteFileApiDirectory`](Common.md#structFRH__RemoteFileApiDirectory)` `[`GetAutoUploadDirectory`](#classURH__GameInstanceServerBootstrapper_1a482bf6b82fcc70879d897f4de4fbc21b)`(bool bDeveloperFile) const` | Gets the directory to use for uploading files for this bootstrapper.
@@ -388,6 +389,11 @@ Gets the bootstrapping result from this bootstrapper.
 #### `public inline virtual TOptional< FString > `[`GetBoundAllocationId`](#classURH__GameInstanceServerBootstrapper_1afc0a4f4f72556a0b713b0bf5f1442eb7)`() const` <a id="classURH__GameInstanceServerBootstrapper_1afc0a4f4f72556a0b713b0bf5f1442eb7"></a>
 
 Gets the allocation id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
+
+<br>
+#### `public inline virtual TOptional< FString > `[`GetBoundSessionId`](#classURH__GameInstanceServerBootstrapper_1ac98b9870f8bd64413cf72f4d00d38447)`() const` <a id="classURH__GameInstanceServerBootstrapper_1ac98b9870f8bd64413cf72f4d00d38447"></a>
+
+Gets the session id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
 
 <br>
 #### `public inline virtual TOptional< FString > `[`GetBoundInstanceId`](#classURH__GameInstanceServerBootstrapper_1a33402e7dd26b4a226f7615749184303b)`() const` <a id="classURH__GameInstanceServerBootstrapper_1a33402e7dd26b4a226f7615749184303b"></a>

--- a/Documentation/md/Session.md
+++ b/Documentation/md/Session.md
@@ -1014,6 +1014,7 @@ Offline Sessions are sessions the session owner is actively a member of that are
 `public virtual void `[`UpdateBrowserInfo`](#classURH__OfflineSession_1a1efa399f684ce083ce292c87717f22ad)`(bool bEnable,const TMap< FString, FString > & CustomData,const FRH_OnSessionUpdatedDelegateBlock & Delegate)` | Updates the sessions browser info.
 `public virtual void `[`UpdateInstanceHealth`](#classURH__OfflineSession_1afeab096fde1a8c507aa1bb90403b9d81)`(ERHAPI_InstanceHealthStatus HealthStatus,const FRH_GenericSuccessWithErrorBlock & Delegate)` | Update the instance health of the session.
 `public virtual void `[`AcknowledgeBackfill`](#classURH__OfflineSession_1aa0472dab20c9193181b61a87f7175db2)`(bool bEnable,const FRH_OnSessionUpdatedDelegateBlock & Delegate)` | Acknowledge backfill for the session, keeping it alive and processing updates.
+`public virtual void `[`DeleteBackfill`](#classURH__OfflineSession_1ad422457d7e902b94d431a41d20246235)`(const FRH_OnSessionUpdatedDelegateBlock & Delegate)` | Delete active backfill request for the session.
 `public virtual void `[`EmitAuditEvent`](#classURH__OfflineSession_1afeb6450ec8e2bf8912f50f7066c23c80)`(const `[`FRHAPI_CreateAuditRequest`](models/RHAPI_CreateAuditRequest.md#structFRHAPI__CreateAuditRequest)` & AuditEvent,const FRH_GenericSuccessWithErrorBlock & Delegate) const` | Emit an event to the session audit log.
 `protected void `[`ImportSessionUpdateToAllPlayers`](#classURH__OfflineSession_1a662a10e6f117bb137f9d0d65b75171a8)`(const `[`FRH_APISessionWithETag`](Session.md#structTRH__DataWithETagWrapper)` & Update)` | 
 
@@ -1166,6 +1167,14 @@ Acknowledge backfill for the session, keeping it alive and processing updates.
 * `Delegate` Callback delegate for the session being updated with backfill data
 
 <br>
+#### `public virtual void `[`DeleteBackfill`](#classURH__OfflineSession_1ad422457d7e902b94d431a41d20246235)`(const FRH_OnSessionUpdatedDelegateBlock & Delegate)` <a id="classURH__OfflineSession_1ad422457d7e902b94d431a41d20246235"></a>
+
+Delete active backfill request for the session.
+
+#### Parameters
+* `Delegate` Callback delegate for the session being updated with backfill data
+
+<br>
 #### `public virtual void `[`EmitAuditEvent`](#classURH__OfflineSession_1afeb6450ec8e2bf8912f50f7066c23c80)`(const `[`FRHAPI_CreateAuditRequest`](models/RHAPI_CreateAuditRequest.md#structFRHAPI__CreateAuditRequest)` & AuditEvent,const FRH_GenericSuccessWithErrorBlock & Delegate) const` <a id="classURH__OfflineSession_1afeb6450ec8e2bf8912f50f7066c23c80"></a>
 
 Emit an event to the session audit log.
@@ -1223,6 +1232,7 @@ Online Sessions are sessions that are synchronized from the API (and since it is
 `public virtual void `[`UpdateBrowserInfo`](#classURH__OnlineSession_1a35197db28a89b5325ef4384dca5d76c8)`(bool bEnable,const TMap< FString, FString > & CustomData,const FRH_OnSessionUpdatedDelegateBlock & Delegate)` | Updates the sessions browser info.
 `public virtual void `[`UpdateInstanceHealth`](#classURH__OnlineSession_1ac49edd6dd0b2987fc8b0dcb6f563f585)`(ERHAPI_InstanceHealthStatus HealthStatus,const FRH_GenericSuccessWithErrorBlock & Delegate)` | Update the instance health of the session.
 `public virtual void `[`AcknowledgeBackfill`](#classURH__OnlineSession_1aa087b6190e032b3d3c22c110498cd33a)`(bool bEnable,const FRH_OnSessionUpdatedDelegateBlock & Delegate)` | Acknowledge backfill for the session, keeping it alive and processing updates.
+`public virtual void `[`DeleteBackfill`](#classURH__OnlineSession_1a0e98bf0b3e205c2102364daccb7bb610)`(const FRH_OnSessionUpdatedDelegateBlock & Delegate)` | Delete active backfill request for the session.
 `public virtual void `[`EmitAuditEvent`](#classURH__OnlineSession_1a7bdff0e988bdaa1fb3e4be2d2c8b3513)`(const `[`FRHAPI_CreateAuditRequest`](models/RHAPI_CreateAuditRequest.md#structFRHAPI__CreateAuditRequest)` & AuditEvent,const FRH_GenericSuccessWithErrorBlock & Delegate) const` | Emit an event to the session audit log.
 
 #### Members
@@ -1514,6 +1524,14 @@ Acknowledge backfill for the session, keeping it alive and processing updates.
 * `Delegate` Callback delegate for the session being updated with backfill data
 
 <br>
+#### `public virtual void `[`DeleteBackfill`](#classURH__OnlineSession_1a0e98bf0b3e205c2102364daccb7bb610)`(const FRH_OnSessionUpdatedDelegateBlock & Delegate)` <a id="classURH__OnlineSession_1a0e98bf0b3e205c2102364daccb7bb610"></a>
+
+Delete active backfill request for the session.
+
+#### Parameters
+* `Delegate` Callback delegate for the session being updated with backfill data
+
+<br>
 #### `public virtual void `[`EmitAuditEvent`](#classURH__OnlineSession_1a7bdff0e988bdaa1fb3e4be2d2c8b3513)`(const `[`FRHAPI_CreateAuditRequest`](models/RHAPI_CreateAuditRequest.md#structFRHAPI__CreateAuditRequest)` & AuditEvent,const FRH_GenericSuccessWithErrorBlock & Delegate) const` <a id="classURH__OnlineSession_1a7bdff0e988bdaa1fb3e4be2d2c8b3513"></a>
 
 Emit an event to the session audit log.
@@ -1568,6 +1586,7 @@ Session Owner Interface.
 `public `[`URH_PlatformSessionSyncer`](Session.md#classURH__PlatformSessionSyncer)` * `[`GetPlatformSyncerByRHSessionId`](#classIRH__SessionOwnerInterface_1ade9ca2876030b163a060e8f417889985)`(const FString & SessionId) const` | Gets the platform synchronization object using the rally here session id.
 `public `[`URH_PlatformSessionSyncer`](Session.md#classURH__PlatformSessionSyncer)` * `[`GetPlatformSyncerByPlatformSessionId`](#classIRH__SessionOwnerInterface_1a47d9ac6d2c0326ddc79c563932a6754c)`(const FUniqueNetIdRepl & SessionId) const` | Gets the platform synchronization object using the platform session id.
 `public inline virtual TOptional< FString > `[`GetBoundAllocationId`](#classIRH__SessionOwnerInterface_1ad99ac10113649bae8b6622f6399bf5e0)`() const` | Gets the allocation id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
+`public inline virtual TOptional< FString > `[`GetBoundSessionId`](#classIRH__SessionOwnerInterface_1a38a2d02fd9a0acac8fb6211cae79fe20)`() const` | Gets the session id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
 `public inline virtual TOptional< FString > `[`GetBoundInstanceId`](#classIRH__SessionOwnerInterface_1a9c6431597880a47737b20b12c48ee697)`() const` | Gets the instance id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
 
 #### Members
@@ -1709,6 +1728,11 @@ Gets the platform synchronization object using the platform session id.
 #### `public inline virtual TOptional< FString > `[`GetBoundAllocationId`](#classIRH__SessionOwnerInterface_1ad99ac10113649bae8b6622f6399bf5e0)`() const` <a id="classIRH__SessionOwnerInterface_1ad99ac10113649bae8b6622f6399bf5e0"></a>
 
 Gets the allocation id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
+
+<br>
+#### `public inline virtual TOptional< FString > `[`GetBoundSessionId`](#classIRH__SessionOwnerInterface_1a38a2d02fd9a0acac8fb6211cae79fe20)`() const` <a id="classIRH__SessionOwnerInterface_1a38a2d02fd9a0acac8fb6211cae79fe20"></a>
+
+Gets the session id this session owner is bound to, if any. Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view.
 
 <br>
 #### `public inline virtual TOptional< FString > `[`GetBoundInstanceId`](#classIRH__SessionOwnerInterface_1a9c6431597880a47737b20b12c48ee697)`() const` <a id="classIRH__SessionOwnerInterface_1a9c6431597880a47737b20b12c48ee697"></a>

--- a/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
@@ -603,6 +603,28 @@ void FRHDTW_Session::ImGuiDisplaySession(const FRH_APISessionWithETag& SessionWr
 			ImGui::TreePop();
 		}
 
+		if (ImGui::TreeNodeEx("Backfill", RH_DefaultTreeFlags))
+		{
+			auto Backfill = Session.GetBackfillOrNull();
+			if (Backfill)
+			{
+				if (pGISessionSubsystem != nullptr)
+				{
+					ImGui::Text("Backfill Terminated: %s", pGISessionSubsystem->IsBackfillTerminated() ? "true" : "false");
+					ImGui::BeginDisabled(pGISessionSubsystem->IsBackfillTerminated());
+					if (ImGui::Button("Terminate Backfill"))
+					{
+						pGISessionSubsystem->TerminateBackfill();
+					}
+					ImGui::EndDisabled();
+				}
+				ImGuiDisplayCopyableValue(TEXT("BackfillId"), Backfill->GetBackfillId());
+				ImGuiDisplayCustomData(Backfill->GetExtensionsOrNull(), TEXT("Extensions"), TEXT("Extensions"));
+			}
+
+			ImGui::TreePop();
+		}
+
 		if (ImGui::TreeNodeEx("Browser", RH_DefaultTreeFlags))
 		{
 			auto BrowserData = Session.GetBrowserOrNull();

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
@@ -1073,6 +1073,23 @@ void URH_GameInstanceSessionSubsystem::PollBackfill(const FRH_PollCompleteFunc& 
 	}
 }
 
+void URH_GameInstanceSessionSubsystem::TerminateBackfill()
+{
+	UE_LOG(LogRHSession, Log, TEXT("[%s]"), ANSI_TO_TCHAR(__FUNCTION__));
+
+	if (!ActiveSessionState.bIsBackfillTerminated)
+	{
+		ActiveSessionState.bIsBackfillTerminated = true;
+
+		// attempt to delete the backfill request if able to
+		auto* ActiveSession = GetActiveSession();
+		if (ActiveSession != nullptr)
+		{
+			ActiveSession->DeleteBackfill();
+		}
+	}
+}
+
 ARH_OnlineBeaconHost* URH_GameInstanceSessionSubsystem::CreateBeaconHost(UWorld* pWorld, uint32 Port, bool bShutdownWorldNetDriver)
 {
 	if (pWorld == nullptr)

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
@@ -513,6 +513,24 @@ public:
 	* @brief Gets the allocation id this session owner is bound to, if any.  Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view
 	*/
 	virtual TOptional<FString> GetBoundAllocationId() const { return BootstrappingResult.AllocationInfo.AllocationId; }
+
+	/**
+	* @brief Gets the session id this session owner is bound to, if any.  Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view
+	*/
+	virtual TOptional<FString> GetBoundSessionId() const
+	{
+		if (BootstrappingResult.Session.IsSet())
+		{
+			return BootstrappingResult.Session->Data.GetSessionId();
+		}
+		else if (BootstrappingResult.AllocationInfo.SessionId.IsSet())
+		{
+			return BootstrappingResult.AllocationInfo.SessionId;
+		}
+
+		return TOptional<FString>();
+	}
+
 	/**
 	* @brief Gets the instance id this session owner is bound to, if any.  Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view
 	*/

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceSessionSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceSessionSubsystem.h
@@ -266,7 +266,7 @@ public:
 	 * @brief Shuts down backfill handling for the current session, cannot be reversed
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Session", meta = (DisplayName = "Terminate Backfill"))
-	virtual void TerminateBackfill() { ActiveSessionState.bIsBackfillTerminated = true; }
+	virtual void TerminateBackfill();
 
 	/**
 	 * @brief Set the currently active session as joinable, and do any work necessary to make it so.  Automatically called if bAutoMakeSessionsJoinableOnHostMapLoadComplete is true

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_SessionData.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_SessionData.h
@@ -914,6 +914,17 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Session|Host", meta = (DisplayName = "Update Browser Info", AutoCreateRefTerm = "CustomData,Delegate"))
 	void BLUEPRINT_AcknowledgeBackfill(bool bEnable, const FRH_OnSessionUpdatedDynamicDelegate& Delegate) { AcknowledgeBackfill(bEnable, Delegate); };
 	/**
+	* @brief Delete active backfill request for the session
+	* @param [in] Delegate Callback delegate for the session being updated with backfill data
+	*/
+	virtual void DeleteBackfill(const FRH_OnSessionUpdatedDelegateBlock& Delegate = FRH_OnSessionUpdatedDelegateBlock()) { PURE_VIRTUAL(URH_JoinedSession::DeleteBackfill, ); };
+	/**
+	* @brief Blueprint compatible version of DeleteBackfill
+	* @param [in] Delegate Callback delegate for the session being updated with new browser data.
+	*/
+	UFUNCTION(BlueprintCallable, Category = "Session|Host", meta = (DisplayName = "Update Browser Info", AutoCreateRefTerm = "CustomData,Delegate"))
+	void BLUEPRINT_DeleteBackfill(const FRH_OnSessionUpdatedDynamicDelegate& Delegate) { DeleteBackfill(Delegate); };
+	/**
 	* @brief Emit an event to the session audit log
 	* @param [in] AuditEvent The event to send
 	* @param [in] Delegate Callback delegate for the completion of the audit event
@@ -1077,6 +1088,11 @@ public:
 	* @param [in] Delegate Callback delegate for the session being updated with backfill data
 	*/
 	virtual void AcknowledgeBackfill(bool bEnable, const FRH_OnSessionUpdatedDelegateBlock& Delegate = FRH_OnSessionUpdatedDelegateBlock()) override;
+	/**
+	* @brief Delete active backfill request for the session
+	* @param [in] Delegate Callback delegate for the session being updated with backfill data
+	*/
+	virtual void DeleteBackfill(const FRH_OnSessionUpdatedDelegateBlock& Delegate = FRH_OnSessionUpdatedDelegateBlock()) override;
 	/**
 	* @brief Emit an event to the session audit log
 	* @param [in] AuditEvent The event to send
@@ -1328,6 +1344,11 @@ public:
 	*/
 	virtual void AcknowledgeBackfill(bool bEnable, const FRH_OnSessionUpdatedDelegateBlock& Delegate = FRH_OnSessionUpdatedDelegateBlock()) override;
 	/**
+	* @brief Delete active backfill request for the session
+	* @param [in] Delegate Callback delegate for the session being updated with backfill data
+	*/
+	virtual void DeleteBackfill(const FRH_OnSessionUpdatedDelegateBlock& Delegate = FRH_OnSessionUpdatedDelegateBlock()) override;
+	/**
 	* @brief Emit an event to the session audit log
 	* @param [in] AuditEvent The event to send
 	* @param [in] Delegate Callback delegate for the completion of the audit event
@@ -1467,6 +1488,10 @@ public:
 	* @brief Gets the allocation id this session owner is bound to, if any.  Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view
 	*/
 	virtual TOptional<FString> GetBoundAllocationId() const { return TOptional<FString>(); }
+	/**
+	* @brief Gets the session id this session owner is bound to, if any.  Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view
+	*/
+	virtual TOptional<FString> GetBoundSessionId() const { return TOptional<FString>(); }
 	/**
 	* @brief Gets the instance id this session owner is bound to, if any.  Needed for some specific calls to ensure they are operating on the proper object regardless of our current session view
 	*/


### PR DESCRIPTION
Add some logic for certain common server calls to use bound ids rather than the ids on the session.

Add debug tool display and terminate button for backfill