### PR TITLE
Fix active state changed broadcast for debug tool not getting triggered for netimgui only views (ex: dedicated server)

### DIFF
--- a/RallyHereDebugTool/Source/Public/RallyHereDebugTool.h
+++ b/RallyHereDebugTool/Source/Public/RallyHereDebugTool.h
@@ -91,7 +91,7 @@ public:
 	UPROPERTY(Transient)
 	TArray<TWeakObjectPtr<URH_PlayerInfo>> TargetedPlayerInfos;
 
-	bool bActive;
+	bool bActive, bWasUIActive;
 	FSimpleMulticastDelegate OnActiveStateChanged;
 	ImGuiKey ToggleUIKeyBindAsImGuiKey;
 


### PR DESCRIPTION
Active state is now evaluated on tick, and broadcasted if it changed since last tick.