### PR TITLE
Add variants for commandline params that consistently use `rh.` prefix for consistency (do not remove/deprecate old versions)

### DIFF
--- a/RallyHereIntegration/Source/RallyHereGameHostProvider/Private/RH_GameHostProviderGHA.cpp
+++ b/RallyHereIntegration/Source/RallyHereGameHostProvider/Private/RH_GameHostProviderGHA.cpp
@@ -14,7 +14,8 @@
 
 bool FRH_GameHostProviderGHA::IsAvailable()
 {
-	if (FParse::Param(FCommandLine::Get(), TEXT("ForceNoGHA")))
+	if (FParse::Param(FCommandLine::Get(), TEXT("ForceNoGHA"))
+		|| FParse::Param(FCommandLine::Get(), TEXT("rh.ForceNoGHA")))
 	{
 		return false;
 	}

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -67,8 +67,11 @@ bool URH_GameInstanceServerBootstrapper::GetCommandlineBootstrapModeOverride(ERH
 {
 	// note - mirror changes to this function below in Initialize, which provides more error handling
 	FString BootstrapCommandlineModeString;
-	if (FParse::Value(FCommandLine::Get(), TEXT("rhbootstrapmode="), BootstrapCommandlineModeString)
-		|| FParse::Value(FCommandLine::Get(), TEXT("rh.bootstrapmode="), BootstrapCommandlineModeString))
+	if (
+#if ALLOW_RH_COMMANDLINE_ARGS_WITHOUT_PREFIX
+		FParse::Value(FCommandLine::Get(), TEXT("rhbootstrapmode="), BootstrapCommandlineModeString) ||
+#endif
+		FParse::Value(FCommandLine::Get(), TEXT("rh.bootstrapmode="), BootstrapCommandlineModeString))
 	{
 		auto BootstrapCommandlineMode = RH_GETENUMFROMSTRING("/Script/RallyHereIntegration", "ERH_ServerBootstrapMode", BootstrapCommandlineModeString);
 		if (BootstrapCommandlineMode != INDEX_NONE)
@@ -143,8 +146,11 @@ void URH_GameInstanceServerBootstrapper::Initialize()
 			, *RH_GETENUMSTRING("/Script/RallyHereIntegration", "ERH_ServerBootstrapMode", BootstrapMode));
 	}
 
-	if (FParse::Value(FCommandLine::Get(), TEXT("rhmaxrecyclecount="), MaxRecycleCount)
-		|| FParse::Value(FCommandLine::Get(), TEXT("rh.maxrecyclecount="), MaxRecycleCount))
+	if (
+#if ALLOW_RH_COMMANDLINE_ARGS_WITHOUT_PREFIX
+		FParse::Value(FCommandLine::Get(), TEXT("rhmaxrecyclecount="), MaxRecycleCount) ||
+#endif
+		FParse::Value(FCommandLine::Get(), TEXT("rh.maxrecyclecount="), MaxRecycleCount))
 	{
 		UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] - Max recycle count overridden by commandline to %d"), ANSI_TO_TCHAR(__FUNCTION__), MaxRecycleCount);
 	}
@@ -818,8 +824,11 @@ void URH_GameInstanceServerBootstrapper::OnReservationComplete(bool bSuccess)
 	bool bStartedHelper = false;
 	FString SessionType = DefaultAutoCreateSessionType;
 
-	if (FParse::Value(FCommandLine::Get(), TEXT("rhsessiontype="), SessionType) 
-		|| FParse::Value(FCommandLine::Get(), TEXT("rh.sessiontype="), SessionType))
+	if (
+#if ALLOW_RH_COMMANDLINE_ARGS_WITHOUT_PREFIX
+		FParse::Value(FCommandLine::Get(), TEXT("rhsessiontype="), SessionType) ||
+#endif
+		FParse::Value(FCommandLine::Get(), TEXT("rh.sessiontype="), SessionType))
 	{
 		UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] - default session type overridden by commandline to %s"), ANSI_TO_TCHAR(__FUNCTION__), *SessionType);
 	}

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -67,7 +67,8 @@ bool URH_GameInstanceServerBootstrapper::GetCommandlineBootstrapModeOverride(ERH
 {
 	// note - mirror changes to this function below in Initialize, which provides more error handling
 	FString BootstrapCommandlineModeString;
-	if (FParse::Value(FCommandLine::Get(), TEXT("rhbootstrapmode="), BootstrapCommandlineModeString))
+	if (FParse::Value(FCommandLine::Get(), TEXT("rhbootstrapmode="), BootstrapCommandlineModeString)
+		|| FParse::Value(FCommandLine::Get(), TEXT("rh.bootstrapmode="), BootstrapCommandlineModeString))
 	{
 		auto BootstrapCommandlineMode = RH_GETENUMFROMSTRING("/Script/RallyHereIntegration", "ERH_ServerBootstrapMode", BootstrapCommandlineModeString);
 		if (BootstrapCommandlineMode != INDEX_NONE)
@@ -142,7 +143,8 @@ void URH_GameInstanceServerBootstrapper::Initialize()
 			, *RH_GETENUMSTRING("/Script/RallyHereIntegration", "ERH_ServerBootstrapMode", BootstrapMode));
 	}
 
-	if (FParse::Value(FCommandLine::Get(), TEXT("rhmaxrecyclecount="), MaxRecycleCount))
+	if (FParse::Value(FCommandLine::Get(), TEXT("rhmaxrecyclecount="), MaxRecycleCount)
+		|| FParse::Value(FCommandLine::Get(), TEXT("rh.maxrecyclecount="), MaxRecycleCount))
 	{
 		UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] - Max recycle count overridden by commandline to %d"), ANSI_TO_TCHAR(__FUNCTION__), MaxRecycleCount);
 	}
@@ -813,7 +815,8 @@ void URH_GameInstanceServerBootstrapper::OnReservationComplete(bool bSuccess)
 	bool bStartedHelper = false;
 	FString SessionType = DefaultAutoCreateSessionType;
 
-	if (FParse::Value(FCommandLine::Get(), TEXT("rhsessiontype="), SessionType))
+	if (FParse::Value(FCommandLine::Get(), TEXT("rhsessiontype="), SessionType) 
+		|| FParse::Value(FCommandLine::Get(), TEXT("rh.sessiontype="), SessionType))
 	{
 		UE_LOG(LogRallyHereIntegration, Log, TEXT("[%s] - default session type overridden by commandline to %s"), ANSI_TO_TCHAR(__FUNCTION__), *SessionType);
 	}

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
@@ -20,14 +20,18 @@ URH_IntegrationSettings::URH_IntegrationSettings(const FObjectInitializer& Objec
 	SettingName.Add(TEXT(CommandLineBase "Internal"));	/* internal variant (lowest priority, for automation defaults from build/package) */ \
 
 	// set the default internal commandline keys for each setting
+#if ALLOW_RH_COMMANDLINE_ARGS_WITHOUT_PREFIX
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(BaseURLCommandLineKeysInternal, "RallyHereURL");
-	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(BaseURLCommandLineKeysInternal, "rh.url");
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(EnvironmentCommandLineKeysInternal, "RallyHereEnv");
-	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(EnvironmentCommandLineKeysInternal, "rh.env");
-	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(DefaultOSSCommandLineKeysInternal, "OSS");
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(ClientIdCommandLineKeysInternal, "RallyHereClientId");
-	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(ClientIdCommandLineKeysInternal, "rh.clientid");
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(ClientSecretCommandLineKeysInternal, "RallyHereClientSecret");
+	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(DefaultOSSCommandLineKeysInternal, "OSS");
+#endif
+
+	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(BaseURLCommandLineKeysInternal, "rh.url");
+	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(EnvironmentCommandLineKeysInternal, "rh.env");
+	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(DefaultOSSCommandLineKeysInternal, "rh.OSS");
+	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(ClientIdCommandLineKeysInternal, "rh.clientid");
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(ClientSecretCommandLineKeysInternal, "rh.clientsecret");
 
 	bAutomaticallyPollConfigurationData = true;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_IntegrationSettings.cpp
@@ -21,10 +21,14 @@ URH_IntegrationSettings::URH_IntegrationSettings(const FObjectInitializer& Objec
 
 	// set the default internal commandline keys for each setting
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(BaseURLCommandLineKeysInternal, "RallyHereURL");
+	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(BaseURLCommandLineKeysInternal, "rh.url");
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(EnvironmentCommandLineKeysInternal, "RallyHereEnv");
+	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(EnvironmentCommandLineKeysInternal, "rh.env");
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(DefaultOSSCommandLineKeysInternal, "OSS");
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(ClientIdCommandLineKeysInternal, "RallyHereClientId");
+	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(ClientIdCommandLineKeysInternal, "rh.clientid");
 	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(ClientSecretCommandLineKeysInternal, "RallyHereClientSecret");
+	SET_DEFAULT_INTERNAL_COMMANDLINE_KEYS(ClientSecretCommandLineKeysInternal, "rh.clientsecret");
 
 	bAutomaticallyPollConfigurationData = true;
 	bAutomaticallyApplyHotfixData = false;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
@@ -32,6 +32,10 @@ extern FString GRallyHereIntegrationIni;
 #define RH_BELOW_ENGINE_VERSION(Major, Minor)  (ENGINE_MAJOR_VERSION < (Major) || (ENGINE_MAJOR_VERSION == (Major) && ENGINE_MINOR_VERSION < (Minor)))
 #define RH_FROM_ENGINE_VERSION(Major, Minor)   !RH_BELOW_ENGINE_VERSION(Major, Minor)
 
+#ifndef ALLOW_RH_COMMANDLINE_ARGS_WITHOUT_PREFIX
+	#define ALLOW_RH_COMMANDLINE_ARGS_WITHOUT_PREFIX 1
+#endif
+
 #ifndef RH_GETENUMSTRING
 #if RH_FROM_ENGINE_VERSION(5, 1)
 #define RH_GETENUMSTRING(package, etype, evalue) ( (FindObject<UEnum>(nullptr, TEXT(package) TEXT(".") TEXT(etype), true) != nullptr) ? FindObject<UEnum>(nullptr, TEXT(package) TEXT(".") TEXT(etype), true)->GetNameStringByValue((int32)evalue) : FString(TEXT("Invalid - are you sure enum uses UENUM() macro?")) )


### PR DESCRIPTION
This PR adds properly prefixed commandline arguments using the `rh.` prefix, and paves the way for deprecating the old arguments.

This affects the following commandline arguments:
`-ForceNoGHA` -> `-rh.ForceNoGHA`
`-rhbootstrapmode` -> `-rh.bootstrapmode`
`-rhmaxrecyclecount` -> `rh.maxrecyclecount`
`-rhsessiontype` -> `rh.sessiontype`

For commandline arguments using the priority family keys, the priority specifies have changed to the following (from lowest to highest priority):
`-RallyHere<arg>Internal` -> `-rh.<arg>Internal`
`-RallyHere<arg>` -> `-rh.<arg>`
`-RallyHere<arg>X` -> `-rh.<arg>X`

For example, using the URL argument family:
`-rallyhereurlInternal` -> `-rh.urlInternal`
`-rallyhereurl` -> `-rh.url`
`-rallyhereurlX` -> `-rh.urlX`