### PR TITLE
Rework bootstrapper logic for shutdown to have multiple cleanup handlers for different cases

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
@@ -307,6 +307,12 @@ void URH_GameInstanceSessionSubsystem::SetActiveSession(URH_JoinedSession* Joine
 
 				MatchSubsystem->UpdateMatch(MatchSubsystem->GetActiveMatchId(), UpdateRequest);
 
+				// Trigger the bootstrapper log file upload if configured
+				if (GetGameInstanceSubsystem()->GetServerBootstrapper() != nullptr)
+				{
+					GetGameInstanceSubsystem()->GetServerBootstrapper()->ConditionalAutoUploadLogFile();
+				}
+
 				// clear out the active match id
 				MatchSubsystem->SetActiveMatchId(FString());
 			}


### PR DESCRIPTION
The cleanup handlers should make sure the instance and any other engine state is cleaned up before calling the common Cleanup() function which will flush out the bootstrapper state and potentially recycle.

Moved log auto upload to be done before session and match are fully cleared out, rather than potentially failing to upload due to the upload specifiers being lost.