### PR TITLE
Add thread safety around submitting requests, and ensure all requests are processed on game thread

### DIFF
--- a/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIHttpRequester.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIHttpRequester.cpp
@@ -9,7 +9,7 @@ TSharedPtr<FRallyHereAPIHttpRequester> FRallyHereAPIHttpRequester::Singleton = n
 FRallyHereAPIHttpRequester::FRallyHereAPIHttpRequester()
 {
 	MaxSimultaneousRequests = 15;
-	PendingRequestCount = 0;
+	InFlightRequestCount = 0;
 }
 
 void FRallyHereAPIHttpRequester::FlushRequestQueue(bool bIsExiting)
@@ -27,6 +27,9 @@ void FRallyHereAPIHttpRequester::TryExecuteNextRequest(bool bIsExiting)
 	{
 		return;
 	}
+
+	// this function is intended only to be run on the main game thread, as it can internally trigger delegates
+	ensure(IsInGameThread());
 
 	FScopeLock RequestQueueLock(&RequestQueueLockCS);
 
@@ -46,7 +49,8 @@ void FRallyHereAPIHttpRequester::TryExecuteNextRequest(bool bIsExiting)
 					Request->HttpRequest->OnProcessRequestComplete().BindSP(AsShared(), &FRallyHereAPIHttpRequester::OnResponse, Request->ResponseDelegate);
 					if (Request->HttpRequest->ProcessRequest())
 					{
-						PendingRequestCount++;
+						// increment pending request count, so we can keep track of how many requests are currently in-flight
+						InFlightRequestCount++;
 					}
 
 					// do not fire callback if exiting
@@ -56,7 +60,7 @@ void FRallyHereAPIHttpRequester::TryExecuteNextRequest(bool bIsExiting)
 						Request->API->OnRequestStarted().Broadcast(Request->Metadata, Request->HttpRequest);
 					}
 
-					if (MaxSimultaneousRequests > 0 && PendingRequestCount >= MaxSimultaneousRequests)
+					if (MaxSimultaneousRequests > 0 && InFlightRequestCount >= MaxSimultaneousRequests)
 					{
 						break;
 					}
@@ -68,7 +72,7 @@ void FRallyHereAPIHttpRequester::TryExecuteNextRequest(bool bIsExiting)
 				}
 			}
 
-			if (MaxSimultaneousRequests > 0 && PendingRequestCount >= MaxSimultaneousRequests)
+			if (MaxSimultaneousRequests > 0 && InFlightRequestCount >= MaxSimultaneousRequests)
 			{
 				return;
 			}
@@ -78,10 +82,12 @@ void FRallyHereAPIHttpRequester::TryExecuteNextRequest(bool bIsExiting)
 
 void FRallyHereAPIHttpRequester::OnResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FHttpRequestCompleteDelegate ResponseDelegate)
 {
-	PendingRequestCount--;
+	// execute the response delegate
 	ResponseDelegate.Execute(HttpRequest, HttpResponse, bSucceeded);
-	// Whenever we get a request response try to execute new requests if we have any.
-	QueueNextRequestCall();
+
+	// decrement pending request count
+	FScopeLock RequestQueueLock(&RequestQueueLockCS);
+	InFlightRequestCount--;
 }
 
 void FRallyHereAPIHttpRequester::EnqueueHttpRequest(TSharedPtr<struct FRallyHereAPIHttpRequestData> RequestData)
@@ -98,29 +104,11 @@ void FRallyHereAPIHttpRequester::EnqueueHttpRequest(TSharedPtr<struct FRallyHere
 	{
 		HttpRequestQueue.Add(RequestData->Priority, {RequestData});
 	}
-	// Whenever we get a new request, try to execute requests
-	QueueNextRequestCall();
 }
 
-void FRallyHereAPIHttpRequester::QueueNextRequestCall()
+void FRallyHereAPIHttpRequester::Tick(float DeltaTime)
 {
-	if (GIsEditor && !GIsPlayInEditorWorld)
-	{
-		TryExecuteNextRequest();
-	}
-	else
-	{
-		// Delay until next frame
-		FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateLambda([](float dts)
-		{
-			auto* Requester = FRallyHereAPIHttpRequester::Get();
-			if (Requester != nullptr)
-			{
-				Requester->TryExecuteNextRequest();
-			}
-			return false;
-		}), 0.0f);
-	}
+	TryExecuteNextRequest();
 }
 
 }

--- a/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIHttpRequester.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIHttpRequester.cpp
@@ -28,6 +28,8 @@ void FRallyHereAPIHttpRequester::TryExecuteNextRequest(bool bIsExiting)
 		return;
 	}
 
+	FScopeLock RequestQueueLock(&RequestQueueLockCS);
+
 	TArray<int32> Keys;
 
 	if (HttpRequestQueue.GetKeys(Keys) > 0)
@@ -85,6 +87,8 @@ void FRallyHereAPIHttpRequester::OnResponse(FHttpRequestPtr HttpRequest, FHttpRe
 void FRallyHereAPIHttpRequester::EnqueueHttpRequest(TSharedPtr<struct FRallyHereAPIHttpRequestData> RequestData)
 {
 	RequestData->Metadata.QueuedTimestamp = FDateTime::Now();
+
+	FScopeLock RequestQueueLock(&RequestQueueLockCS);
 
 	if (auto findItem = HttpRequestQueue.Find(RequestData->Priority))
 	{

--- a/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIHttpRequester.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/RallyHereAPIHttpRequester.cpp
@@ -23,15 +23,15 @@ void FRallyHereAPIHttpRequester::FlushRequestQueue(bool bIsExiting)
 
 void FRallyHereAPIHttpRequester::TryExecuteNextRequest(bool bIsExiting)
 {
-	if (!CanExecuteRequest())
-	{
-		return;
-	}
-
 	// this function is intended only to be run on the main game thread, as it can internally trigger delegates
 	ensure(IsInGameThread());
 
 	FScopeLock RequestQueueLock(&RequestQueueLockCS);
+
+	if (HttpRequestQueue.IsEmpty() || (MaxSimultaneousRequests > 0 && InFlightRequestCount > MaxSimultaneousRequests))
+	{
+		return;
+	}
 
 	TArray<int32> Keys;
 

--- a/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIHttpRequester.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIHttpRequester.h
@@ -95,14 +95,13 @@ public:
 	// FTickableGameObject interface
 	/** @brief Scan request queue to determine if any need to be kicked off. */
 	virtual void Tick(float DeltaTime);
-	/** @brief Poll controller is always tickable. */
+	/** @brief Only tick if there is work in the queue. */
 	virtual bool IsTickable() const { return HttpRequestQueue.Num() > 0; }
-	/** Gets the poll controller stat Id. */
+	/** Gets the stat Id. */
 	virtual TStatId GetStatId() const { RETURN_QUICK_DECLARE_CYCLE_STAT(FRallyHereAPIHttpRequester, STATGROUP_TaskGraphTasks); }
 
 private:
 	void TryExecuteNextRequest(bool bIsExiting = false);
-	bool CanExecuteRequest() const { return HttpRequestQueue.Num() > 0 && (MaxSimultaneousRequests == 0 || InFlightRequestCount < MaxSimultaneousRequests); }
 
 	static TSharedPtr<FRallyHereAPIHttpRequester> Singleton;
 

--- a/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIHttpRequester.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIHttpRequester.h
@@ -10,6 +10,9 @@
 #include "CoreMinimal.h"
 #include "RallyHereAPIBaseModel.h"
 #include "HttpModule.h"
+#include "Stats/Stats2.h"
+#include "Async/TaskGraphInterfaces.h"
+#include "Tickable.h"
 
 DECLARE_STATS_GROUP(TEXT("RallyHereAPI"), STATGROUP_RallyHereAPI, STATCAT_Advanced);
 
@@ -47,7 +50,7 @@ public:
 
 typedef TMap<int32, TArray<TSharedPtr<struct FRallyHereAPIHttpRequestData>, TInlineAllocator<10>>> HttpRequestMap;
 
-class RALLYHEREAPI_API FRallyHereAPIHttpRequester : public TSharedFromThis<FRallyHereAPIHttpRequester>
+class RALLYHEREAPI_API FRallyHereAPIHttpRequester : public TSharedFromThis<FRallyHereAPIHttpRequester>, public FTickableGameObject
 {
 public:
 	FRallyHereAPIHttpRequester();
@@ -86,20 +89,27 @@ public:
 
 	void OnResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FHttpRequestCompleteDelegate ResponseDelegate);
 
-	// Immediately flushes all requests in the queue (useful in cases where the http system may be shutting down soon)
+	// Immediately flushes all requests in the queue (useful in cases where the http system may be shutting down soon).  Only safe on the main game thread.
 	void FlushRequestQueue(bool bIsExiting = false);
 
+	// FTickableGameObject interface
+	/** @brief Scan request queue to determine if any need to be kicked off. */
+	virtual void Tick(float DeltaTime);
+	/** @brief Poll controller is always tickable. */
+	virtual bool IsTickable() const { return HttpRequestQueue.Num() > 0; }
+	/** Gets the poll controller stat Id. */
+	virtual TStatId GetStatId() const { RETURN_QUICK_DECLARE_CYCLE_STAT(FRallyHereAPIHttpRequester, STATGROUP_TaskGraphTasks); }
+
 private:
-	void QueueNextRequestCall();
 	void TryExecuteNextRequest(bool bIsExiting = false);
-	bool CanExecuteRequest() const { return HttpRequestQueue.Num() > 0 && (MaxSimultaneousRequests == 0 || PendingRequestCount < MaxSimultaneousRequests); }
+	bool CanExecuteRequest() const { return HttpRequestQueue.Num() > 0 && (MaxSimultaneousRequests == 0 || InFlightRequestCount < MaxSimultaneousRequests); }
 
 	static TSharedPtr<FRallyHereAPIHttpRequester> Singleton;
 
 	HttpRequestMap HttpRequestQueue;
 
 	int32 MaxSimultaneousRequests;
-	int32 PendingRequestCount;
+	int32 InFlightRequestCount;
 
 	FCriticalSection RequestQueueLockCS;
 };

--- a/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIHttpRequester.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIHttpRequester.h
@@ -100,6 +100,8 @@ private:
 
 	int32 MaxSimultaneousRequests;
 	int32 PendingRequestCount;
+
+	FCriticalSection RequestQueueLockCS;
 };
 
 }

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_AutomatedTests.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_AutomatedTests.cpp
@@ -1,0 +1,131 @@
+// Copyright 2022-2023 RallyHere Interactive
+// SPDX-License-Identifier: Apache-2.0
+
+//////////////////////////////////////////////////////////////////////////////////
+// Automation tests - General Automation Tests, not associated with any specific subsystem
+//////////////////////////////////////////////////////////////////////////////////
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "RH_Common.h"
+#include "RH_Integration.h"
+#include "TimerManager.h"
+
+#include "RH_AutomationTests.h"
+#include "RH_IntegrationSettings.h"
+
+#include "RH_LocalPlayerSubsystem.h"
+#include "RH_GameInstanceSessionSubsystem.h"
+#include "RH_PlayerInfoSubsystem.h"
+
+#include "TimeAPI.h"
+
+BEGIN_DEFINE_SPEC(FRH_RequesterThreading, "RHAutomation.HttpRequester.Threading", EAutomationTestFlags::ClientContext | /*EAutomationTestFlags::RequiresUser |*/ EAutomationTestFlags::ProductFilter | EAutomationTestFlags::MediumPriority)
+
+END_DEFINE_SPEC(FRH_RequesterThreading)
+
+void FRH_RequesterThreading::Define()
+{
+	Describe("Http Requester Threading", [this]()
+		{
+			LatentIt("should create a bunch of time requests in worker threads, then run them in parallel", [this](const FDoneDelegate& Done)
+				{					
+					const int32 NumTasks = 256;
+
+					struct FRunningTasksTracker
+					{
+						TAtomic<int32> RunningTasks, TasksStarted, SuccessfulTasks;
+
+						FAutomationTestBase* Test = nullptr;
+						FDoneDelegate AsyncDone;
+
+						void TaskStarted()
+						{
+							++RunningTasks;
+							++TasksStarted;
+						}
+
+						void TaskEnded(bool bSucesss)
+						{
+							auto NewTaskCount = --RunningTasks;
+							if (bSucesss)
+							{
+								++SuccessfulTasks;
+							}
+
+							if (NewTaskCount == 0)
+							{
+								Test->TestEqual(TEXT("All Tasks Successful"), SuccessfulTasks.Load(), TasksStarted.Load());
+
+								AsyncDone.Execute();
+							}
+						}
+
+						FRunningTasksTracker(FAutomationTestBase* InTest, const FDoneDelegate& InDoneDelegate)
+							: RunningTasks(0), TasksStarted(0), SuccessfulTasks(0)
+							, Test(InTest)
+							, AsyncDone(InDoneDelegate)
+						{
+						}
+					};
+
+					struct FTimeRequestTask : public FNonAbandonableTask
+					{
+						FTimeRequestTask(TSharedRef<FRunningTasksTracker> InTasksTracker)
+							: TasksTracker(InTasksTracker)
+						{
+						}
+
+						/** Returns the stat id for this task */
+						FORCEINLINE TStatId GetStatId() const
+						{
+							RETURN_QUICK_DECLARE_CYCLE_STAT(FTimeRequestTask, STATGROUP_ThreadPoolAsyncTasks);
+						}
+
+						void DoWork()
+						{
+							TasksTracker->TaskStarted();
+
+							typedef RallyHereAPI::Traits_GetUtcTime BaseType;
+
+							BaseType::Request Request;
+
+							auto Helper = MakeShared<FRH_SimpleQueryHelper<BaseType>>(
+								BaseType::Delegate(),
+								FRH_GenericSuccessWithErrorDelegate::CreateLambda([this](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
+									{
+										TasksTracker->TaskEnded(bSuccess);
+									}),
+								GetDefault<URH_IntegrationSettings>()->FetchAppSettingsPriority);
+
+							Helper->Start(RH_APIs::GetAPIs().GetTime(), Request);
+						}
+
+						TSharedRef<FRunningTasksTracker> TasksTracker;
+					};
+
+					// Create a bunch of tasks
+					TSharedRef<FRunningTasksTracker> RunningTasksTracker = MakeShared<FRunningTasksTracker>(this, Done);
+					TArray<FAsyncTask<FTimeRequestTask>*> Tasks;
+					Tasks.Reserve(NumTasks);
+
+					for (int32 i = 0; i < NumTasks; ++i)
+					{
+						Tasks.Add(new FAsyncTask<FTimeRequestTask>(RunningTasksTracker));
+					}
+
+					// Start all the tasks
+					for (auto Task : Tasks)
+					{
+						Task->StartBackgroundTask();
+					}
+				});
+		});
+}
+
+#endif
+
+
+

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-header.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-header.mustache
@@ -109,14 +109,13 @@ public:
 	// FTickableGameObject interface
 	/** @brief Scan request queue to determine if any need to be kicked off. */
 	virtual void Tick(float DeltaTime);
-	/** @brief Poll controller is always tickable. */
+	/** @brief Only tick if there is work in the queue. */
 	virtual bool IsTickable() const { return HttpRequestQueue.Num() > 0; }
-	/** Gets the poll controller stat Id. */
+	/** Gets the stat Id. */
 	virtual TStatId GetStatId() const { RETURN_QUICK_DECLARE_CYCLE_STAT(F{{unrealModuleName}}HttpRequester, STATGROUP_TaskGraphTasks); }
 
 private:
 	void TryExecuteNextRequest(bool bIsExiting = false);
-	bool CanExecuteRequest() const { return HttpRequestQueue.Num() > 0 && (MaxSimultaneousRequests == 0 || InFlightRequestCount < MaxSimultaneousRequests); }
 
 	static TSharedPtr<F{{unrealModuleName}}HttpRequester> Singleton;
 

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-header.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-header.mustache
@@ -114,6 +114,8 @@ private:
 
 	int32 MaxSimultaneousRequests;
 	int32 PendingRequestCount;
+
+	FCriticalSection RequestQueueLockCS;
 };
 
 {{#cppNamespaceDeclarations}}

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-header.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-header.mustache
@@ -20,6 +20,9 @@ limitations under the License.
 #include "CoreMinimal.h"
 #include "{{unrealModuleName}}BaseModel.h"
 #include "HttpModule.h"
+#include "Stats/Stats2.h"
+#include "Async/TaskGraphInterfaces.h"
+#include "Tickable.h"
 {{#imports}}{{{import}}}
 {{/imports}}
 
@@ -61,7 +64,7 @@ public:
 
 typedef TMap<int32, TArray<TSharedPtr<struct F{{unrealModuleName}}HttpRequestData>, TInlineAllocator<10>>> HttpRequestMap;
 
-class {{dllapi}} F{{unrealModuleName}}HttpRequester : public TSharedFromThis<F{{unrealModuleName}}HttpRequester>
+class {{dllapi}} F{{unrealModuleName}}HttpRequester : public TSharedFromThis<F{{unrealModuleName}}HttpRequester>, public FTickableGameObject
 {
 public:
 	F{{unrealModuleName}}HttpRequester();
@@ -100,20 +103,27 @@ public:
 
 	void OnResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FHttpRequestCompleteDelegate ResponseDelegate);
 
-	// Immediately flushes all requests in the queue (useful in cases where the http system may be shutting down soon)
+	// Immediately flushes all requests in the queue (useful in cases where the http system may be shutting down soon).  Only safe on the main game thread.
 	void FlushRequestQueue(bool bIsExiting = false);
 
+	// FTickableGameObject interface
+	/** @brief Scan request queue to determine if any need to be kicked off. */
+	virtual void Tick(float DeltaTime);
+	/** @brief Poll controller is always tickable. */
+	virtual bool IsTickable() const { return HttpRequestQueue.Num() > 0; }
+	/** Gets the poll controller stat Id. */
+	virtual TStatId GetStatId() const { RETURN_QUICK_DECLARE_CYCLE_STAT(F{{unrealModuleName}}HttpRequester, STATGROUP_TaskGraphTasks); }
+
 private:
-	void QueueNextRequestCall();
 	void TryExecuteNextRequest(bool bIsExiting = false);
-	bool CanExecuteRequest() const { return HttpRequestQueue.Num() > 0 && (MaxSimultaneousRequests == 0 || PendingRequestCount < MaxSimultaneousRequests); }
+	bool CanExecuteRequest() const { return HttpRequestQueue.Num() > 0 && (MaxSimultaneousRequests == 0 || InFlightRequestCount < MaxSimultaneousRequests); }
 
 	static TSharedPtr<F{{unrealModuleName}}HttpRequester> Singleton;
 
 	HttpRequestMap HttpRequestQueue;
 
 	int32 MaxSimultaneousRequests;
-	int32 PendingRequestCount;
+	int32 InFlightRequestCount;
 
 	FCriticalSection RequestQueueLockCS;
 };

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-source.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-source.mustache
@@ -41,15 +41,15 @@ void F{{unrealModuleName}}HttpRequester::FlushRequestQueue(bool bIsExiting)
 
 void F{{unrealModuleName}}HttpRequester::TryExecuteNextRequest(bool bIsExiting)
 {
-	if (!CanExecuteRequest())
-	{
-		return;
-	}
-
 	// this function is intended only to be run on the main game thread, as it can internally trigger delegates
 	ensure(IsInGameThread());
 
 	FScopeLock RequestQueueLock(&RequestQueueLockCS);
+
+	if (HttpRequestQueue.IsEmpty() || (MaxSimultaneousRequests > 0 && InFlightRequestCount > MaxSimultaneousRequests))
+	{
+		return;
+	}
 
 	TArray<int32> Keys;
 

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-source.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-source.mustache
@@ -46,6 +46,8 @@ void F{{unrealModuleName}}HttpRequester::TryExecuteNextRequest(bool bIsExiting)
 		return;
 	}
 
+	FScopeLock RequestQueueLock(&RequestQueueLockCS);
+
 	TArray<int32> Keys;
 
 	if (HttpRequestQueue.GetKeys(Keys) > 0)
@@ -103,6 +105,8 @@ void F{{unrealModuleName}}HttpRequester::OnResponse(FHttpRequestPtr HttpRequest,
 void F{{unrealModuleName}}HttpRequester::EnqueueHttpRequest(TSharedPtr<struct F{{unrealModuleName}}HttpRequestData> RequestData)
 {
 	RequestData->Metadata.QueuedTimestamp = FDateTime::Now();
+
+	FScopeLock RequestQueueLock(&RequestQueueLockCS);
 
 	if (auto findItem = HttpRequestQueue.Find(RequestData->Priority))
 	{

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-source.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/http-requester-source.mustache
@@ -27,7 +27,7 @@ TSharedPtr<F{{unrealModuleName}}HttpRequester> F{{unrealModuleName}}HttpRequeste
 F{{unrealModuleName}}HttpRequester::F{{unrealModuleName}}HttpRequester()
 {
 	MaxSimultaneousRequests = 15;
-	PendingRequestCount = 0;
+	InFlightRequestCount = 0;
 }
 
 void F{{unrealModuleName}}HttpRequester::FlushRequestQueue(bool bIsExiting)
@@ -45,6 +45,9 @@ void F{{unrealModuleName}}HttpRequester::TryExecuteNextRequest(bool bIsExiting)
 	{
 		return;
 	}
+
+	// this function is intended only to be run on the main game thread, as it can internally trigger delegates
+	ensure(IsInGameThread());
 
 	FScopeLock RequestQueueLock(&RequestQueueLockCS);
 
@@ -64,7 +67,8 @@ void F{{unrealModuleName}}HttpRequester::TryExecuteNextRequest(bool bIsExiting)
 					Request->HttpRequest->OnProcessRequestComplete().BindSP(AsShared(), &F{{unrealModuleName}}HttpRequester::OnResponse, Request->ResponseDelegate);
 					if (Request->HttpRequest->ProcessRequest())
 					{
-						PendingRequestCount++;
+						// increment pending request count, so we can keep track of how many requests are currently in-flight
+						InFlightRequestCount++;
 					}
 
 					// do not fire callback if exiting
@@ -74,7 +78,7 @@ void F{{unrealModuleName}}HttpRequester::TryExecuteNextRequest(bool bIsExiting)
 						Request->API->OnRequestStarted().Broadcast(Request->Metadata, Request->HttpRequest);
 					}
 
-					if (MaxSimultaneousRequests > 0 && PendingRequestCount >= MaxSimultaneousRequests)
+					if (MaxSimultaneousRequests > 0 && InFlightRequestCount >= MaxSimultaneousRequests)
 					{
 						break;
 					}
@@ -86,7 +90,7 @@ void F{{unrealModuleName}}HttpRequester::TryExecuteNextRequest(bool bIsExiting)
 				}
 			}
 
-			if (MaxSimultaneousRequests > 0 && PendingRequestCount >= MaxSimultaneousRequests)
+			if (MaxSimultaneousRequests > 0 && InFlightRequestCount >= MaxSimultaneousRequests)
 			{
 				return;
 			}
@@ -96,10 +100,12 @@ void F{{unrealModuleName}}HttpRequester::TryExecuteNextRequest(bool bIsExiting)
 
 void F{{unrealModuleName}}HttpRequester::OnResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FHttpRequestCompleteDelegate ResponseDelegate)
 {
-	PendingRequestCount--;
+	// execute the response delegate
 	ResponseDelegate.Execute(HttpRequest, HttpResponse, bSucceeded);
-	// Whenever we get a request response try to execute new requests if we have any.
-	QueueNextRequestCall();
+
+	// decrement pending request count
+	FScopeLock RequestQueueLock(&RequestQueueLockCS);
+	InFlightRequestCount--;
 }
 
 void F{{unrealModuleName}}HttpRequester::EnqueueHttpRequest(TSharedPtr<struct F{{unrealModuleName}}HttpRequestData> RequestData)
@@ -116,29 +122,11 @@ void F{{unrealModuleName}}HttpRequester::EnqueueHttpRequest(TSharedPtr<struct F{
 	{
 		HttpRequestQueue.Add(RequestData->Priority, {RequestData});
 	}
-	// Whenever we get a new request, try to execute requests
-	QueueNextRequestCall();
 }
 
-void F{{unrealModuleName}}HttpRequester::QueueNextRequestCall()
+void F{{unrealModuleName}}HttpRequester::Tick(float DeltaTime)
 {
-	if (GIsEditor && !GIsPlayInEditorWorld)
-	{
-		TryExecuteNextRequest();
-	}
-	else
-	{
-		// Delay until next frame
-		FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateLambda([](float dts)
-		{
-			auto* Requester = F{{unrealModuleName}}HttpRequester::Get();
-			if (Requester != nullptr)
-			{
-				Requester->TryExecuteNextRequest();
-			}
-			return false;
-		}), 0.0f);
-	}
+	TryExecuteNextRequest();
 }
 
 {{#cppNamespaceDeclarations}}


### PR DESCRIPTION
This adds a critical section around the requests being added to the requester, and also defers all http kickoffs to game thread (this ensures all callbacks are executed on main thread).

Additionally, add an automated to test that slams the requester with requests from multiple worker tasks.