### PR TITLE
Deprecate multiset interface for settings in favor of single set/get/delete

### DIFF
--- a/Documentation/md/PlayerInfo.md
+++ b/Documentation/md/PlayerInfo.md
@@ -495,7 +495,10 @@ Stores and fetchs all the information about a given player.
 `public virtual bool `[`GetLastKnownDisplayName`](#classURH__PlayerInfo_1ac983a0c5b8e6e3df2f216b94b7fd249c)`(FString & OutDisplayName,ERHAPI_Platform PreferredPlatformType) const` | Gets the last known display name for the player.
 `public virtual void `[`GetLinkedPlatformInfo`](#classURH__PlayerInfo_1a3cdeb290b652d16aa44e5c6e1e4ae44c)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlatformsBlock & Delegate)` | Gets the players linked platforms via API call.
 `public virtual void `[`GetPlayerSettings`](#classURH__PlayerInfo_1a6f0c823fb1c55bcf4ab2482092cfad2a)`(const FString & SettingTypeId,const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerSettingsBlock & Delegate)` | Gets the players settings information for a given type.
+`public virtual void `[`GetPlayerSettingsForKeys`](#classURH__PlayerInfo_1ae6eeb698d34e599d1ec6f32b04c182eb)`(const FString & SettingTypeId,const TArray< FString > & Keys,const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerSettingsBlock & Delegate)` | Gets the players settings information for a given type, restricted to a list of keys.
 `public virtual void `[`SetPlayerSettings`](#classURH__PlayerInfo_1ab8f4ba97458cb8df50445db8547bbc4c)`(const FString & SettingTypeId,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` & SettingsData,const FRH_PlayerInfoSetPlayerSettingsBlock & Delegate)` | Sets the players settings information for a given type.
+`public virtual PRAGMA_ENABLE_DEPRECATION_WARNINGS void `[`SetPlayerSetting`](#classURH__PlayerInfo_1a8106539300d99b5056aacdd6474c4ef9)`(const FString & SettingTypeId,const FString & Key,const `[`FRHAPI_SetSinglePlayerSettingRequest`](models/RHAPI_SetSinglePlayerSettingRequest.md#structFRHAPI__SetSinglePlayerSettingRequest)` & Document,const FRH_PlayerInfoSetPlayerSettingBlock & Delegate)` | Sets the players settings information for a given type.
+`public virtual void `[`DeletePlayerSetting`](#classURH__PlayerInfo_1a75f8a74087a97a33e9bc3dc296abbf0c)`(const FString & SettingTypeId,const FString & Key,const FRH_GenericSuccessWithErrorBlock & Delegate)` | Deletes a players setting for a given type.
 `public virtual void `[`GetPlayerRankings`](#classURH__PlayerInfo_1a03b9bc9136601f64145bec69a5e9e9e8)`(const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` | Gets the players ranking information for a given type.
 `public virtual void `[`UpdatePlayerRanking`](#classURH__PlayerInfo_1afd6c1206e990ca64b9fa56a54e085094)`(const FString & RankId,const `[`FRHAPI_PlayerRankUpdateRequest`](models/RHAPI_PlayerRankUpdateRequest.md#structFRHAPI__PlayerRankUpdateRequest)` & RankData,const FRH_PlayerInfoGetPlayerRankingsBlock & Delegate)` | Sets the players settings information for a given type.
 `public FAuthContextPtr `[`GetAuthContext`](#classURH__PlayerInfo_1a38aa7a072a97be36bc623a9cda702cdf)`() const` | Gets the local Auth Context for making API calls.
@@ -518,13 +521,15 @@ Stores and fetchs all the information about a given player.
 `protected virtual void `[`OnGetPlayerLinkedPlatformsForLastKnownDisplayNameResponse`](#classURH__PlayerInfo_1a49e19ae4082f15e22b2062c1cb78deb0)`(bool bSuccess,const TArray< `[`URH_PlayerPlatformInfo`](PlayerInfo.md#classURH__PlayerPlatformInfo)` * > & Platforms,ERHAPI_Platform PreferredPlatformType,const FRH_PlayerInfoGetDisplayNameBlock Delegate,const class `[`URH_LocalPlayerSubsystem`](LocalPlayer.md#classURH__LocalPlayerSubsystem)` * LocalPlayerSubsystem)` | Handles the response to a Get Linked Platforms For Last Known Display Name call.
 `protected virtual void `[`OnDisplayNameSanitized`](#classURH__PlayerInfo_1afe5a34e86382c3f78767f2d72e3819fd)`(bool bSuccess,const FString & SanitizedMessage,ERHAPI_Platform PreferredPlatformType,const FRH_PlayerInfoGetDisplayNameBlock Delegate)` | Handles the response to sanitizing the players display name.
 `protected virtual void `[`OnGetPlayerLinkedPlatformsResponse`](#classURH__PlayerInfo_1ada74501b2e422f1fcf8f76825d74cc58)`(const GetPlatforms::Response & Response,const FRH_PlayerInfoGetPlatformsBlock Delegate)` | Handles the response to a Get Linked Platforms call.
-`protected virtual void `[`OnGetPlayerSettingsResponse`](#classURH__PlayerInfo_1a115f584e7b7b210193fd9e302abbd3ed)`(const GetSettings::Response & Response,const FRH_PlayerInfoGetPlayerSettingsBlock Delegate,const FString SettingTypeId)` | Handles the response to a Get Player Settings call.
+`protected virtual void `[`OnGetPlayerSettingsResponse`](#classURH__PlayerInfo_1aaa4c9a884f7291607e315db74776867a)`(const GetSettings::Response & Response,const FRH_PlayerInfoGetPlayerSettingsBlock Delegate,const FString SettingTypeId,TOptional< TArray< FString >> PartialKeys)` | Handles the response to a Get Player Settings call.
 `protected virtual void `[`OnSetPlayerSettingsResponse`](#classURH__PlayerInfo_1a6f59dae05d5371b867091b180280f091)`(const SetSettings::Response & Response,const FRH_PlayerInfoSetPlayerSettingsBlock Delegate,const FString SettingTypeId,const FString SettingKey,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` SettingsData)` | Handles the response to a Set Player Settings call.
 `protected virtual void `[`OnGetPlayerRankingsResponse`](#classURH__PlayerInfo_1a53c355b2f85273d37008d685c3cc113c)`(const GetRankings::Response & Response,const FRH_PlayerInfoGetPlayerRankingsBlock Delegate)` | Handles the response to a Get Player Rankings call.
 `protected virtual void `[`OnUpdatePlayerRankingResponse`](#classURH__PlayerInfo_1a214672d0d5001ec24098b5414b0fc35d)`(const UpdateRanking::Response & Response,const FRH_PlayerInfoGetPlayerRankingsBlock Delegate)` | Handles the response to a Update Player Ranking call.
 `typedef `[`GetPlatforms`](#classURH__PlayerInfo_1a88c3597ebf7f47399d936f5a96d344f6) | 
 `typedef `[`GetSettings`](#classURH__PlayerInfo_1ae425cac3ffa853a48c03df8caa2c8ca9) | 
 `typedef `[`SetSettings`](#classURH__PlayerInfo_1af84cca7ca91da85ceec6caf73af9db11) | 
+`typedef `[`SetSetting`](#classURH__PlayerInfo_1a0bef921ed67ed064ea96aebadcb7b412) | 
+`typedef `[`DeleteSetting`](#classURH__PlayerInfo_1af46fb4796e432727cf5a5041ec673a61) | 
 `typedef `[`GetRankings`](#classURH__PlayerInfo_1ae1180995c5f25cb946b6f47e44886c46) | 
 `typedef `[`UpdateRanking`](#classURH__PlayerInfo_1a0dde72a36a43d91264f8dc89aafcd5de) | 
 
@@ -700,6 +705,19 @@ Gets the players settings information for a given type.
 
 * `Delegate` Callback with the players settings for the given type.
 
+#### `public virtual void `[`GetPlayerSettingsForKeys`](#classURH__PlayerInfo_1ae6eeb698d34e599d1ec6f32b04c182eb)`(const FString & SettingTypeId,const TArray< FString > & Keys,const FTimespan & StaleThreshold,bool bForceRefresh,const FRH_PlayerInfoGetPlayerSettingsBlock & Delegate)` <a id="classURH__PlayerInfo_1ae6eeb698d34e599d1ec6f32b04c182eb"></a>
+
+Gets the players settings information for a given type, restricted to a list of keys.
+
+#### Parameters
+* `SettingTypeId` The setting type requested. 
+
+* `StaleThreshold` If set, will force a re-request of the players information if the last updated time was more than the threshold. 
+
+* `bForceRefresh` If true, will force a re-request of the players information. 
+
+* `Delegate` Callback with the players settings for the given type.
+
 #### `public virtual void `[`SetPlayerSettings`](#classURH__PlayerInfo_1ab8f4ba97458cb8df50445db8547bbc4c)`(const FString & SettingTypeId,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` & SettingsData,const FRH_PlayerInfoSetPlayerSettingsBlock & Delegate)` <a id="classURH__PlayerInfo_1ab8f4ba97458cb8df50445db8547bbc4c"></a>
 
 Sets the players settings information for a given type.
@@ -708,6 +726,30 @@ Sets the players settings information for a given type.
 * `SettingTypeId` The setting type to update. 
 
 * `SettingsData` Data to be stored into the players settings. 
+
+* `Delegate` Callback when the operation is complete with success information.
+
+#### `public virtual PRAGMA_ENABLE_DEPRECATION_WARNINGS void `[`SetPlayerSetting`](#classURH__PlayerInfo_1a8106539300d99b5056aacdd6474c4ef9)`(const FString & SettingTypeId,const FString & Key,const `[`FRHAPI_SetSinglePlayerSettingRequest`](models/RHAPI_SetSinglePlayerSettingRequest.md#structFRHAPI__SetSinglePlayerSettingRequest)` & Document,const FRH_PlayerInfoSetPlayerSettingBlock & Delegate)` <a id="classURH__PlayerInfo_1a8106539300d99b5056aacdd6474c4ef9"></a>
+
+Sets the players settings information for a given type.
+
+#### Parameters
+* `SettingTypeId` The setting type to update. 
+
+* `Key` The setting key being updated within the type. 
+
+* `Document` Json Document to be stored. 
+
+* `Delegate` Callback when the operation is complete with success information.
+
+#### `public virtual void `[`DeletePlayerSetting`](#classURH__PlayerInfo_1a75f8a74087a97a33e9bc3dc296abbf0c)`(const FString & SettingTypeId,const FString & Key,const FRH_GenericSuccessWithErrorBlock & Delegate)` <a id="classURH__PlayerInfo_1a75f8a74087a97a33e9bc3dc296abbf0c"></a>
+
+Deletes a players setting for a given type.
+
+#### Parameters
+* `SettingTypeId` The setting type to update. 
+
+* `Key` The setting key being updated within the type. 
 
 * `Delegate` Callback when the operation is complete with success information.
 
@@ -844,7 +886,7 @@ Handles the response to a Get Linked Platforms call.
 
 * `Delegate` Delegate passed in for original call to respond to when call completes.
 
-#### `protected virtual void `[`OnGetPlayerSettingsResponse`](#classURH__PlayerInfo_1a115f584e7b7b210193fd9e302abbd3ed)`(const GetSettings::Response & Response,const FRH_PlayerInfoGetPlayerSettingsBlock Delegate,const FString SettingTypeId)` <a id="classURH__PlayerInfo_1a115f584e7b7b210193fd9e302abbd3ed"></a>
+#### `protected virtual void `[`OnGetPlayerSettingsResponse`](#classURH__PlayerInfo_1aaa4c9a884f7291607e315db74776867a)`(const GetSettings::Response & Response,const FRH_PlayerInfoGetPlayerSettingsBlock Delegate,const FString SettingTypeId,TOptional< TArray< FString >> PartialKeys)` <a id="classURH__PlayerInfo_1aaa4c9a884f7291607e315db74776867a"></a>
 
 Handles the response to a Get Player Settings call.
 
@@ -853,7 +895,9 @@ Handles the response to a Get Player Settings call.
 
 * `Delegate` Delegate passed in for original call to respond to when call completes. 
 
-* `SettinyTypeId` The type of settings that were requested.
+* `SettingTypeId` The type of settings that were requested. 
+
+* `PartialKeys` If Specified, only the keys in this list were requested.
 
 #### `protected virtual void `[`OnSetPlayerSettingsResponse`](#classURH__PlayerInfo_1a6f59dae05d5371b867091b180280f091)`(const SetSettings::Response & Response,const FRH_PlayerInfoSetPlayerSettingsBlock Delegate,const FString SettingTypeId,const FString SettingKey,`[`FRH_PlayerSettingsDataWrapper`](undefined.md#structFRH__PlayerSettingsDataWrapper)` SettingsData)` <a id="classURH__PlayerInfo_1a6f59dae05d5371b867091b180280f091"></a>
 
@@ -893,6 +937,10 @@ Handles the response to a Update Player Ranking call.
 #### `typedef `[`GetSettings`](#classURH__PlayerInfo_1ae425cac3ffa853a48c03df8caa2c8ca9) <a id="classURH__PlayerInfo_1ae425cac3ffa853a48c03df8caa2c8ca9"></a>
 
 #### `typedef `[`SetSettings`](#classURH__PlayerInfo_1af84cca7ca91da85ceec6caf73af9db11) <a id="classURH__PlayerInfo_1af84cca7ca91da85ceec6caf73af9db11"></a>
+
+#### `typedef `[`SetSetting`](#classURH__PlayerInfo_1a0bef921ed67ed064ea96aebadcb7b412) <a id="classURH__PlayerInfo_1a0bef921ed67ed064ea96aebadcb7b412"></a>
+
+#### `typedef `[`DeleteSetting`](#classURH__PlayerInfo_1af46fb4796e432727cf5a5041ec673a61) <a id="classURH__PlayerInfo_1af46fb4796e432727cf5a5041ec673a61"></a>
 
 #### `typedef `[`GetRankings`](#classURH__PlayerInfo_1ae1180995c5f25cb946b6f47e44886c46) <a id="classURH__PlayerInfo_1ae1180995c5f25cb946b6f47e44886c46"></a>
 

--- a/RallyHereDebugTool/Source/Public/RHDTW_PlayerSettings.h
+++ b/RallyHereDebugTool/Source/Public/RHDTW_PlayerSettings.h
@@ -19,12 +19,13 @@ struct FRHDTW_PlayerSettings : public FRH_DebugToolWindow
 	void DoSettingsTypes();
 
 	int32 SettingVersionNum;
-	TArray<ANSICHAR> SettingsIdInput;
-	TArray<ANSICHAR> ModifySettingsIdInput;
-	TArray<ANSICHAR> ModifySettingsKeyInput;
-	TArray<ANSICHAR> ModifySettingsJsonInput;
+	FString SettingsIdInput;
+	FString ModifySettingsIdInput;
+	FString ModifySettingsKeyInput;
+	FString ModifySettingsJsonInput;
 
 private:
-	FString SetPlayerSettingsActionResult;
-	void HandleSetPlayerSettingsResponse(bool bSuccess, const FRH_PlayerSettingsDataWrapper& Response, FGuid PlayerUuid);
+	FString SetPlayerSettingActionResult;
+	void HandleSetPlayerSettingResponse(bool bSuccess, const FRH_PlayerSettingsDataWrapper& Response, const FRH_ErrorInfo& ErrorInfo, FGuid PlayerUuid);
+	void HandleDeletePlayerSettingResponse(bool bSuccess, const FRH_ErrorInfo& ErrorInfo, FGuid PlayerUuid);
 };

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlayerInfoSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlayerInfoSubsystem.cpp
@@ -468,6 +468,7 @@ void URH_PlayerInfo::OnGetPlayerLinkedPlatformsResponse(const GetPlatforms::Resp
 	Delegate.ExecuteIfBound(Response.IsSuccessful(), Infos);
 }
 
+
 void URH_PlayerInfo::GetPlayerSettings(const FString& SettingTypeId, const FTimespan& StaleThreshold /* = FTimespan()*/, bool bForceRefresh /*= false*/, const FRH_PlayerInfoGetPlayerSettingsBlock& Delegate /*= FRH_PlayerInfoGetPlayerSettingsBlock()*/)
 {
 	if (auto FoundLastRequested = LastRequestSettingsByTypeId.Find(SettingTypeId))
@@ -494,28 +495,113 @@ void URH_PlayerInfo::GetPlayerSettings(const FString& SettingTypeId, const FTime
 	Request.PlayerUuid = RHPlayerUuid;
 	Request.SettingTypeId = SettingTypeId;
 	Request.AuthContext = GetAuthContext();
-	if (!GetSettings::DoCall(RH_APIs::GetSettingsAPI(), Request, GetSettings::Delegate::CreateUObject(this, &URH_PlayerInfo::OnGetPlayerSettingsResponse, Delegate, SettingTypeId), GetDefault<URH_IntegrationSettings>()->SettingsGetPriority))
+	if (!GetSettings::DoCall(RH_APIs::GetSettingsAPI(), Request, GetSettings::Delegate::CreateUObject(this, &URH_PlayerInfo::OnGetPlayerSettingsResponse, Delegate, SettingTypeId, TOptional<TArray<FString>>()), GetDefault<URH_IntegrationSettings>()->SettingsGetPriority))
 	{
 		FRH_PlayerSettingsDataWrapper EmptyWrapper;
 		Delegate.ExecuteIfBound(false, EmptyWrapper);
 	}
 }
 
-void URH_PlayerInfo::OnGetPlayerSettingsResponse(const GetSettings::Response& Response, FRH_PlayerInfoGetPlayerSettingsBlock Delegate, const FString SettingTypeId)
+
+void URH_PlayerInfo::GetPlayerSettingsForKeys(const FString& SettingTypeId, const TArray<FString>& Keys, const FTimespan& StaleThreshold /* = FTimespan()*/, bool bForceRefresh /*= false*/, const FRH_PlayerInfoGetPlayerSettingsBlock& Delegate /*= FRH_PlayerInfoGetPlayerSettingsBlock()*/)
+{
+	if (auto FoundLastRequested = LastRequestSettingsByTypeId.Find(SettingTypeId))
+	{
+		FDateTime Now = FDateTime::UtcNow();
+		if (FoundLastRequested->GetTicks() != 0 && !bForceRefresh)
+		{
+			// check if we are in the stale threshold, or if it is not set (in which case, always prefer the cache)
+			if ((*FoundLastRequested) + StaleThreshold < Now || StaleThreshold.IsZero())
+			{
+				// for specific settings requests, we need to check if we have all the keys we need
+				if (auto FoundSettings = PlayerSettingsByTypeId.Find(SettingTypeId))
+				{
+					bool bHasAllKeys = true;
+					FRH_PlayerSettingsDataWrapper ReturnedSettings;
+					for (const auto& Key : Keys)
+					{
+						const auto FoundSetting = FoundSettings->Content.Find(Key);
+						if (FoundSetting)
+						{
+							ReturnedSettings.Content.Add(Key, *FoundSetting);
+						}
+						else
+						{
+							bHasAllKeys = false;
+							break;
+						}
+					}
+
+					if (FoundSettings->Content.Num() > 0)
+					{
+						Delegate.ExecuteIfBound(true, ReturnedSettings);
+						return;
+					}
+				}
+			}
+		}
+	}
+
+	auto Request = GetSettings::Request();
+	Request.PlayerUuid = RHPlayerUuid;
+	Request.SettingTypeId = SettingTypeId;
+	if (Keys.Num() > 0)
+	{
+		Request.Key = Keys;
+	}
+	Request.AuthContext = GetAuthContext();
+	if (!GetSettings::DoCall(RH_APIs::GetSettingsAPI(), Request, GetSettings::Delegate::CreateUObject(this, &URH_PlayerInfo::OnGetPlayerSettingsResponse, Delegate, SettingTypeId, Request.Key), GetDefault<URH_IntegrationSettings>()->SettingsGetPriority))
+	{
+		FRH_PlayerSettingsDataWrapper EmptyWrapper;
+		Delegate.ExecuteIfBound(false, EmptyWrapper);
+	}
+}
+
+void URH_PlayerInfo::OnGetPlayerSettingsResponse(const GetSettings::Response& Response, FRH_PlayerInfoGetPlayerSettingsBlock Delegate, const FString SettingTypeId, TOptional<TArray<FString>> OptionalKeys)
 {
 	FRH_PlayerSettingsDataWrapper ResponseWrapper;
-	ResponseWrapper.Content.Empty();
 
 	if (Response.IsSuccessful())
 	{
+		const bool bIsPartial = OptionalKeys.IsSet();
+
 		for (const auto& Pair : Response.Content)
 		{
 			ResponseWrapper.Content.Add(Pair);
 		}
+
+		if (bIsPartial)
+		{
+			// Update the local cache with the new settings (certain legacy setting types can affect multiple keys, so process all entries in the list)
+			auto SettingWrapper = PlayerSettingsByTypeId.FindOrAdd(SettingTypeId);
+
+			for (const auto& Key : OptionalKeys.GetValue())
+			{
+				const auto Value = ResponseWrapper.Content.Find(Key);
+				// if value exists, add it to the local cache, otherwise remove it
+				if (Value != nullptr)
+				{
+					SettingWrapper.Content.Add(Key, *Value);
+				}
+				else
+				{
+					SettingWrapper.Content.Remove(Key);
+				}
+			}
+		}
+		else
+		{
+			// Update the local cache with the new settings (can just use the response wrapper, as it contains a full and complete set)
+			PlayerSettingsByTypeId.Add(SettingTypeId, ResponseWrapper);
+
+			// Update the last request time only if not a partial request, since partial requests are not guaranteed to have all the keys
+			if (!bIsPartial)
+			{
+				LastRequestSettingsByTypeId.Add(SettingTypeId, FDateTime::UtcNow());
+			}
+		}
 	}
 
-	PlayerSettingsByTypeId.Add(SettingTypeId, ResponseWrapper);
-	LastRequestSettingsByTypeId.Add(SettingTypeId, FDateTime::UtcNow());
 	Delegate.ExecuteIfBound(Response.IsSuccessful(), ResponseWrapper);
 }
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInfoSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInfoSubsystem.h
@@ -813,7 +813,19 @@ public:
 	virtual void GetPlayerSettings(const FString& SettingTypeId, const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, const FRH_PlayerInfoGetPlayerSettingsBlock& Delegate = FRH_PlayerInfoGetPlayerSettingsBlock());
 	/** @private */
 	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Get Player Settings", AutoCreateRefTerm = "Delegate"))
-	void BLUEPRINT_GetPlayerSettings(const FString& SettingTypeId, const FTimespan& StaleThreshold, bool bForceRefresh, const FRH_PlayerInfoGetPlayerSettingsDynamicDelegate& Delegate) { GetPlayerSettings(SettingTypeId, StaleThreshold, bForceRefresh, Delegate); }
+	void BLUEPRINT_GetPlayerSettings(const FString& SettingTypeId, const FTimespan& StaleThreshold, bool bForceRefresh, const FRH_PlayerInfoGetPlayerSettingsDynamicDelegate& Delegate) { GetPlayerSettingsForKeys(SettingTypeId, TArray<FString>(), StaleThreshold, bForceRefresh, Delegate); }
+
+	/**
+	* @brief Gets the players settings information for a given type, restricted to a list of keys.
+	* @param [in] SettingTypeId The setting type requested.
+	* @param [in] StaleThreshold If set, will force a re-request of the players information if the last updated time was more than the threshold.
+	* @param [in] bForceRefresh If true, will force a re-request of the players information.
+	* @param [in] Delegate Callback with the players settings for the given type.
+	*/
+	virtual void GetPlayerSettingsForKeys(const FString& SettingTypeId, const TArray<FString>& Keys, const FTimespan& StaleThreshold = FTimespan(), bool bForceRefresh = false, const FRH_PlayerInfoGetPlayerSettingsBlock& Delegate = FRH_PlayerInfoGetPlayerSettingsBlock());
+	/** @private */
+	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Get Player Settings", AutoCreateRefTerm = "Delegate"))
+	void BLUEPRINT_GetPlayerSettingsForKeys(const FString& SettingTypeId, const TArray<FString>& Keys, const FTimespan& StaleThreshold, bool bForceRefresh, const FRH_PlayerInfoGetPlayerSettingsDynamicDelegate& Delegate) { GetPlayerSettingsForKeys(SettingTypeId, Keys, StaleThreshold, bForceRefresh, Delegate); }
 
 	/**
 	* @brief Sets the players settings information for a given type.
@@ -984,9 +996,10 @@ protected:
 	 * @brief Handles the response to a Get Player Settings call.
 	 * @param [in] Resp Response given for the call
 	 * @param [in] Delegate Delegate passed in for original call to respond to when call completes.
-	 * @param [in] SettinyTypeId The type of settings that were requested.
+	 * @param [in] SettingTypeId The type of settings that were requested.
+	 * @param [in] PartialKeys If Specified, only the keys in this list were requested.
 	 */
-	virtual void OnGetPlayerSettingsResponse(const GetSettings::Response& Response, const FRH_PlayerInfoGetPlayerSettingsBlock Delegate, const FString SettingTypeId);
+	virtual void OnGetPlayerSettingsResponse(const GetSettings::Response& Response, const FRH_PlayerInfoGetPlayerSettingsBlock Delegate, const FString SettingTypeId, TOptional<TArray<FString>> PartialKeys);
 	/**
 	 * @brief Handles the response to a Set Player Settings call.
 	 * @param [in] Resp Response given for the call

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInfoSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInfoSubsystem.h
@@ -54,6 +54,11 @@ DECLARE_DELEGATE_TwoParams(FRH_PlayerInfoSetPlayerSettingsDelegate, bool, const 
 DECLARE_RH_DELEGATE_BLOCK(FRH_PlayerInfoSetPlayerSettingsBlock, FRH_PlayerInfoSetPlayerSettingsDelegate, FRH_PlayerInfoSetPlayerSettingsDynamicDelegate, bool, const FRH_PlayerSettingsDataWrapper&);
 
 UDELEGATE()
+DECLARE_DYNAMIC_DELEGATE_ThreeParams(FRH_PlayerInfoSetPlayerSettingDynamicDelegate, bool, bSuccess, const FRH_PlayerSettingsDataWrapper&, UpdatedSettings, const FRH_ErrorInfo&, ErrorInfo);
+DECLARE_DELEGATE_ThreeParams(FRH_PlayerInfoSetPlayerSettingDelegate, bool, const FRH_PlayerSettingsDataWrapper&, const FRH_ErrorInfo& ErrorInfo);
+DECLARE_RH_DELEGATE_BLOCK(FRH_PlayerInfoSetPlayerSettingBlock, FRH_PlayerInfoSetPlayerSettingDelegate, FRH_PlayerInfoSetPlayerSettingDynamicDelegate, bool, const FRH_PlayerSettingsDataWrapper&, const FRH_ErrorInfo&);
+
+UDELEGATE()
 DECLARE_DYNAMIC_DELEGATE_TwoParams(FRH_PlayerInfoGetDisplayNameDynamicDelegate, bool, bSuccess, const FString&, DisplayName);
 DECLARE_DELEGATE_TwoParams(FRH_PlayerInfoGetDisplayNameDelegate, bool, const FString&);
 DECLARE_RH_DELEGATE_BLOCK(FRH_PlayerInfoGetDisplayNameBlock, FRH_PlayerInfoGetDisplayNameDelegate, FRH_PlayerInfoGetDisplayNameDynamicDelegate, bool, const FString&)
@@ -642,7 +647,10 @@ class RALLYHEREINTEGRATION_API URH_PlayerInfo : public UObject
 public:
 	typedef RallyHereAPI::Traits_GetPlayerLinks GetPlatforms;
 	typedef RallyHereAPI::Traits_GetAllPlayerUuidSettingsForSettingType GetSettings;
+	UE_DEPRECATED(5.0, "Use of the functions to set multiple settings at once has been deprecated, please use the single setting version instead.")
 	typedef RallyHereAPI::Traits_SetSinglePlayerUuidSetting SetSettings;
+	typedef RallyHereAPI::Traits_SetSinglePlayerUuidSetting SetSetting;
+	typedef RallyHereAPI::Traits_DeleteSinglePlayerUuidSetting DeleteSetting;
 	typedef RallyHereAPI::Traits_GetAllPlayerUuidRanksV2 GetRankings;
 	typedef RallyHereAPI::Traits_UpdatePlayerUuidRankV2 UpdateRanking;
 
@@ -813,10 +821,36 @@ public:
 	* @param [in] SettingsData Data to be stored into the players settings.
 	* @param [in] Delegate Callback when the operation is complete with success information.
 	*/
+	UE_DEPRECATED(5.0, "Setting multiple settings in one call is deprecated, use SetPlayerSetting instead.")
 	virtual void SetPlayerSettings(const FString& SettingTypeId, FRH_PlayerSettingsDataWrapper& SettingsData, const FRH_PlayerInfoSetPlayerSettingsBlock& Delegate = FRH_PlayerInfoSetPlayerSettingsBlock());
+	PRAGMA_DISABLE_DEPRECATION_WARNINGS
 	/** @private */
-	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Set Player Settings", AutoCreateRefTerm = "Delegate"))
+	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DeprecatedFunction, DeprecationMessage = "Setting multiple settings in one call is deprecated, use SetPlayerSetting instead.", DisplayName = "Set Player Settings", AutoCreateRefTerm = "Delegate"))
 	void BLUEPRINT_SetPlayerSettings(const FString& SettingTypeId, FRH_PlayerSettingsDataWrapper SettingsData, const FRH_PlayerInfoSetPlayerSettingsDynamicDelegate& Delegate) { SetPlayerSettings(SettingTypeId, SettingsData, Delegate); }
+	PRAGMA_ENABLE_DEPRECATION_WARNINGS
+
+	/**
+	* @brief Sets the players settings information for a given type.
+	* @param [in] SettingTypeId The setting type to update.
+	* @param [in] Key The setting key being updated within the type.
+	* @param [in] Document Json Document to be stored.
+	* @param [in] Delegate Callback when the operation is complete with success information.
+	*/
+	virtual void SetPlayerSetting(const FString& SettingTypeId, const FString& Key, const FRHAPI_SetSinglePlayerSettingRequest& Document, const FRH_PlayerInfoSetPlayerSettingBlock& Delegate = FRH_PlayerInfoSetPlayerSettingBlock());
+	/** @private */
+	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Set Player Setting", AutoCreateRefTerm = "Delegate"))
+	void BLUEPRINT_SetPlayerSetting(const FString& SettingTypeId, const FString& Key, const FRHAPI_SetSinglePlayerSettingRequest& Document, const FRH_PlayerInfoSetPlayerSettingDynamicDelegate& Delegate) { SetPlayerSetting(SettingTypeId, Key, Document, Delegate); }
+
+	/**
+	* @brief Deletes a players setting for a given type.
+	* @param [in] SettingTypeId The setting type to update.
+	* @param [in] Key The setting key being updated within the type.
+	* @param [in] Delegate Callback when the operation is complete with success information.
+	*/
+	virtual void DeletePlayerSetting(const FString& SettingTypeId, const FString& Key, const FRH_GenericSuccessWithErrorBlock& Delegate = FRH_GenericSuccessWithErrorBlock());
+	/** @private */
+	UFUNCTION(BlueprintCallable, Category = "Player Info Subsystem | Player Info", meta = (DisplayName = "Set Player Setting", AutoCreateRefTerm = "Delegate"))
+	void BLUEPRINT_DeletePlayerSetting(const FString& SettingTypeId, const FString& Key, const FRH_GenericSuccessWithErrorDynamicDelegate& Delegate) { DeletePlayerSetting(SettingTypeId, Key, Delegate); }
 
 	/**
 	* @brief Gets the players ranking information for a given type.


### PR DESCRIPTION
This simplifies the interface and also reduces likelihood of bad behavior since the function that sets multiple at a time implies setting a list of many at once, where the preferred behavior is to set a single value of a document of many settings (within reason).