### PR TITLE
BREAKING CHANGE - Add variant of IsReadyToJoinInstance() that takes a string for the reason it failed.  

### DIFF
--- a/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Session.cpp
@@ -441,9 +441,16 @@ void FRHDTW_Session::ImGuiDisplaySession(const FRH_APISessionWithETag& SessionWr
 						}
 						else
 						{
-							ImGui::BeginDisabled(!pGISessionSubsystem->IsReadyToJoinInstance(RHJoinedSession, false));
+							FString ErrorLog;
+							bool bCanActivate = pGISessionSubsystem->IsReadyToJoinInstanceWithReason(RHJoinedSession, ErrorLog);
+							ImGui::BeginDisabled(!bCanActivate);
 							if (ImGui::Button("Activate"))
 							{
+								if (!bCanActivate && ErrorLog.Len() > 0)
+								{
+									ImGui::SameLine();
+									ImGui::Text("(%s)", TCHAR_TO_UTF8(*ErrorLog));
+								}
 								pGISessionSubsystem->SyncToSession(RHJoinedSession);
 							}
 							ImGui::EndDisabled();

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
@@ -1169,10 +1169,21 @@ void URH_GameInstanceSessionSubsystem::SyncToSession(URH_JoinedSession* SessionI
 
 bool URH_GameInstanceSessionSubsystem::IsReadyToJoinInstance(const URH_JoinedSession* Session, bool bLog) const
 {
+	FString LogLine;
+	bool bIsReady = IsReadyToJoinInstanceWithReason(Session, LogLine);
+	if (bLog && LogLine.Len() > 0)
+	{
+		UE_LOG(LogRallyHereIntegration, Verbose, TEXT("[%s] - %s"), ANSI_TO_TCHAR(__FUNCTION__), *LogLine);
+	}
+	return bIsReady;
+}
+
+bool URH_GameInstanceSessionSubsystem::IsReadyToJoinInstanceWithReason(const URH_JoinedSession* Session, FString& Error) const
+{
 	if (Session->IsActive())
 	{
 		// session is already active, cannot join it
-		UE_CLOG(bLog, LogRallyHereIntegration, Verbose, TEXT("[%s] - Session already active"), ANSI_TO_TCHAR(__FUNCTION__));
+		Error = FString::Printf(TEXT("[%s] - Session already active"), ANSI_TO_TCHAR(__FUNCTION__));
 		return false;
 	}
 
@@ -1180,7 +1191,7 @@ bool URH_GameInstanceSessionSubsystem::IsReadyToJoinInstance(const URH_JoinedSes
 	if (Instance == nullptr)
 	{
 		// session has no instance to join
-		UE_CLOG(bLog, LogRallyHereIntegration, Verbose, TEXT("[%s] - Session has no instance"), ANSI_TO_TCHAR(__FUNCTION__));
+		Error = FString::Printf(TEXT("[%s] - Session has no instance"), ANSI_TO_TCHAR(__FUNCTION__));
 		return false;
 	}
 
@@ -1197,7 +1208,7 @@ bool URH_GameInstanceSessionSubsystem::IsReadyToJoinInstance(const URH_JoinedSes
 			// someone is not in the session
 			FGuid playerId = FGuid();
 			RH_GetPlayerIdFromLocalPlayer(LP, &playerId);
-			UE_CLOG(bLog, LogRallyHereIntegration, Verbose, TEXT("[%s] - player %s not in session"), ANSI_TO_TCHAR(__FUNCTION__), *playerId.ToString());
+			Error = FString::Printf(TEXT("[%s] - player %s not in session"), ANSI_TO_TCHAR(__FUNCTION__), *playerId.ToString());
 			return false;
 		}
 	}
@@ -1212,7 +1223,7 @@ bool URH_GameInstanceSessionSubsystem::IsReadyToJoinInstance(const URH_JoinedSes
 		}
 		else
 		{
-			UE_CLOG(bLog, LogRallyHereIntegration, Verbose, TEXT("[%s] - Locally hosted session cannot generated host URL"), ANSI_TO_TCHAR(__FUNCTION__));
+			Error = FString::Printf(TEXT("[%s] - Locally hosted session cannot generated host URL"), ANSI_TO_TCHAR(__FUNCTION__));
 			return false;
 		}
 	}
@@ -1221,14 +1232,14 @@ bool URH_GameInstanceSessionSubsystem::IsReadyToJoinInstance(const URH_JoinedSes
 		// specifically call out joinable state errors
 		if (Instance->GetJoinStatus() != ERHAPI_InstanceJoinableStatus::Joinable)
 		{
-			UE_CLOG(bLog, LogRallyHereIntegration, Verbose, TEXT("[%s] - Instance is not in joinable state"), ANSI_TO_TCHAR(__FUNCTION__));
+			Error = FString::Printf(TEXT("[%s] - Instance is not in joinable state"), ANSI_TO_TCHAR(__FUNCTION__));
 			return false;
 		}
 
 		FURL JoinURL;
 		if (!GenerateJoinURL(Session, pWorldContext->LastURL, JoinURL))
 		{
-			UE_CLOG(bLog, LogRallyHereIntegration, Verbose, TEXT("[%s] - Could not generate join URL"), ANSI_TO_TCHAR(__FUNCTION__));
+			Error = FString::Printf(TEXT("[%s] - Could not generate join URL"), ANSI_TO_TCHAR(__FUNCTION__));
 			return false;
 		}
 	}

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceSessionSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceSessionSubsystem.h
@@ -192,12 +192,21 @@ public:
 	UFUNCTION(BlueprintGetter, Category = "Session|Instance")
 	FORCEINLINE bool IsBackfillTerminated() const { return ActiveSessionState.bIsBackfillTerminated; }
 	/**
-	* @brief Checks if the session has all the players and is good to change maps.
+	* @brief Checks if the session has all the players and is good to change maps, and conditionally logs errors
 	* @param [in] Session The session being checked.
+	* @param [in] bLog If true, log errors.
 	* @return If true, the session is ready for a map transition.
 	*/
 	UFUNCTION(BlueprintCallable, Category = "Session|Instance")
 	virtual bool IsReadyToJoinInstance(const URH_JoinedSession* Session, bool bLog = false) const;
+	/**
+	* @brief Checks if the session has all the players and is good to change maps, and passes back first error in a string
+	* @param [in] Session The session being checked.
+	* @param [out] Error The first error encountered.
+	* @return If true, the session is ready for a map transition.
+	*/
+	UFUNCTION(BlueprintCallable, Category = "Session|Instance")
+	virtual bool IsReadyToJoinInstanceWithReason(const URH_JoinedSession* Session, FString& Error) const;
 	/**
 	* @brief Starts the process of transitioning the instance to a new session.
 	* @param [in] Delegate Callback delegate for when the session is now active, or failed to transition.


### PR DESCRIPTION
Reroute existing function to call that and if log value is set to log out the value.

Note - this is breaking if a function had overrode the original base function, which no longer contains the business logic