### PR TITLE
BREAKING CHANGE - Convert GetLoggedInPlatform() to return a TOptional rather than Anon so it is correct when not logged in.

### DIFF
--- a/Documentation/md/LocalPlayer.md
+++ b/Documentation/md/LocalPlayer.md
@@ -1428,7 +1428,7 @@ Subsystem to manage the local player.
 `public virtual bool `[`IsLoggedIn`](#classURH__LocalPlayerSubsystem_1aa87f996f6200f58e7bb5b1e76af85f78)`() const` | Gets if the player is currently logged in.
 `public virtual FGuid `[`GetPlayerUuid`](#classURH__LocalPlayerSubsystem_1a639688a2978cc465ad6576e100daffe4)`() const` | Gets the player's unique player id.
 `public `[`ERHAPI_PlatformTypes_DEPRECATED`](undefined.md#group__Common_1ga8d2aa1d87e398a5548531751e8cea759)` `[`GetLoggedInPlatformType`](#classURH__LocalPlayerSubsystem_1a42fa36a5163bc8f1000945c19f5efeb7)`() const` | Gets the platform type for the player if logged in.
-`public virtual ERHAPI_Platform `[`GetLoggedInPlatform`](#classURH__LocalPlayerSubsystem_1a5e0f993799a9be841c52cb7198979d31)`() const` | Gets the platform type for the player if logged in.
+`public virtual TOptional< ERHAPI_Platform > `[`GetLoggedInPlatform`](#classURH__LocalPlayerSubsystem_1afe833d0afadea6cd3e526c5feb86a6e6)`() const` | Gets the platform type for the player if logged in.
 `public virtual FUniqueNetIdWrapper `[`GetOSSUniqueId`](#classURH__LocalPlayerSubsystem_1a4c35e09b4d1d7b9c2b1994ba26519509)`() const` | Gets the player's OSS unique id.
 `public virtual int32 `[`GetPlatformUserId`](#classURH__LocalPlayerSubsystem_1a67201c7ebaba8d4b7f72bb55064f518c)`() const` | Gets the player's platform id.
 `public inline virtual TSharedPtr< class IAnalyticsProvider > `[`GetAnalyticsProvider`](#classURH__LocalPlayerSubsystem_1a971e67d99251ee5a805fc339f48ab66d)`() const` | Gets the player's analytics provider.
@@ -1505,7 +1505,7 @@ Gets the player's unique player id.
 
 Gets the platform type for the player if logged in.
 
-#### `public virtual ERHAPI_Platform `[`GetLoggedInPlatform`](#classURH__LocalPlayerSubsystem_1a5e0f993799a9be841c52cb7198979d31)`() const` <a id="classURH__LocalPlayerSubsystem_1a5e0f993799a9be841c52cb7198979d31"></a>
+#### `public virtual TOptional< ERHAPI_Platform > `[`GetLoggedInPlatform`](#classURH__LocalPlayerSubsystem_1afe833d0afadea6cd3e526c5feb86a6e6)`() const` <a id="classURH__LocalPlayerSubsystem_1afe833d0afadea6cd3e526c5feb86a6e6"></a>
 
 Gets the platform type for the player if logged in.
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_LocalPlayerSubsystem.cpp
@@ -402,13 +402,13 @@ ERHAPI_PlatformTypes_DEPRECATED URH_LocalPlayerSubsystem::GetLoggedInPlatformTyp
 	return ERHAPI_PlatformTypes_DEPRECATED::PT_UNKNOWN;
 }
 
-ERHAPI_Platform URH_LocalPlayerSubsystem::GetLoggedInPlatform() const
+TOptional<ERHAPI_Platform> URH_LocalPlayerSubsystem::GetLoggedInPlatform() const
 {
 	if (IsLoggedIn() && AuthContext->GetLoginResult().IsSet())
 	{
 		return AuthContext->GetLoginResult()->GetPlatform();
 	}
-	return ERHAPI_Platform::Anon;
+	return TOptional<ERHAPI_Platform>();
 }
 
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerSubsystem.h
@@ -66,7 +66,7 @@ public:
 	/**
 	* @brief Gets the platform type for the player if logged in.
 	*/
-	virtual ERHAPI_Platform GetLoggedInPlatform() const;
+	virtual TOptional<ERHAPI_Platform> GetLoggedInPlatform() const;
 	/**
 	* @brief Gets the player's OSS unique id.
 	*/


### PR DESCRIPTION
This resolves an issue where it is possible to determine that a player is using the Anon platform when they are not, or when login is in flight.  Instead, return empty optional object when type cannot be determined properly, rather than being incorrect.