### PR TITLE
BREAKING CHANGE - Rework some aspects of session syncing and bootstrapping shutdown

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -1299,7 +1299,7 @@ void URH_GameInstanceServerBootstrapper::Cleanup()
 		{
 			RHStandardEvents::FCorrelationEndEvent CorrelationEndEvent;
 
-			CorrelationEndEvent.Reason = TEXT("Recycle");
+			CorrelationEndEvent.Reason = TEXT("Cleanup");
 
 			if (AnalyticsStartTime.IsSet())
 			{

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -1255,7 +1255,7 @@ void URH_GameInstanceServerBootstrapper::CleanupAfterInstanceRemoval()
 	else
 	{
 		UE_LOG(LogRallyHereIntegration, Error, TEXT("[%s] - Session subsystem invalid or did not have session, moving to cleanup directly"), ANSI_TO_TCHAR(__FUNCTION__));
-		Cleanup();
+		OnCleanupSessionSyncComplete(nullptr, true, TEXT("Instance removal with no active session"));
 	}
 }
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -377,13 +377,15 @@ void URH_GameInstanceServerBootstrapper::SetTerminationSignalHandler()
 
 // SIGKILL / CTRL-C (Windows) handlers - these are indicating an IMMEDIATE shutdown
 void URH_GameInstanceServerBootstrapper::ApplicationTerminationNotify()
-{
+{	
 	if (IsInGameThread())
 	{
+		UE_LOG(LogRallyHereIntegration, Warning, TEXT("[%s] - Application Termination Notified, running immediate termination handler"), ANSI_TO_TCHAR(__FUNCTION__));
 		HandleAppTerminatedGameThread();
 	}
 	else
 	{
+		UE_LOG(LogRallyHereIntegration, Warning, TEXT("[%s] - Application Termination Notified from secondary thread, running immediate termination handler in game thread"), ANSI_TO_TCHAR(__FUNCTION__));
 		const FGraphEventRef Task = FSimpleDelegateGraphTask::CreateAndDispatchWhenReady(
 			FSimpleDelegateGraphTask::FDelegate::CreateUObject(this, &URH_GameInstanceServerBootstrapper::HandleAppTerminatedGameThread),
 			QUICK_USE_CYCLE_STAT(FRH_TerminationNotify, STATGROUP_TaskGraphTasks),
@@ -400,8 +402,36 @@ void URH_GameInstanceServerBootstrapper::HandleAppTerminatedGameThread()
 	// make sure this was invoked if it was not previously
 	RallyHere::TermSignalHandler::TerminationSignalHandler();
 
-	// attempt to leave current session if still in one
-	BestEffortLeaveSession();
+	// if we still have an active session, try to leave it
+	if (RHSession != nullptr && RHSession->IsActive())
+	{
+		auto* SessionSubsystem = GetGameInstanceSubsystem()->GetSessionSubsystem();
+		if (SessionSubsystem)
+		{
+			UE_LOG(LogRallyHereIntegration, Warning, TEXT("[%s] - Application Termination, attempting to leave active session to properly clean it up"), ANSI_TO_TCHAR(__FUNCTION__));
+			
+			// attempt to sync to null to clear out any session state
+			SessionSubsystem->SyncToSession(nullptr);
+
+			// above call should have handled leaving the session in line, and invoked the session change handler to run cleanup.  This is a backup in case something went wrong
+			if (!ensure(RHSession == nullptr))
+			{
+				BestEffortLeaveSession();
+			}
+		}
+		else
+		{
+			UE_LOG(LogRallyHereIntegration, Warning, TEXT("[%s] - Application Termination, could not find session subsystem"), ANSI_TO_TCHAR(__FUNCTION__));
+			
+			BestEffortLeaveSession();
+		}
+	}
+	else
+	{
+		UE_LOG(LogRallyHereIntegration, Warning, TEXT("[%s] - Application Termination, no active session"), ANSI_TO_TCHAR(__FUNCTION__));
+		
+		BestEffortLeaveSession();
+	}
 }
 
 void URH_GameInstanceServerBootstrapper::UpdateBootstrapStep(ERH_ServerBootstrapFlowStep NewStep)

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
@@ -1157,18 +1157,24 @@ void URH_GameInstanceSessionSubsystem::SyncToSession(URH_JoinedSession* SessionI
 	// swap our session data for the update
 	DesiredSession = SessionInfo;
 
-	// notify analytics that we are starting to join a session
-	EmitJoinInstanceStartedEvent(DesiredSession);
+	FRH_GameInstanceSessionSyncBlock Delegate = InDelegate;
 
-	// wrapper the delegate to fire the completed analytics event to match the started event
-	FRH_GameInstanceSessionSyncDelegate Delegate = FRH_GameInstanceSessionSyncDelegate::CreateWeakLambda(this, [this, InDelegate](URH_JoinedSession* Session, bool bSuccess, const FString& Error)
-		{
-			// notify analytics that we are done joining a session
-			EmitJoinInstanceCompletedEvent(DesiredSession, bSuccess, Error);
+	// if we are transitioning to a session, emit analytics events
+	if (SessionInfo != nullptr)
+	{
+		// notify analytics that we are starting to join a session
+		EmitJoinInstanceStartedEvent(DesiredSession);
 
-			// fire delegate
-			InDelegate.ExecuteIfBound(Session, bSuccess, Error);
-		});
+		// wrapper the delegate to fire the completed analytics event to match the started event
+		Delegate = FRH_GameInstanceSessionSyncDelegate::CreateWeakLambda(this, [this, InDelegate](URH_JoinedSession* Session, bool bSuccess, const FString& Error)
+			{
+				// notify analytics that we are done joining a session
+				EmitJoinInstanceCompletedEvent(DesiredSession, bSuccess, Error);
+
+				// fire delegate
+				InDelegate.ExecuteIfBound(Session, bSuccess, Error);
+			});
+	}
 
 	const FRHAPI_InstanceInfo* newInstanceData = DesiredSession != nullptr ? DesiredSession->GetInstanceData() : nullptr;
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
@@ -211,7 +211,17 @@ bool URH_GameInstanceSessionSubsystem::MakeActiveSessionJoinable(UWorld* pWorld)
 			InstanceInfo.JoinParams_IsSet = true;
 		}
 
-		ActiveSession->UpdateInstanceInfo(InstanceInfo);
+		// bind a delegate to leave the instance if we fail to make it joinable
+		auto Delegate = FRH_OnSessionUpdatedDelegate::CreateWeakLambda(this, [this](bool bSuccess, URH_SessionView* Session, const FRH_ErrorInfo& ErrorInfo)
+			{
+				// if the update failed, leave the instance, since it is not in a valid playable state
+				if (!bSuccess && Session != nullptr && Session == GetActiveSession())
+				{
+					StartLeaveInstanceFlow();
+				}
+			});
+		
+		ActiveSession->UpdateInstanceInfo(InstanceInfo, Delegate);
 
 		return true;
 	}

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceSessionSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceSessionSubsystem.h
@@ -207,31 +207,7 @@ public:
 	*/
 	UFUNCTION(BlueprintCallable, Category = "Session|Instance")
 	virtual bool IsReadyToJoinInstanceWithReason(const URH_JoinedSession* Session, FString& Error) const;
-	/**
-	* @brief Starts the process of transitioning the instance to a new session.
-	* @param [in] Delegate Callback delegate for when the session is now active, or failed to transition.
-	*/
-	virtual bool StartJoinInstanceFlow(const FRH_GameInstanceSessionSyncBlock& Delegate = FRH_GameInstanceSessionSyncBlock());
-	/**
-	* @private
-	* @brief Blueprint compatible wrapper for StartJoinInstanceFlow
-	*/
-	UFUNCTION(BlueprintCallable, Category = "Session|Instance", meta = (DisplayName = "Start Join Instance Flow", AutoCreateRefTerm = "Delegate"))
-	bool BLUEPRINT_StartJoinInstanceFlow(const FRH_GameInstanceSessionSyncDynamicDelegate& Delegate) { return StartJoinInstanceFlow(Delegate); }
-	/**
-	* @brief Starts the process of leaving a previous the instance session.
-	* @param [in] bAlreadyDisconnected If true, the instance is already disconnected from the previous session.
-	* @param [in] bCheckDesired If true, and the instance has a desired session, start joining that session.
-	* @param [in] Delegate Callback delegate for when the instance is left.
-	*/
-	virtual void StartLeaveInstanceFlow(bool bAlreadyDisconnected = false, bool bCheckDesired = false, const FRH_GameInstanceSessionSyncBlock& Delegate = FRH_GameInstanceSessionSyncBlock());
-	/**
-	* @private
-	* @brief Blueprint compatible wrapper for StartLeaveInstanceFlow
-	*/
-	UFUNCTION(BlueprintCallable, Category = "Session|Instance", meta = (DisplayName = "Start Leave Instance Flow", AutoCreateRefTerm = "Delegate"))
-	void BLUEPRINT_StartLeaveInstanceFlow(bool bAlreadyDisconnected, bool bCheckDesired, const FRH_GameInstanceSessionSyncDynamicDelegate& Delegate) { StartLeaveInstanceFlow(bAlreadyDisconnected, bCheckDesired, Delegate); }
-
+	
 	/**
 	 * @brief @brief Attempt to generate a join URL from a session.
 	 * @param [in] Session The session to be joined.
@@ -328,6 +304,31 @@ protected:
 	 * @param [in] Session to set as active session
 	 */
 	virtual void SetActiveSession(URH_JoinedSession* Session);
+
+	/**
+	* @brief Starts the process of transitioning the instance to the desired session.
+	* @param [in] Delegate Callback delegate for when the session is now active, or failed to transition.
+	*/
+	virtual bool StartJoinInstanceFlow(const FRH_GameInstanceSessionSyncBlock& Delegate = FRH_GameInstanceSessionSyncBlock());
+	/**
+	* @private
+	* @brief Blueprint compatible wrapper for StartJoinInstanceFlow
+	*/
+	UFUNCTION(BlueprintCallable, Category = "Session|Instance", meta = (DisplayName = "Start Join Instance Flow", AutoCreateRefTerm = "Delegate", DeprecatedFunction, DeprecationMessage = "Direct calls to StartJoinInstanceFlow are deprecated, please route calls through SyncToSession for consistency"))
+	bool BLUEPRINT_StartJoinInstanceFlow(const FRH_GameInstanceSessionSyncDynamicDelegate& Delegate) { return StartJoinInstanceFlow(Delegate); }
+	/**
+	* @brief Starts the process of leaving a previous the instance session.
+	* @param [in] bAlreadyDisconnected If true, the instance is already disconnected from the previous session.
+	* @param [in] bCheckDesired If true, and the instance has a desired session, start joining that session.
+	* @param [in] Delegate Callback delegate for when the instance is left.
+	*/
+	virtual void StartLeaveInstanceFlow(bool bAlreadyDisconnected = false, bool bCheckDesired = false, const FRH_GameInstanceSessionSyncBlock& Delegate = FRH_GameInstanceSessionSyncBlock());
+	/**
+	* @private
+	* @brief Blueprint compatible wrapper for StartLeaveInstanceFlow
+	*/
+	UFUNCTION(BlueprintCallable, Category = "Session|Instance", meta = (DisplayName = "Start Leave Instance Flow", AutoCreateRefTerm = "Delegate", DeprecatedFunction, DeprecationMessage = "Direct calls to StartLeaveInstanceFlow are deprecated, please route calls through SyncToSession for consistency"))
+	void BLUEPRINT_StartLeaveInstanceFlow(bool bAlreadyDisconnected, bool bCheckDesired, const FRH_GameInstanceSessionSyncDynamicDelegate& Delegate) { StartLeaveInstanceFlow(bAlreadyDisconnected, bCheckDesired, Delegate); }
 
 	/**
 	 * @brief Handles verification and validation of a player attempting to connect to the instance.


### PR DESCRIPTION
Moved `StartJoinInstanceFlow()` and `StartLeaveInstanceFlow()` to be protected.  This will likely break existing game code that called those functions.  Instead, `SyncToSession()` should be used to initiate those calls, as it will do proper analytics tracking, as well as correctly set the DesiredSession state.  To initiate a leave, use `SyncToSession(nullptr)`

Additional improvements to bootstrapping shutdown logic to cleanup some inconsistencies.  This includes making the process termination handler attempt to do a session leave (this is called, for example, from the Windows CTRL-C handler).

Add a handler for if the session subsystem fails to update a session to joinable.  If this happens, the session is left (since it has left the session in an invalid state).  For a server this will initiate a recycle.