### PR TITLE
API Update: KickBeforeHint for mass logoff, remove Secret KVs support.  Session new feature implementation for reserved state and instance request

### DIFF
--- a/Documentation/md/Config.md
+++ b/Documentation/md/Config.md
@@ -28,10 +28,9 @@ Config Subsystem used for interfacing with configuration coming from the core se
 `public virtual void `[`FetchKVs`](#classURH__ConfigSubsystem_1a79d77433c4d5f4c671fc1ecadf1645bd)`(const FRH_GenericSuccessWithErrorBlock & Delegate)` | Requests the server for the latest KVs.
 `public void `[`PollKVs`](#classURH__ConfigSubsystem_1aac6461308740848ec368388c5793f5c8)`(const FRH_PollCompleteFunc & Delegate)` | Pulses a FetchKVs call for the polling of KVs.
 `public inline const TMap< FString, FString > & `[`GetKVs`](#classURH__ConfigSubsystem_1a757de9fcdf1e5cb32f566f9415f79921)`() const` | Gets the map of all the Public KVs and their values.
-`public inline const TMap< FString, FString > & `[`GetSecretKVs`](#classURH__ConfigSubsystem_1a497dcf0e98da8e43f59e11a577d81da1)`() const` | Gets the map of all the Secret KVs and their values.
 `public inline bool `[`GetKV`](#classURH__ConfigSubsystem_1aa1248874924178b0be7b383b09fb095b)`(const FString & Key,FString & Value) const` | Gets the value of a specific Publc KV.
-`public inline bool `[`GetSecretKV`](#classURH__ConfigSubsystem_1abe02b79f2b4fc1c152b75a7d9892c9d4)`(const FString & Key,FString & Value) const` | Gets the value of a specific Secret KV.
-`public inline bool `[`GetAnyKV`](#classURH__ConfigSubsystem_1ac5caaee0e2aa29122861d5b45ee3d41c)`(const FString & Key,FString & Value) const` | Gets the value of a specific Publc or Secret KV (secret takes precidence.
+`public inline bool `[`GetAnyKV`](#classURH__ConfigSubsystem_1ac5caaee0e2aa29122861d5b45ee3d41c)`(const FString & Key,FString & Value) const` | Gets the value of a specific KV (wrapper for if multiple KV sources are present).
+`public inline FDateTime `[`GetKickBeforeHint`](#classURH__ConfigSubsystem_1a5051253a4523c1d2b76c0a3fe53d5e3a)`() const` | Time for which any player logins older than should log out (staggered kick all players support).
 `public inline void `[`FetchAppSettings`](#classURH__ConfigSubsystem_1ad403c4ca8a27ea7c655e90a284dc78d5)`(const FRH_GenericSuccessWithErrorBlock & Delegate)` | Requests the server for the latest App Settings.
 `public inline FORCEINLINE void `[`FetchAppSettings`](#classURH__ConfigSubsystem_1a50fe9c7e6cff1c087b90a9a260589d42)`(const FRH_GenericSuccessDelegate & Delegate)` | 
 `public inline void `[`PollAppSettings`](#classURH__ConfigSubsystem_1af54aaef08b3ea1cde7002a1d9c799f5e)`(const FRH_PollCompleteFunc & Delegate)` | Pulses a FetchAppSettings call for the polling of App Settings.
@@ -46,7 +45,7 @@ Config Subsystem used for interfacing with configuration coming from the core se
 `public inline bool `[`GetServerTimeDrift`](#classURH__ConfigSubsystem_1a8c858f002ca9de0d0c656e2dad1d08a8)`(FTimespan & Timespan) const` | Gets the approximate server time, if we have received one.
 `public bool `[`GetHotfixTestValue`](#classURH__ConfigSubsystem_1a36219ba1c46c10df675d0fe546fc31b4)`() const` | Gets if the hotfix system is enabled.
 `protected TMap< FString, FString > `[`KVs`](#classURH__ConfigSubsystem_1a1e87c42ea752046a6f1451ef8b0af7fb) | Map of KVs by Key.
-`protected TMap< FString, FString > `[`SecretKVs`](#classURH__ConfigSubsystem_1a85df31c77b24ace44b6db77db74bb051) | Map of secret (permissioned) KVs by Key.
+`protected FDateTime `[`KickBeforeHint`](#classURH__ConfigSubsystem_1a50515929646fb35feaf02832a3dc9b9e) | Time for which any player logins older than should log out (staggered kick all players support).
 `protected FString `[`KVsETag`](#classURH__ConfigSubsystem_1ad27491fc5b8ddc1e7479a642579d721f) | ETag of last GetKVs call response.
 `protected FRH_AutoPollerPtr `[`KVsPoller`](#classURH__ConfigSubsystem_1aa886fb633317ba0538aec00464604ba6) | Poller responsible for KVs.
 `protected `[`FRH_ServerTimeCache`](Config.md#structFRH__ServerTimeCache)` `[`ServerTimeCache`](#classURH__ConfigSubsystem_1a89412dc101f8e23d7715719f46ac079a) | Cache data for storing time information from the API.
@@ -97,13 +96,6 @@ Gets the map of all the Public KVs and their values.
 #### Returns
 Map of all the Public KVs and their values
 
-#### `public inline const TMap< FString, FString > & `[`GetSecretKVs`](#classURH__ConfigSubsystem_1a497dcf0e98da8e43f59e11a577d81da1)`() const` <a id="classURH__ConfigSubsystem_1a497dcf0e98da8e43f59e11a577d81da1"></a>
-
-Gets the map of all the Secret KVs and their values.
-
-#### Returns
-Map of all the Secret KVs and their values
-
 #### `public inline bool `[`GetKV`](#classURH__ConfigSubsystem_1aa1248874924178b0be7b383b09fb095b)`(const FString & Key,FString & Value) const` <a id="classURH__ConfigSubsystem_1aa1248874924178b0be7b383b09fb095b"></a>
 
 Gets the value of a specific Publc KV.
@@ -116,21 +108,9 @@ Gets the value of a specific Publc KV.
 #### Returns
 if true, a Value was found for the Key.
 
-#### `public inline bool `[`GetSecretKV`](#classURH__ConfigSubsystem_1abe02b79f2b4fc1c152b75a7d9892c9d4)`(const FString & Key,FString & Value) const` <a id="classURH__ConfigSubsystem_1abe02b79f2b4fc1c152b75a7d9892c9d4"></a>
-
-Gets the value of a specific Secret KV.
-
-#### Parameters
-* `Key` Key of the KV to get the value of. 
-
-* `Value` Value of the KV. 
-
-#### Returns
-if true, a Value was found for the Key.
-
 #### `public inline bool `[`GetAnyKV`](#classURH__ConfigSubsystem_1ac5caaee0e2aa29122861d5b45ee3d41c)`(const FString & Key,FString & Value) const` <a id="classURH__ConfigSubsystem_1ac5caaee0e2aa29122861d5b45ee3d41c"></a>
 
-Gets the value of a specific Publc or Secret KV (secret takes precidence.
+Gets the value of a specific KV (wrapper for if multiple KV sources are present).
 
 #### Parameters
 * `Key` Key of the KV to get the value of. 
@@ -139,6 +119,10 @@ Gets the value of a specific Publc or Secret KV (secret takes precidence.
 
 #### Returns
 if true, a Value was found for the Key.
+
+#### `public inline FDateTime `[`GetKickBeforeHint`](#classURH__ConfigSubsystem_1a5051253a4523c1d2b76c0a3fe53d5e3a)`() const` <a id="classURH__ConfigSubsystem_1a5051253a4523c1d2b76c0a3fe53d5e3a"></a>
+
+Time for which any player logins older than should log out (staggered kick all players support).
 
 #### `public inline void `[`FetchAppSettings`](#classURH__ConfigSubsystem_1ad403c4ca8a27ea7c655e90a284dc78d5)`(const FRH_GenericSuccessWithErrorBlock & Delegate)` <a id="classURH__ConfigSubsystem_1ad403c4ca8a27ea7c655e90a284dc78d5"></a>
 
@@ -226,9 +210,9 @@ Gets if enabled.
 
 Map of KVs by Key.
 
-#### `protected TMap< FString, FString > `[`SecretKVs`](#classURH__ConfigSubsystem_1a85df31c77b24ace44b6db77db74bb051) <a id="classURH__ConfigSubsystem_1a85df31c77b24ace44b6db77db74bb051"></a>
+#### `protected FDateTime `[`KickBeforeHint`](#classURH__ConfigSubsystem_1a50515929646fb35feaf02832a3dc9b9e) <a id="classURH__ConfigSubsystem_1a50515929646fb35feaf02832a3dc9b9e"></a>
 
-Map of secret (permissioned) KVs by Key.
+Time for which any player logins older than should log out (staggered kick all players support).
 
 #### `protected FString `[`KVsETag`](#classURH__ConfigSubsystem_1ad27491fc5b8ddc1e7479a642579d721f) <a id="classURH__ConfigSubsystem_1ad27491fc5b8ddc1e7479a642579d721f"></a>
 

--- a/Documentation/md/LocalPlayer.md
+++ b/Documentation/md/LocalPlayer.md
@@ -1460,12 +1460,14 @@ Subsystem to manage the local player.
 `protected `[`URH_PlayerInfoSubsystem`](PlayerInfo.md#classURH__PlayerInfoSubsystem)` * `[`SandboxedPlayerInfoSubsystem`](#classURH__LocalPlayerSubsystem_1a2f8620e8c3c50fdfea4ec0c39678b476) | The Sandboxed PlayerInfo Subsystem for the player.
 `protected TWeakObjectPtr< `[`URH_PlayerInfo`](PlayerInfo.md#classURH__PlayerInfo)` > `[`PlayerInfoCache`](#classURH__LocalPlayerSubsystem_1a48fa6f3ba219852b90b6eaa9bf0ec5e4) | The Player Info associated with the local player.
 `protected FAuthContextPtr `[`AuthContext`](#classURH__LocalPlayerSubsystem_1a7db0fee21f61da0729bba78d7a892430) | The Local Players auth context.
+`protected TOptional< FDateTime > `[`LastLoginTime`](#classURH__LocalPlayerSubsystem_1ae888b4ea2ddbba822b8182789f401ebe) | The timestamp of the last successful login.
 `protected TSharedPtr< class IAnalyticsProvider > `[`AnalyticsProvider`](#classURH__LocalPlayerSubsystem_1a9ece424deff5492e8d400a01c3295514) | The Analytics Provider for the player.
 `protected TOptional< FDateTime > `[`AnalyticsStartTime`](#classURH__LocalPlayerSubsystem_1a4035dec7f2a4568acd091f0058fbf0b3) | The start time of the AnalyticsProvider
 `protected template<>`  <br/>`inline UClassToUse * `[`AddSubsystemPlugin`](#classURH__LocalPlayerSubsystem_1ab757058d891a562b63869377edf607bf)`(const FSoftClassPath & SubsystemClassPath)` | Adds a plugin to the Local Player Subsystem.
 `protected inline virtual void `[`AddSubsystemPlugin`](#classURH__LocalPlayerSubsystem_1aae3af807f829d7481c4622a022753287)`(`[`URH_LocalPlayerSubsystemPlugin`](SubsystemBase.md#classURH__LocalPlayerSubsystemPlugin)` * InPlugin)` | Adds a plugin to the Local Player Subsystem.
 `protected template<>`  <br/>`inline UClassToUse * `[`AddSandboxedSubsystemPlugin`](#classURH__LocalPlayerSubsystem_1a2de7a5eafd696d509f653192edd9a09f)`(const FSoftClassPath & SubsystemClassPath)` | Adds a sandboxed plugin to the Local Player Subsystem.
 `protected inline virtual void `[`AddSandboxedSubsystemPlugin`](#classURH__LocalPlayerSubsystem_1a92a9fa258ca81bc42ceb380a9703f747)`(`[`URH_SandboxedSubsystemPlugin`](SubsystemBase.md#classURH__SandboxedSubsystemPlugin)` * InPlugin)` | Adds a plugin to the Local Player Subsystem.
+`protected virtual void `[`OnConfigKVsUpdated`](#classURH__LocalPlayerSubsystem_1ad7883d278b8e1b20b214396eca363f74)`(class `[`URH_ConfigSubsystem`](Config.md#classURH__ConfigSubsystem)` * ConfigSubsystem)` | Called whenever the config subsystem KV list is updated.
 `protected virtual void `[`OnUserLoggedIn`](#classURH__LocalPlayerSubsystem_1a9ef1338417d75dfc9f463538e2515d72)`(bool bSuccess)` | Called whenever the user logs in.
 `protected virtual void `[`OnUserLoggedOut`](#classURH__LocalPlayerSubsystem_1a8486ce5ac38cd0baa2d1a3d8ed319fd5)`(bool bRefreshTokenExpired)` | Called whenever the user logs out explicitly.
 `protected virtual void `[`OnUserChanged`](#classURH__LocalPlayerSubsystem_1a8a159f043f9aaed47f06d7c6706cb6b7)`()` | Callback that occurs whenever the local player this subsystem is associated with changes.
@@ -1643,6 +1645,10 @@ The Player Info associated with the local player.
 
 The Local Players auth context.
 
+#### `protected TOptional< FDateTime > `[`LastLoginTime`](#classURH__LocalPlayerSubsystem_1ae888b4ea2ddbba822b8182789f401ebe) <a id="classURH__LocalPlayerSubsystem_1ae888b4ea2ddbba822b8182789f401ebe"></a>
+
+The timestamp of the last successful login.
+
 #### `protected TSharedPtr< class IAnalyticsProvider > `[`AnalyticsProvider`](#classURH__LocalPlayerSubsystem_1a9ece424deff5492e8d400a01c3295514) <a id="classURH__LocalPlayerSubsystem_1a9ece424deff5492e8d400a01c3295514"></a>
 
 The Analytics Provider for the player.
@@ -1690,6 +1696,13 @@ Adds a plugin to the Local Player Subsystem.
 
 #### Returns
 The plugin that was added.
+
+#### `protected virtual void `[`OnConfigKVsUpdated`](#classURH__LocalPlayerSubsystem_1ad7883d278b8e1b20b214396eca363f74)`(class `[`URH_ConfigSubsystem`](Config.md#classURH__ConfigSubsystem)` * ConfigSubsystem)` <a id="classURH__LocalPlayerSubsystem_1ad7883d278b8e1b20b214396eca363f74"></a>
+
+Called whenever the config subsystem KV list is updated.
+
+#### Parameters
+* `ConfigSubsystem` The config subsystem that was updated.
 
 #### `protected virtual void `[`OnUserLoggedIn`](#classURH__LocalPlayerSubsystem_1a9ef1338417d75dfc9f463538e2515d72)`(bool bSuccess)` <a id="classURH__LocalPlayerSubsystem_1a9ef1338417d75dfc9f463538e2515d72"></a>
 

--- a/Documentation/md/models/RHAPI_DeserterConfig.md
+++ b/Documentation/md/models/RHAPI_DeserterConfig.md
@@ -18,18 +18,37 @@ struct FRHAPI_DeserterConfig
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
 `public FGuid `[`DeserterId`](#structFRHAPI__DeserterConfig_1a42bd72546bd60dd7b5b6074e2e7e81a9) | Unique id for this set of deserter config.
+`public FDateTime `[`LastClearedTimestamp_Optional`](#structFRHAPI__DeserterConfig_1aa10fbedf77df6acf14c1baadbd85aed9) | Datetime that enforces that a timezone is given. Unix timestamps are allowed and forced into the UTC time zone.
+`public bool `[`LastClearedTimestamp_IsSet`](#structFRHAPI__DeserterConfig_1a142a8e7dd0dd85a701c846e9e83240cb) | true if LastClearedTimestamp_Optional has been set to a value
 `public virtual bool `[`FromJson`](#structFRHAPI__DeserterConfig_1ab950edf6f534fd2b2ef88f7b2568f116)`(const TSharedPtr< FJsonValue > & JsonValue)` | Fills this object with data from the passed in JSON.
 `public virtual void `[`WriteJson`](#structFRHAPI__DeserterConfig_1a4c6d6628ce9e99d9c9f1fc03121bfa51)`(TSharedRef< TJsonWriter<>> & Writer) const` | Writes the data from this object into the specified JSON Writer stream.
 `public inline FGuid & `[`GetDeserterId`](#structFRHAPI__DeserterConfig_1abef8c3d4985a16c1eb40d4201d8c2936)`()` | Gets the value of DeserterId.
 `public inline const FGuid & `[`GetDeserterId`](#structFRHAPI__DeserterConfig_1a190a0c787e262b1567635044f20f93b5)`() const` | Gets the value of DeserterId.
 `public inline void `[`SetDeserterId`](#structFRHAPI__DeserterConfig_1af62955f81dcc7402a4966c62fc7951d0)`(const FGuid & NewValue)` | Sets the value of DeserterId.
 `public inline void `[`SetDeserterId`](#structFRHAPI__DeserterConfig_1a96294d315340ed2d4e916c1cea93aa08)`(FGuid && NewValue)` | Sets the value of DeserterId using move semantics.
+`public inline FDateTime & `[`GetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a02f8afd5a2b575b71b3120093b3487b6)`()` | Gets the value of LastClearedTimestamp_Optional, regardless of it having been set.
+`public inline const FDateTime & `[`GetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1afd6cfd3d8d2ea918c99e0142a5e1b6e2)`() const` | Gets the value of LastClearedTimestamp_Optional, regardless of it having been set.
+`public inline const FDateTime & `[`GetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a835bbecef2debeb7d72828f9cf3c8693)`(const FDateTime & DefaultValue) const` | Gets the value of LastClearedTimestamp_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a3ec57dc0b89c718e615f8d7e88564060)`(FDateTime & OutValue) const` | Fills OutValue with the value of LastClearedTimestamp_Optional and returns true if it has been set, otherwise returns false.
+`public inline FDateTime * `[`GetLastClearedTimestampOrNull`](#structFRHAPI__DeserterConfig_1a155327175285bd680fc817c69aed45b0)`()` | Returns a pointer to LastClearedTimestamp_Optional, if it has been set, otherwise returns nullptr.
+`public inline const FDateTime * `[`GetLastClearedTimestampOrNull`](#structFRHAPI__DeserterConfig_1a133464d9ce007c928b1190ad68a8f53f)`() const` | Returns a pointer to LastClearedTimestamp_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1aba498c071f117a16558e996462115ed2)`(const FDateTime & NewValue)` | Sets the value of LastClearedTimestamp_Optional and also sets LastClearedTimestamp_IsSet to true.
+`public inline void `[`SetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a6322addc289964692a5f20845ad5a54a)`(FDateTime && NewValue)` | Sets the value of LastClearedTimestamp_Optional and also sets LastClearedTimestamp_IsSet to true using move semantics.
+`public inline void `[`ClearLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a2759353d424262873a9d4cbf842aa670)`()` | Clears the value of LastClearedTimestamp_Optional and sets LastClearedTimestamp_IsSet to false.
 
 ### Members
 
 #### `public FGuid `[`DeserterId`](#structFRHAPI__DeserterConfig_1a42bd72546bd60dd7b5b6074e2e7e81a9) <a id="structFRHAPI__DeserterConfig_1a42bd72546bd60dd7b5b6074e2e7e81a9"></a>
 
 Unique id for this set of deserter config.
+
+#### `public FDateTime `[`LastClearedTimestamp_Optional`](#structFRHAPI__DeserterConfig_1aa10fbedf77df6acf14c1baadbd85aed9) <a id="structFRHAPI__DeserterConfig_1aa10fbedf77df6acf14c1baadbd85aed9"></a>
+
+Datetime that enforces that a timezone is given. Unix timestamps are allowed and forced into the UTC time zone.
+
+#### `public bool `[`LastClearedTimestamp_IsSet`](#structFRHAPI__DeserterConfig_1a142a8e7dd0dd85a701c846e9e83240cb) <a id="structFRHAPI__DeserterConfig_1a142a8e7dd0dd85a701c846e9e83240cb"></a>
+
+true if LastClearedTimestamp_Optional has been set to a value
 
 #### `public virtual bool `[`FromJson`](#structFRHAPI__DeserterConfig_1ab950edf6f534fd2b2ef88f7b2568f116)`(const TSharedPtr< FJsonValue > & JsonValue)` <a id="structFRHAPI__DeserterConfig_1ab950edf6f534fd2b2ef88f7b2568f116"></a>
 
@@ -63,4 +82,40 @@ Sets the value of DeserterId.
 #### `public inline void `[`SetDeserterId`](#structFRHAPI__DeserterConfig_1a96294d315340ed2d4e916c1cea93aa08)`(FGuid && NewValue)` <a id="structFRHAPI__DeserterConfig_1a96294d315340ed2d4e916c1cea93aa08"></a>
 
 Sets the value of DeserterId using move semantics.
+
+#### `public inline FDateTime & `[`GetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a02f8afd5a2b575b71b3120093b3487b6)`()` <a id="structFRHAPI__DeserterConfig_1a02f8afd5a2b575b71b3120093b3487b6"></a>
+
+Gets the value of LastClearedTimestamp_Optional, regardless of it having been set.
+
+#### `public inline const FDateTime & `[`GetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1afd6cfd3d8d2ea918c99e0142a5e1b6e2)`() const` <a id="structFRHAPI__DeserterConfig_1afd6cfd3d8d2ea918c99e0142a5e1b6e2"></a>
+
+Gets the value of LastClearedTimestamp_Optional, regardless of it having been set.
+
+#### `public inline const FDateTime & `[`GetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a835bbecef2debeb7d72828f9cf3c8693)`(const FDateTime & DefaultValue) const` <a id="structFRHAPI__DeserterConfig_1a835bbecef2debeb7d72828f9cf3c8693"></a>
+
+Gets the value of LastClearedTimestamp_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a3ec57dc0b89c718e615f8d7e88564060)`(FDateTime & OutValue) const` <a id="structFRHAPI__DeserterConfig_1a3ec57dc0b89c718e615f8d7e88564060"></a>
+
+Fills OutValue with the value of LastClearedTimestamp_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline FDateTime * `[`GetLastClearedTimestampOrNull`](#structFRHAPI__DeserterConfig_1a155327175285bd680fc817c69aed45b0)`()` <a id="structFRHAPI__DeserterConfig_1a155327175285bd680fc817c69aed45b0"></a>
+
+Returns a pointer to LastClearedTimestamp_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const FDateTime * `[`GetLastClearedTimestampOrNull`](#structFRHAPI__DeserterConfig_1a133464d9ce007c928b1190ad68a8f53f)`() const` <a id="structFRHAPI__DeserterConfig_1a133464d9ce007c928b1190ad68a8f53f"></a>
+
+Returns a pointer to LastClearedTimestamp_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline void `[`SetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1aba498c071f117a16558e996462115ed2)`(const FDateTime & NewValue)` <a id="structFRHAPI__DeserterConfig_1aba498c071f117a16558e996462115ed2"></a>
+
+Sets the value of LastClearedTimestamp_Optional and also sets LastClearedTimestamp_IsSet to true.
+
+#### `public inline void `[`SetLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a6322addc289964692a5f20845ad5a54a)`(FDateTime && NewValue)` <a id="structFRHAPI__DeserterConfig_1a6322addc289964692a5f20845ad5a54a"></a>
+
+Sets the value of LastClearedTimestamp_Optional and also sets LastClearedTimestamp_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearLastClearedTimestamp`](#structFRHAPI__DeserterConfig_1a2759353d424262873a9d4cbf842aa670)`()` <a id="structFRHAPI__DeserterConfig_1a2759353d424262873a9d4cbf842aa670"></a>
+
+Clears the value of LastClearedTimestamp_Optional and sets LastClearedTimestamp_IsSet to false.
 

--- a/Documentation/md/models/RHAPI_InstanceRequest.md
+++ b/Documentation/md/models/RHAPI_InstanceRequest.md
@@ -23,7 +23,10 @@ A request body to create an instance resource in a session.
 `public bool `[`InstanceId_IsSet`](#structFRHAPI__InstanceRequest_1aa2407894fadb8014e21cd940b890673d) | true if InstanceId_Optional has been set to a value
 `public `[`FRHAPI_InstanceStartupParams`](RHAPI_InstanceStartupParams.md#structFRHAPI__InstanceStartupParams)` `[`InstanceStartupParams_Optional`](#structFRHAPI__InstanceRequest_1ae58f5b8ca0b462edb52e44c683a4c1d8) | Parameters used by the host to startup. For UE5 this will contain the map and gamemode.
 `public bool `[`InstanceStartupParams_IsSet`](#structFRHAPI__InstanceRequest_1a31863d6683b7e334f0080c322c519cec) | true if InstanceStartupParams_Optional has been set to a value
-`public ERHAPI_HostType `[`HostType`](#structFRHAPI__InstanceRequest_1ac1fb0f22f5da79bcdf7356ebcba4e972) | Type of the host.
+`public ERHAPI_HostType `[`HostType_Optional`](#structFRHAPI__InstanceRequest_1ab49126ea36e13b898cc993ead30d988f) | Type of the host.
+`public bool `[`HostType_IsSet`](#structFRHAPI__InstanceRequest_1a0af173a7bfef1258354cf2d97f62f298) | true if HostType_Optional has been set to a value
+`public FGuid `[`InstanceRequestTemplateId_Optional`](#structFRHAPI__InstanceRequest_1a9871b3fd123926136de04d484e8d3b52) | Which instance request template should be used to request this instance. Takes priority over instance_startup_params and host_type.
+`public bool `[`InstanceRequestTemplateId_IsSet`](#structFRHAPI__InstanceRequest_1aa95522d7e43e4ad904241b8294d2d530) | true if InstanceRequestTemplateId_Optional has been set to a value
 `public FGuid `[`HostPlayerUuid_Optional`](#structFRHAPI__InstanceRequest_1aec1e068ce4fb2675ce05dc50f6abcbc8) | Player UUID of the host, if the host type is player.
 `public bool `[`HostPlayerUuid_IsSet`](#structFRHAPI__InstanceRequest_1a34fdd62ebfe1782ed08b73f92bfe08ea) | true if HostPlayerUuid_Optional has been set to a value
 `public TMap< FString, FString > `[`CustomData_Optional`](#structFRHAPI__InstanceRequest_1a4c621990c63bed683c60e1665ab72730) | instance-defined custom data
@@ -48,10 +51,24 @@ A request body to create an instance resource in a session.
 `public inline void `[`SetInstanceStartupParams`](#structFRHAPI__InstanceRequest_1ae9d50a4cd7268764cd37fedd8f55932f)`(const `[`FRHAPI_InstanceStartupParams`](RHAPI_InstanceStartupParams.md#structFRHAPI__InstanceStartupParams)` & NewValue)` | Sets the value of InstanceStartupParams_Optional and also sets InstanceStartupParams_IsSet to true.
 `public inline void `[`SetInstanceStartupParams`](#structFRHAPI__InstanceRequest_1a2e4ed0781477c1474ec6da97cdea711f)`(`[`FRHAPI_InstanceStartupParams`](RHAPI_InstanceStartupParams.md#structFRHAPI__InstanceStartupParams)` && NewValue)` | Sets the value of InstanceStartupParams_Optional and also sets InstanceStartupParams_IsSet to true using move semantics.
 `public inline void `[`ClearInstanceStartupParams`](#structFRHAPI__InstanceRequest_1a45fa6311989ae8b6c8e1784594faca03)`()` | Clears the value of InstanceStartupParams_Optional and sets InstanceStartupParams_IsSet to false.
-`public inline ERHAPI_HostType & `[`GetHostType`](#structFRHAPI__InstanceRequest_1aa065c59ff35a79e7fcae4eac6cd3fdb6)`()` | Gets the value of HostType.
-`public inline const ERHAPI_HostType & `[`GetHostType`](#structFRHAPI__InstanceRequest_1a5787c909c62151814f4eb5bca331c72d)`() const` | Gets the value of HostType.
-`public inline void `[`SetHostType`](#structFRHAPI__InstanceRequest_1aa85edcfb5f3d0a745d8934f514a6637e)`(const ERHAPI_HostType & NewValue)` | Sets the value of HostType.
-`public inline void `[`SetHostType`](#structFRHAPI__InstanceRequest_1ac5461f89179f71ea6aa097a737f7620f)`(ERHAPI_HostType && NewValue)` | Sets the value of HostType using move semantics.
+`public inline ERHAPI_HostType & `[`GetHostType`](#structFRHAPI__InstanceRequest_1aa065c59ff35a79e7fcae4eac6cd3fdb6)`()` | Gets the value of HostType_Optional, regardless of it having been set.
+`public inline const ERHAPI_HostType & `[`GetHostType`](#structFRHAPI__InstanceRequest_1a5787c909c62151814f4eb5bca331c72d)`() const` | Gets the value of HostType_Optional, regardless of it having been set.
+`public inline const ERHAPI_HostType & `[`GetHostType`](#structFRHAPI__InstanceRequest_1a84c232c61a17d65b302908ac588517f7)`(const ERHAPI_HostType & DefaultValue) const` | Gets the value of HostType_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetHostType`](#structFRHAPI__InstanceRequest_1a5d59bbe65758cdea98b366d2c642b1bc)`(ERHAPI_HostType & OutValue) const` | Fills OutValue with the value of HostType_Optional and returns true if it has been set, otherwise returns false.
+`public inline ERHAPI_HostType * `[`GetHostTypeOrNull`](#structFRHAPI__InstanceRequest_1a9fe5a00b53969eaa51c7f8dfa2548218)`()` | Returns a pointer to HostType_Optional, if it has been set, otherwise returns nullptr.
+`public inline const ERHAPI_HostType * `[`GetHostTypeOrNull`](#structFRHAPI__InstanceRequest_1a42e0821080a8a2900ebbc61fd080f2a0)`() const` | Returns a pointer to HostType_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetHostType`](#structFRHAPI__InstanceRequest_1aa85edcfb5f3d0a745d8934f514a6637e)`(const ERHAPI_HostType & NewValue)` | Sets the value of HostType_Optional and also sets HostType_IsSet to true.
+`public inline void `[`SetHostType`](#structFRHAPI__InstanceRequest_1ac5461f89179f71ea6aa097a737f7620f)`(ERHAPI_HostType && NewValue)` | Sets the value of HostType_Optional and also sets HostType_IsSet to true using move semantics.
+`public inline void `[`ClearHostType`](#structFRHAPI__InstanceRequest_1a950f4a5ce36d9aa40cb8598a4efcebf5)`()` | Clears the value of HostType_Optional and sets HostType_IsSet to false.
+`public inline FGuid & `[`GetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1a722ddf3e399125f42c0c43f1dcf4ce04)`()` | Gets the value of InstanceRequestTemplateId_Optional, regardless of it having been set.
+`public inline const FGuid & `[`GetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1aedda3324b8af9908f84f5a45c906d498)`() const` | Gets the value of InstanceRequestTemplateId_Optional, regardless of it having been set.
+`public inline const FGuid & `[`GetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1a114b32a60a0412e5bd86bef5fcbc3313)`(const FGuid & DefaultValue) const` | Gets the value of InstanceRequestTemplateId_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1aa03b058c830cbe8ee206509230338e0c)`(FGuid & OutValue) const` | Fills OutValue with the value of InstanceRequestTemplateId_Optional and returns true if it has been set, otherwise returns false.
+`public inline FGuid * `[`GetInstanceRequestTemplateIdOrNull`](#structFRHAPI__InstanceRequest_1af2c6fc221903b6e9c1327e677f713910)`()` | Returns a pointer to InstanceRequestTemplateId_Optional, if it has been set, otherwise returns nullptr.
+`public inline const FGuid * `[`GetInstanceRequestTemplateIdOrNull`](#structFRHAPI__InstanceRequest_1a2f4af974a6bdbc19876463bd362702d6)`() const` | Returns a pointer to InstanceRequestTemplateId_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1ae84772b1f06a5da7cee533b4f76815d5)`(const FGuid & NewValue)` | Sets the value of InstanceRequestTemplateId_Optional and also sets InstanceRequestTemplateId_IsSet to true.
+`public inline void `[`SetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1a1983aebbe2c48ea4efa79f9367fedd9b)`(FGuid && NewValue)` | Sets the value of InstanceRequestTemplateId_Optional and also sets InstanceRequestTemplateId_IsSet to true using move semantics.
+`public inline void `[`ClearInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1a7215adf9c4aa53d153b0bc4f024dfc94)`()` | Clears the value of InstanceRequestTemplateId_Optional and sets InstanceRequestTemplateId_IsSet to false.
 `public inline FGuid & `[`GetHostPlayerUuid`](#structFRHAPI__InstanceRequest_1afea933372204e8989f29f367c20797ae)`()` | Gets the value of HostPlayerUuid_Optional, regardless of it having been set.
 `public inline const FGuid & `[`GetHostPlayerUuid`](#structFRHAPI__InstanceRequest_1ac242ba9cf077f5337f74d21b928fa602)`() const` | Gets the value of HostPlayerUuid_Optional, regardless of it having been set.
 `public inline const FGuid & `[`GetHostPlayerUuid`](#structFRHAPI__InstanceRequest_1a1ca12cfad38278490c1d353be29e55b5)`(const FGuid & DefaultValue) const` | Gets the value of HostPlayerUuid_Optional, if it has been set, otherwise it returns DefaultValue.
@@ -89,9 +106,21 @@ Parameters used by the host to startup. For UE5 this will contain the map and ga
 
 true if InstanceStartupParams_Optional has been set to a value
 
-#### `public ERHAPI_HostType `[`HostType`](#structFRHAPI__InstanceRequest_1ac1fb0f22f5da79bcdf7356ebcba4e972) <a id="structFRHAPI__InstanceRequest_1ac1fb0f22f5da79bcdf7356ebcba4e972"></a>
+#### `public ERHAPI_HostType `[`HostType_Optional`](#structFRHAPI__InstanceRequest_1ab49126ea36e13b898cc993ead30d988f) <a id="structFRHAPI__InstanceRequest_1ab49126ea36e13b898cc993ead30d988f"></a>
 
 Type of the host.
+
+#### `public bool `[`HostType_IsSet`](#structFRHAPI__InstanceRequest_1a0af173a7bfef1258354cf2d97f62f298) <a id="structFRHAPI__InstanceRequest_1a0af173a7bfef1258354cf2d97f62f298"></a>
+
+true if HostType_Optional has been set to a value
+
+#### `public FGuid `[`InstanceRequestTemplateId_Optional`](#structFRHAPI__InstanceRequest_1a9871b3fd123926136de04d484e8d3b52) <a id="structFRHAPI__InstanceRequest_1a9871b3fd123926136de04d484e8d3b52"></a>
+
+Which instance request template should be used to request this instance. Takes priority over instance_startup_params and host_type.
+
+#### `public bool `[`InstanceRequestTemplateId_IsSet`](#structFRHAPI__InstanceRequest_1aa95522d7e43e4ad904241b8294d2d530) <a id="structFRHAPI__InstanceRequest_1aa95522d7e43e4ad904241b8294d2d530"></a>
+
+true if InstanceRequestTemplateId_Optional has been set to a value
 
 #### `public FGuid `[`HostPlayerUuid_Optional`](#structFRHAPI__InstanceRequest_1aec1e068ce4fb2675ce05dc50f6abcbc8) <a id="structFRHAPI__InstanceRequest_1aec1e068ce4fb2675ce05dc50f6abcbc8"></a>
 
@@ -200,19 +229,75 @@ Clears the value of InstanceStartupParams_Optional and sets InstanceStartupParam
 
 #### `public inline ERHAPI_HostType & `[`GetHostType`](#structFRHAPI__InstanceRequest_1aa065c59ff35a79e7fcae4eac6cd3fdb6)`()` <a id="structFRHAPI__InstanceRequest_1aa065c59ff35a79e7fcae4eac6cd3fdb6"></a>
 
-Gets the value of HostType.
+Gets the value of HostType_Optional, regardless of it having been set.
 
 #### `public inline const ERHAPI_HostType & `[`GetHostType`](#structFRHAPI__InstanceRequest_1a5787c909c62151814f4eb5bca331c72d)`() const` <a id="structFRHAPI__InstanceRequest_1a5787c909c62151814f4eb5bca331c72d"></a>
 
-Gets the value of HostType.
+Gets the value of HostType_Optional, regardless of it having been set.
+
+#### `public inline const ERHAPI_HostType & `[`GetHostType`](#structFRHAPI__InstanceRequest_1a84c232c61a17d65b302908ac588517f7)`(const ERHAPI_HostType & DefaultValue) const` <a id="structFRHAPI__InstanceRequest_1a84c232c61a17d65b302908ac588517f7"></a>
+
+Gets the value of HostType_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetHostType`](#structFRHAPI__InstanceRequest_1a5d59bbe65758cdea98b366d2c642b1bc)`(ERHAPI_HostType & OutValue) const` <a id="structFRHAPI__InstanceRequest_1a5d59bbe65758cdea98b366d2c642b1bc"></a>
+
+Fills OutValue with the value of HostType_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline ERHAPI_HostType * `[`GetHostTypeOrNull`](#structFRHAPI__InstanceRequest_1a9fe5a00b53969eaa51c7f8dfa2548218)`()` <a id="structFRHAPI__InstanceRequest_1a9fe5a00b53969eaa51c7f8dfa2548218"></a>
+
+Returns a pointer to HostType_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const ERHAPI_HostType * `[`GetHostTypeOrNull`](#structFRHAPI__InstanceRequest_1a42e0821080a8a2900ebbc61fd080f2a0)`() const` <a id="structFRHAPI__InstanceRequest_1a42e0821080a8a2900ebbc61fd080f2a0"></a>
+
+Returns a pointer to HostType_Optional, if it has been set, otherwise returns nullptr.
 
 #### `public inline void `[`SetHostType`](#structFRHAPI__InstanceRequest_1aa85edcfb5f3d0a745d8934f514a6637e)`(const ERHAPI_HostType & NewValue)` <a id="structFRHAPI__InstanceRequest_1aa85edcfb5f3d0a745d8934f514a6637e"></a>
 
-Sets the value of HostType.
+Sets the value of HostType_Optional and also sets HostType_IsSet to true.
 
 #### `public inline void `[`SetHostType`](#structFRHAPI__InstanceRequest_1ac5461f89179f71ea6aa097a737f7620f)`(ERHAPI_HostType && NewValue)` <a id="structFRHAPI__InstanceRequest_1ac5461f89179f71ea6aa097a737f7620f"></a>
 
-Sets the value of HostType using move semantics.
+Sets the value of HostType_Optional and also sets HostType_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearHostType`](#structFRHAPI__InstanceRequest_1a950f4a5ce36d9aa40cb8598a4efcebf5)`()` <a id="structFRHAPI__InstanceRequest_1a950f4a5ce36d9aa40cb8598a4efcebf5"></a>
+
+Clears the value of HostType_Optional and sets HostType_IsSet to false.
+
+#### `public inline FGuid & `[`GetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1a722ddf3e399125f42c0c43f1dcf4ce04)`()` <a id="structFRHAPI__InstanceRequest_1a722ddf3e399125f42c0c43f1dcf4ce04"></a>
+
+Gets the value of InstanceRequestTemplateId_Optional, regardless of it having been set.
+
+#### `public inline const FGuid & `[`GetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1aedda3324b8af9908f84f5a45c906d498)`() const` <a id="structFRHAPI__InstanceRequest_1aedda3324b8af9908f84f5a45c906d498"></a>
+
+Gets the value of InstanceRequestTemplateId_Optional, regardless of it having been set.
+
+#### `public inline const FGuid & `[`GetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1a114b32a60a0412e5bd86bef5fcbc3313)`(const FGuid & DefaultValue) const` <a id="structFRHAPI__InstanceRequest_1a114b32a60a0412e5bd86bef5fcbc3313"></a>
+
+Gets the value of InstanceRequestTemplateId_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1aa03b058c830cbe8ee206509230338e0c)`(FGuid & OutValue) const` <a id="structFRHAPI__InstanceRequest_1aa03b058c830cbe8ee206509230338e0c"></a>
+
+Fills OutValue with the value of InstanceRequestTemplateId_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline FGuid * `[`GetInstanceRequestTemplateIdOrNull`](#structFRHAPI__InstanceRequest_1af2c6fc221903b6e9c1327e677f713910)`()` <a id="structFRHAPI__InstanceRequest_1af2c6fc221903b6e9c1327e677f713910"></a>
+
+Returns a pointer to InstanceRequestTemplateId_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const FGuid * `[`GetInstanceRequestTemplateIdOrNull`](#structFRHAPI__InstanceRequest_1a2f4af974a6bdbc19876463bd362702d6)`() const` <a id="structFRHAPI__InstanceRequest_1a2f4af974a6bdbc19876463bd362702d6"></a>
+
+Returns a pointer to InstanceRequestTemplateId_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline void `[`SetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1ae84772b1f06a5da7cee533b4f76815d5)`(const FGuid & NewValue)` <a id="structFRHAPI__InstanceRequest_1ae84772b1f06a5da7cee533b4f76815d5"></a>
+
+Sets the value of InstanceRequestTemplateId_Optional and also sets InstanceRequestTemplateId_IsSet to true.
+
+#### `public inline void `[`SetInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1a1983aebbe2c48ea4efa79f9367fedd9b)`(FGuid && NewValue)` <a id="structFRHAPI__InstanceRequest_1a1983aebbe2c48ea4efa79f9367fedd9b"></a>
+
+Sets the value of InstanceRequestTemplateId_Optional and also sets InstanceRequestTemplateId_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearInstanceRequestTemplateId`](#structFRHAPI__InstanceRequest_1a7215adf9c4aa53d153b0bc4f024dfc94)`()` <a id="structFRHAPI__InstanceRequest_1a7215adf9c4aa53d153b0bc4f024dfc94"></a>
+
+Clears the value of InstanceRequestTemplateId_Optional and sets InstanceRequestTemplateId_IsSet to false.
 
 #### `public inline FGuid & `[`GetHostPlayerUuid`](#structFRHAPI__InstanceRequest_1afea933372204e8989f29f367c20797ae)`()` <a id="structFRHAPI__InstanceRequest_1afea933372204e8989f29f367c20797ae"></a>
 

--- a/Documentation/md/models/RHAPI_KVsResponseV2.md
+++ b/Documentation/md/models/RHAPI_KVsResponseV2.md
@@ -19,8 +19,10 @@ struct FRHAPI_KVsResponseV2
 --------------------------------|---------------------------------------------
 `public TMap< FString, FString > `[`Kvs_Optional`](#structFRHAPI__KVsResponseV2_1a82becbf26311d31710b9a8565790b750) | The list of key/value pairs.
 `public bool `[`Kvs_IsSet`](#structFRHAPI__KVsResponseV2_1a2472e7743cd7526c7660eb4e3f013a85) | true if Kvs_Optional has been set to a value
-`public TMap< FString, FString > `[`SecretKvs_Optional`](#structFRHAPI__KVsResponseV2_1aec975fc79d0ab06c9a350336fc4e4890) | The list of secret key/value pairs.
+`public TMap< FString, FString > `[`SecretKvs_Optional`](#structFRHAPI__KVsResponseV2_1aec975fc79d0ab06c9a350336fc4e4890) | *DEPRECATED* The list of permissioned key/value pairs
 `public bool `[`SecretKvs_IsSet`](#structFRHAPI__KVsResponseV2_1ab81590821f474549e20e936b43490aed) | true if SecretKvs_Optional has been set to a value
+`public FDateTime `[`KickBeforeHint_Optional`](#structFRHAPI__KVsResponseV2_1a1c0a8e368f007745fe2d035f92ca0db1) | Datetime that enforces that a timezone is given. Unix timestamps are allowed and forced into the UTC time zone.
+`public bool `[`KickBeforeHint_IsSet`](#structFRHAPI__KVsResponseV2_1a9b71da32e91425d77c18ca9e5cf798c7) | true if KickBeforeHint_Optional has been set to a value
 `public virtual bool `[`FromJson`](#structFRHAPI__KVsResponseV2_1afe7b35f511ed17b3190ea02d2a3af66e)`(const TSharedPtr< FJsonValue > & JsonValue)` | Fills this object with data from the passed in JSON.
 `public virtual void `[`WriteJson`](#structFRHAPI__KVsResponseV2_1acf1330b9370dcf8d9c3955029a2d2a79)`(TSharedRef< TJsonWriter<>> & Writer) const` | Writes the data from this object into the specified JSON Writer stream.
 `public inline TMap< FString, FString > & `[`GetKvs`](#structFRHAPI__KVsResponseV2_1a805b192903a3d77acb16adc1c3c06d4c)`()` | Gets the value of Kvs_Optional, regardless of it having been set.
@@ -41,6 +43,15 @@ struct FRHAPI_KVsResponseV2
 `public inline void `[`SetSecretKvs`](#structFRHAPI__KVsResponseV2_1ace017fbf13868fd79c520f2e0480f009)`(const TMap< FString, FString > & NewValue)` | Sets the value of SecretKvs_Optional and also sets SecretKvs_IsSet to true.
 `public inline void `[`SetSecretKvs`](#structFRHAPI__KVsResponseV2_1afca79ef23c8f802c124bc86c58d44107)`(TMap< FString, FString > && NewValue)` | Sets the value of SecretKvs_Optional and also sets SecretKvs_IsSet to true using move semantics.
 `public inline void `[`ClearSecretKvs`](#structFRHAPI__KVsResponseV2_1aaa15339436ec513d1e51e1900394c473)`()` | Clears the value of SecretKvs_Optional and sets SecretKvs_IsSet to false.
+`public inline FDateTime & `[`GetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1afbe8886c5df11e53c4026b26557ef52e)`()` | Gets the value of KickBeforeHint_Optional, regardless of it having been set.
+`public inline const FDateTime & `[`GetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1ac4168f09c7544ec654a23b64007cf5f8)`() const` | Gets the value of KickBeforeHint_Optional, regardless of it having been set.
+`public inline const FDateTime & `[`GetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1ace49dbe74ffe1345f229267a3117f7ca)`(const FDateTime & DefaultValue) const` | Gets the value of KickBeforeHint_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1add80d3e8abf1a17fc5c9aa5a1f21b5cd)`(FDateTime & OutValue) const` | Fills OutValue with the value of KickBeforeHint_Optional and returns true if it has been set, otherwise returns false.
+`public inline FDateTime * `[`GetKickBeforeHintOrNull`](#structFRHAPI__KVsResponseV2_1ac27b41c0262a8200ce1cdd87b3db953f)`()` | Returns a pointer to KickBeforeHint_Optional, if it has been set, otherwise returns nullptr.
+`public inline const FDateTime * `[`GetKickBeforeHintOrNull`](#structFRHAPI__KVsResponseV2_1aa20747e849cfe502cf2edc540572b1f6)`() const` | Returns a pointer to KickBeforeHint_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1a93f22fe919897974c5e80a6519a7eef9)`(const FDateTime & NewValue)` | Sets the value of KickBeforeHint_Optional and also sets KickBeforeHint_IsSet to true.
+`public inline void `[`SetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1a6777c7f31ee98d28aa940cbd02c2b4f8)`(FDateTime && NewValue)` | Sets the value of KickBeforeHint_Optional and also sets KickBeforeHint_IsSet to true using move semantics.
+`public inline void `[`ClearKickBeforeHint`](#structFRHAPI__KVsResponseV2_1a5764ddc0e6aa98ef1acfbba00d0642fd)`()` | Clears the value of KickBeforeHint_Optional and sets KickBeforeHint_IsSet to false.
 
 ### Members
 
@@ -54,11 +65,19 @@ true if Kvs_Optional has been set to a value
 
 #### `public TMap< FString, FString > `[`SecretKvs_Optional`](#structFRHAPI__KVsResponseV2_1aec975fc79d0ab06c9a350336fc4e4890) <a id="structFRHAPI__KVsResponseV2_1aec975fc79d0ab06c9a350336fc4e4890"></a>
 
-The list of secret key/value pairs.
+*DEPRECATED* The list of permissioned key/value pairs
 
 #### `public bool `[`SecretKvs_IsSet`](#structFRHAPI__KVsResponseV2_1ab81590821f474549e20e936b43490aed) <a id="structFRHAPI__KVsResponseV2_1ab81590821f474549e20e936b43490aed"></a>
 
 true if SecretKvs_Optional has been set to a value
+
+#### `public FDateTime `[`KickBeforeHint_Optional`](#structFRHAPI__KVsResponseV2_1a1c0a8e368f007745fe2d035f92ca0db1) <a id="structFRHAPI__KVsResponseV2_1a1c0a8e368f007745fe2d035f92ca0db1"></a>
+
+Datetime that enforces that a timezone is given. Unix timestamps are allowed and forced into the UTC time zone.
+
+#### `public bool `[`KickBeforeHint_IsSet`](#structFRHAPI__KVsResponseV2_1a9b71da32e91425d77c18ca9e5cf798c7) <a id="structFRHAPI__KVsResponseV2_1a9b71da32e91425d77c18ca9e5cf798c7"></a>
+
+true if KickBeforeHint_Optional has been set to a value
 
 #### `public virtual bool `[`FromJson`](#structFRHAPI__KVsResponseV2_1afe7b35f511ed17b3190ea02d2a3af66e)`(const TSharedPtr< FJsonValue > & JsonValue)` <a id="structFRHAPI__KVsResponseV2_1afe7b35f511ed17b3190ea02d2a3af66e"></a>
 
@@ -148,4 +167,40 @@ Sets the value of SecretKvs_Optional and also sets SecretKvs_IsSet to true using
 #### `public inline void `[`ClearSecretKvs`](#structFRHAPI__KVsResponseV2_1aaa15339436ec513d1e51e1900394c473)`()` <a id="structFRHAPI__KVsResponseV2_1aaa15339436ec513d1e51e1900394c473"></a>
 
 Clears the value of SecretKvs_Optional and sets SecretKvs_IsSet to false.
+
+#### `public inline FDateTime & `[`GetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1afbe8886c5df11e53c4026b26557ef52e)`()` <a id="structFRHAPI__KVsResponseV2_1afbe8886c5df11e53c4026b26557ef52e"></a>
+
+Gets the value of KickBeforeHint_Optional, regardless of it having been set.
+
+#### `public inline const FDateTime & `[`GetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1ac4168f09c7544ec654a23b64007cf5f8)`() const` <a id="structFRHAPI__KVsResponseV2_1ac4168f09c7544ec654a23b64007cf5f8"></a>
+
+Gets the value of KickBeforeHint_Optional, regardless of it having been set.
+
+#### `public inline const FDateTime & `[`GetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1ace49dbe74ffe1345f229267a3117f7ca)`(const FDateTime & DefaultValue) const` <a id="structFRHAPI__KVsResponseV2_1ace49dbe74ffe1345f229267a3117f7ca"></a>
+
+Gets the value of KickBeforeHint_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1add80d3e8abf1a17fc5c9aa5a1f21b5cd)`(FDateTime & OutValue) const` <a id="structFRHAPI__KVsResponseV2_1add80d3e8abf1a17fc5c9aa5a1f21b5cd"></a>
+
+Fills OutValue with the value of KickBeforeHint_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline FDateTime * `[`GetKickBeforeHintOrNull`](#structFRHAPI__KVsResponseV2_1ac27b41c0262a8200ce1cdd87b3db953f)`()` <a id="structFRHAPI__KVsResponseV2_1ac27b41c0262a8200ce1cdd87b3db953f"></a>
+
+Returns a pointer to KickBeforeHint_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const FDateTime * `[`GetKickBeforeHintOrNull`](#structFRHAPI__KVsResponseV2_1aa20747e849cfe502cf2edc540572b1f6)`() const` <a id="structFRHAPI__KVsResponseV2_1aa20747e849cfe502cf2edc540572b1f6"></a>
+
+Returns a pointer to KickBeforeHint_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline void `[`SetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1a93f22fe919897974c5e80a6519a7eef9)`(const FDateTime & NewValue)` <a id="structFRHAPI__KVsResponseV2_1a93f22fe919897974c5e80a6519a7eef9"></a>
+
+Sets the value of KickBeforeHint_Optional and also sets KickBeforeHint_IsSet to true.
+
+#### `public inline void `[`SetKickBeforeHint`](#structFRHAPI__KVsResponseV2_1a6777c7f31ee98d28aa940cbd02c2b4f8)`(FDateTime && NewValue)` <a id="structFRHAPI__KVsResponseV2_1a6777c7f31ee98d28aa940cbd02c2b4f8"></a>
+
+Sets the value of KickBeforeHint_Optional and also sets KickBeforeHint_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearKickBeforeHint`](#structFRHAPI__KVsResponseV2_1a5764ddc0e6aa98ef1acfbba00d0642fd)`()` <a id="structFRHAPI__KVsResponseV2_1a5764ddc0e6aa98ef1acfbba00d0642fd"></a>
+
+Clears the value of KickBeforeHint_Optional and sets KickBeforeHint_IsSet to false.
 

--- a/Documentation/md/models/RHAPI_MatchMakingProfileV2.md
+++ b/Documentation/md/models/RHAPI_MatchMakingProfileV2.md
@@ -35,6 +35,8 @@ A profile that describes what pools of players a session will be a part of when 
 `public bool `[`LegacyConfig_IsSet`](#structFRHAPI__MatchMakingProfileV2_1af417de3e8a601609b54e0310551c9caa) | true if LegacyConfig_Optional has been set to a value
 `public FString `[`DeserterId_Optional`](#structFRHAPI__MatchMakingProfileV2_1aae0011ecf8b0087fc25843b2c81c9d15) | Which deserter this profile should check before allowing players to join matchmaking.
 `public bool `[`DeserterId_IsSet`](#structFRHAPI__MatchMakingProfileV2_1a549f6b87b796d3920408a3e5b103d440) | true if DeserterId_Optional has been set to a value
+`public FGuid `[`SessionTemplateId_Optional`](#structFRHAPI__MatchMakingProfileV2_1a5357bb9dad6eedd14a04648d518bbcbe) | What type of session should result from matchmaking on this profile.
+`public bool `[`SessionTemplateId_IsSet`](#structFRHAPI__MatchMakingProfileV2_1a671a2d069be65d525493b353b34c3b4c) | true if SessionTemplateId_Optional has been set to a value
 `public virtual bool `[`FromJson`](#structFRHAPI__MatchMakingProfileV2_1a27b71626be2a2edef0ed660aa42fcaa6)`(const TSharedPtr< FJsonValue > & JsonValue)` | Fills this object with data from the passed in JSON.
 `public virtual void `[`WriteJson`](#structFRHAPI__MatchMakingProfileV2_1aa6ebcdc58854a72f9cb8c75b9f86834c)`(TSharedRef< TJsonWriter<>> & Writer) const` | Writes the data from this object into the specified JSON Writer stream.
 `public inline FString & `[`GetMatchMakingProfileId`](#structFRHAPI__MatchMakingProfileV2_1a4ae3b82d9d3c2bb53a131330dfe71e59)`()` | Gets the value of MatchMakingProfileId.
@@ -114,6 +116,15 @@ A profile that describes what pools of players a session will be a part of when 
 `public inline void `[`SetDeserterId`](#structFRHAPI__MatchMakingProfileV2_1a87b490afc4f498967cf5cd4e408102ab)`(const FString & NewValue)` | Sets the value of DeserterId_Optional and also sets DeserterId_IsSet to true.
 `public inline void `[`SetDeserterId`](#structFRHAPI__MatchMakingProfileV2_1ada7889860e0a249e13c7c3b3ecbb651a)`(FString && NewValue)` | Sets the value of DeserterId_Optional and also sets DeserterId_IsSet to true using move semantics.
 `public inline void `[`ClearDeserterId`](#structFRHAPI__MatchMakingProfileV2_1a8f6b926107cd9f277a465b93b2c47d19)`()` | Clears the value of DeserterId_Optional and sets DeserterId_IsSet to false.
+`public inline FGuid & `[`GetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1acf11e8feb64e573568edfc304d71d970)`()` | Gets the value of SessionTemplateId_Optional, regardless of it having been set.
+`public inline const FGuid & `[`GetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1ae0f95322ce912f321247f0862f4407e5)`() const` | Gets the value of SessionTemplateId_Optional, regardless of it having been set.
+`public inline const FGuid & `[`GetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1ad9e457ba0fdbdde859fc926a5726f50e)`(const FGuid & DefaultValue) const` | Gets the value of SessionTemplateId_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1af79ce39b605eae9c4cf488e8d6e34bcb)`(FGuid & OutValue) const` | Fills OutValue with the value of SessionTemplateId_Optional and returns true if it has been set, otherwise returns false.
+`public inline FGuid * `[`GetSessionTemplateIdOrNull`](#structFRHAPI__MatchMakingProfileV2_1ab0293f281e1e5c4e245480522693c03f)`()` | Returns a pointer to SessionTemplateId_Optional, if it has been set, otherwise returns nullptr.
+`public inline const FGuid * `[`GetSessionTemplateIdOrNull`](#structFRHAPI__MatchMakingProfileV2_1a1afc3b38c4a366a5a6f8315648f2c1ed)`() const` | Returns a pointer to SessionTemplateId_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1a4f88ff43e5836edfd1422393318c7597)`(const FGuid & NewValue)` | Sets the value of SessionTemplateId_Optional and also sets SessionTemplateId_IsSet to true.
+`public inline void `[`SetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1ac3441ac2b72a3045333f8226bc4a81e8)`(FGuid && NewValue)` | Sets the value of SessionTemplateId_Optional and also sets SessionTemplateId_IsSet to true using move semantics.
+`public inline void `[`ClearSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1aa0a57023b70ac8d739eace48091a70ef)`()` | Clears the value of SessionTemplateId_Optional and sets SessionTemplateId_IsSet to false.
 
 ### Members
 
@@ -180,6 +191,14 @@ Which deserter this profile should check before allowing players to join matchma
 #### `public bool `[`DeserterId_IsSet`](#structFRHAPI__MatchMakingProfileV2_1a549f6b87b796d3920408a3e5b103d440) <a id="structFRHAPI__MatchMakingProfileV2_1a549f6b87b796d3920408a3e5b103d440"></a>
 
 true if DeserterId_Optional has been set to a value
+
+#### `public FGuid `[`SessionTemplateId_Optional`](#structFRHAPI__MatchMakingProfileV2_1a5357bb9dad6eedd14a04648d518bbcbe) <a id="structFRHAPI__MatchMakingProfileV2_1a5357bb9dad6eedd14a04648d518bbcbe"></a>
+
+What type of session should result from matchmaking on this profile.
+
+#### `public bool `[`SessionTemplateId_IsSet`](#structFRHAPI__MatchMakingProfileV2_1a671a2d069be65d525493b353b34c3b4c) <a id="structFRHAPI__MatchMakingProfileV2_1a671a2d069be65d525493b353b34c3b4c"></a>
+
+true if SessionTemplateId_Optional has been set to a value
 
 #### `public virtual bool `[`FromJson`](#structFRHAPI__MatchMakingProfileV2_1a27b71626be2a2edef0ed660aa42fcaa6)`(const TSharedPtr< FJsonValue > & JsonValue)` <a id="structFRHAPI__MatchMakingProfileV2_1a27b71626be2a2edef0ed660aa42fcaa6"></a>
 
@@ -505,4 +524,40 @@ Sets the value of DeserterId_Optional and also sets DeserterId_IsSet to true usi
 #### `public inline void `[`ClearDeserterId`](#structFRHAPI__MatchMakingProfileV2_1a8f6b926107cd9f277a465b93b2c47d19)`()` <a id="structFRHAPI__MatchMakingProfileV2_1a8f6b926107cd9f277a465b93b2c47d19"></a>
 
 Clears the value of DeserterId_Optional and sets DeserterId_IsSet to false.
+
+#### `public inline FGuid & `[`GetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1acf11e8feb64e573568edfc304d71d970)`()` <a id="structFRHAPI__MatchMakingProfileV2_1acf11e8feb64e573568edfc304d71d970"></a>
+
+Gets the value of SessionTemplateId_Optional, regardless of it having been set.
+
+#### `public inline const FGuid & `[`GetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1ae0f95322ce912f321247f0862f4407e5)`() const` <a id="structFRHAPI__MatchMakingProfileV2_1ae0f95322ce912f321247f0862f4407e5"></a>
+
+Gets the value of SessionTemplateId_Optional, regardless of it having been set.
+
+#### `public inline const FGuid & `[`GetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1ad9e457ba0fdbdde859fc926a5726f50e)`(const FGuid & DefaultValue) const` <a id="structFRHAPI__MatchMakingProfileV2_1ad9e457ba0fdbdde859fc926a5726f50e"></a>
+
+Gets the value of SessionTemplateId_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1af79ce39b605eae9c4cf488e8d6e34bcb)`(FGuid & OutValue) const` <a id="structFRHAPI__MatchMakingProfileV2_1af79ce39b605eae9c4cf488e8d6e34bcb"></a>
+
+Fills OutValue with the value of SessionTemplateId_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline FGuid * `[`GetSessionTemplateIdOrNull`](#structFRHAPI__MatchMakingProfileV2_1ab0293f281e1e5c4e245480522693c03f)`()` <a id="structFRHAPI__MatchMakingProfileV2_1ab0293f281e1e5c4e245480522693c03f"></a>
+
+Returns a pointer to SessionTemplateId_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const FGuid * `[`GetSessionTemplateIdOrNull`](#structFRHAPI__MatchMakingProfileV2_1a1afc3b38c4a366a5a6f8315648f2c1ed)`() const` <a id="structFRHAPI__MatchMakingProfileV2_1a1afc3b38c4a366a5a6f8315648f2c1ed"></a>
+
+Returns a pointer to SessionTemplateId_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline void `[`SetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1a4f88ff43e5836edfd1422393318c7597)`(const FGuid & NewValue)` <a id="structFRHAPI__MatchMakingProfileV2_1a4f88ff43e5836edfd1422393318c7597"></a>
+
+Sets the value of SessionTemplateId_Optional and also sets SessionTemplateId_IsSet to true.
+
+#### `public inline void `[`SetSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1ac3441ac2b72a3045333f8226bc4a81e8)`(FGuid && NewValue)` <a id="structFRHAPI__MatchMakingProfileV2_1ac3441ac2b72a3045333f8226bc4a81e8"></a>
+
+Sets the value of SessionTemplateId_Optional and also sets SessionTemplateId_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearSessionTemplateId`](#structFRHAPI__MatchMakingProfileV2_1aa0a57023b70ac8d739eace48091a70ef)`()` <a id="structFRHAPI__MatchMakingProfileV2_1aa0a57023b70ac8d739eace48091a70ef"></a>
+
+Clears the value of SessionTemplateId_Optional and sets SessionTemplateId_IsSet to false.
 

--- a/Documentation/md/models/RHAPI_MatchMakingRuleset.md
+++ b/Documentation/md/models/RHAPI_MatchMakingRuleset.md
@@ -19,15 +19,21 @@ A collection of rules that are used to determine whether a MatchMakingTemplate s
 
  Members                        | Descriptions                                
 --------------------------------|---------------------------------------------
-`public TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > `[`Rules`](#structFRHAPI__MatchMakingRuleset_1a0af2817935346ffb9855da1f5618e851) | A list of the rules to be checked for this ruleset.
+`public TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > `[`Rules_Optional`](#structFRHAPI__MatchMakingRuleset_1ae35cc55358ffea98b34afba1fcd07488) | A list of the rules to be checked for this ruleset.
+`public bool `[`Rules_IsSet`](#structFRHAPI__MatchMakingRuleset_1af746f0c4dc26fa6709b576c533f88641) | true if Rules_Optional has been set to a value
 `public ERHAPI_Determiner `[`Determiner_Optional`](#structFRHAPI__MatchMakingRuleset_1a74ca9855c1709e5bdd47954fe18db642) | Determiner of how many rules must be satisfied in this rulest (all, any, one, none)
 `public bool `[`Determiner_IsSet`](#structFRHAPI__MatchMakingRuleset_1ab27952b6758121d98c6c193f996fae6e) | true if Determiner_Optional has been set to a value
 `public virtual bool `[`FromJson`](#structFRHAPI__MatchMakingRuleset_1a0f28034647f6b5adafd82a3549489c70)`(const TSharedPtr< FJsonValue > & JsonValue)` | Fills this object with data from the passed in JSON.
 `public virtual void `[`WriteJson`](#structFRHAPI__MatchMakingRuleset_1acb32bcfdfac306d329be3cdd71e40e4e)`(TSharedRef< TJsonWriter<>> & Writer) const` | Writes the data from this object into the specified JSON Writer stream.
-`public inline TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a02f9dfc75b2ceedb77dc171f93f29683)`()` | Gets the value of Rules.
-`public inline const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a30d5a11c789d4ca8a141fad42a84bcce)`() const` | Gets the value of Rules.
-`public inline void `[`SetRules`](#structFRHAPI__MatchMakingRuleset_1a95dd984ce4623055d498de65234758f6)`(const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & NewValue)` | Sets the value of Rules.
-`public inline void `[`SetRules`](#structFRHAPI__MatchMakingRuleset_1a6deb26d921c7b27c4f10e0934a8f4c79)`(TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > && NewValue)` | Sets the value of Rules using move semantics.
+`public inline TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a02f9dfc75b2ceedb77dc171f93f29683)`()` | Gets the value of Rules_Optional, regardless of it having been set.
+`public inline const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a30d5a11c789d4ca8a141fad42a84bcce)`() const` | Gets the value of Rules_Optional, regardless of it having been set.
+`public inline const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a1c10b0c80b86e97a991c13c41ac74963)`(const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & DefaultValue) const` | Gets the value of Rules_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a45fa64772049608807364383ea381613)`(TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & OutValue) const` | Fills OutValue with the value of Rules_Optional and returns true if it has been set, otherwise returns false.
+`public inline TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > * `[`GetRulesOrNull`](#structFRHAPI__MatchMakingRuleset_1a3f24556a7103da6e0d1ac3f27575f68e)`()` | Returns a pointer to Rules_Optional, if it has been set, otherwise returns nullptr.
+`public inline const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > * `[`GetRulesOrNull`](#structFRHAPI__MatchMakingRuleset_1a53bcdce9aa2b2c583c0336950279a9ae)`() const` | Returns a pointer to Rules_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetRules`](#structFRHAPI__MatchMakingRuleset_1a95dd984ce4623055d498de65234758f6)`(const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & NewValue)` | Sets the value of Rules_Optional and also sets Rules_IsSet to true.
+`public inline void `[`SetRules`](#structFRHAPI__MatchMakingRuleset_1a6deb26d921c7b27c4f10e0934a8f4c79)`(TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > && NewValue)` | Sets the value of Rules_Optional and also sets Rules_IsSet to true using move semantics.
+`public inline void `[`ClearRules`](#structFRHAPI__MatchMakingRuleset_1ac5e27b95f504890017e37f935c478838)`()` | Clears the value of Rules_Optional and sets Rules_IsSet to false.
 `public inline ERHAPI_Determiner & `[`GetDeterminer`](#structFRHAPI__MatchMakingRuleset_1a52023e14aad3971fb54eb804c09d5666)`()` | Gets the value of Determiner_Optional, regardless of it having been set.
 `public inline const ERHAPI_Determiner & `[`GetDeterminer`](#structFRHAPI__MatchMakingRuleset_1acf42a5782b5100020c053a91300768f6)`() const` | Gets the value of Determiner_Optional, regardless of it having been set.
 `public inline const ERHAPI_Determiner & `[`GetDeterminer`](#structFRHAPI__MatchMakingRuleset_1a5538ca24eb8a3a5f688f737fb8abce7b)`(const ERHAPI_Determiner & DefaultValue) const` | Gets the value of Determiner_Optional, if it has been set, otherwise it returns DefaultValue.
@@ -40,9 +46,13 @@ A collection of rules that are used to determine whether a MatchMakingTemplate s
 
 ### Members
 
-#### `public TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > `[`Rules`](#structFRHAPI__MatchMakingRuleset_1a0af2817935346ffb9855da1f5618e851) <a id="structFRHAPI__MatchMakingRuleset_1a0af2817935346ffb9855da1f5618e851"></a>
+#### `public TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > `[`Rules_Optional`](#structFRHAPI__MatchMakingRuleset_1ae35cc55358ffea98b34afba1fcd07488) <a id="structFRHAPI__MatchMakingRuleset_1ae35cc55358ffea98b34afba1fcd07488"></a>
 
 A list of the rules to be checked for this ruleset.
+
+#### `public bool `[`Rules_IsSet`](#structFRHAPI__MatchMakingRuleset_1af746f0c4dc26fa6709b576c533f88641) <a id="structFRHAPI__MatchMakingRuleset_1af746f0c4dc26fa6709b576c533f88641"></a>
+
+true if Rules_Optional has been set to a value
 
 #### `public ERHAPI_Determiner `[`Determiner_Optional`](#structFRHAPI__MatchMakingRuleset_1a74ca9855c1709e5bdd47954fe18db642) <a id="structFRHAPI__MatchMakingRuleset_1a74ca9855c1709e5bdd47954fe18db642"></a>
 
@@ -71,19 +81,39 @@ Writes the data from this object into the specified JSON Writer stream.
 
 #### `public inline TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a02f9dfc75b2ceedb77dc171f93f29683)`()` <a id="structFRHAPI__MatchMakingRuleset_1a02f9dfc75b2ceedb77dc171f93f29683"></a>
 
-Gets the value of Rules.
+Gets the value of Rules_Optional, regardless of it having been set.
 
 #### `public inline const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a30d5a11c789d4ca8a141fad42a84bcce)`() const` <a id="structFRHAPI__MatchMakingRuleset_1a30d5a11c789d4ca8a141fad42a84bcce"></a>
 
-Gets the value of Rules.
+Gets the value of Rules_Optional, regardless of it having been set.
+
+#### `public inline const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a1c10b0c80b86e97a991c13c41ac74963)`(const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & DefaultValue) const` <a id="structFRHAPI__MatchMakingRuleset_1a1c10b0c80b86e97a991c13c41ac74963"></a>
+
+Gets the value of Rules_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetRules`](#structFRHAPI__MatchMakingRuleset_1a45fa64772049608807364383ea381613)`(TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & OutValue) const` <a id="structFRHAPI__MatchMakingRuleset_1a45fa64772049608807364383ea381613"></a>
+
+Fills OutValue with the value of Rules_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > * `[`GetRulesOrNull`](#structFRHAPI__MatchMakingRuleset_1a3f24556a7103da6e0d1ac3f27575f68e)`()` <a id="structFRHAPI__MatchMakingRuleset_1a3f24556a7103da6e0d1ac3f27575f68e"></a>
+
+Returns a pointer to Rules_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > * `[`GetRulesOrNull`](#structFRHAPI__MatchMakingRuleset_1a53bcdce9aa2b2c583c0336950279a9ae)`() const` <a id="structFRHAPI__MatchMakingRuleset_1a53bcdce9aa2b2c583c0336950279a9ae"></a>
+
+Returns a pointer to Rules_Optional, if it has been set, otherwise returns nullptr.
 
 #### `public inline void `[`SetRules`](#structFRHAPI__MatchMakingRuleset_1a95dd984ce4623055d498de65234758f6)`(const TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > & NewValue)` <a id="structFRHAPI__MatchMakingRuleset_1a95dd984ce4623055d498de65234758f6"></a>
 
-Sets the value of Rules.
+Sets the value of Rules_Optional and also sets Rules_IsSet to true.
 
 #### `public inline void `[`SetRules`](#structFRHAPI__MatchMakingRuleset_1a6deb26d921c7b27c4f10e0934a8f4c79)`(TArray< `[`FRHAPI_Rule`](RHAPI_Rule.md#structFRHAPI__Rule)` > && NewValue)` <a id="structFRHAPI__MatchMakingRuleset_1a6deb26d921c7b27c4f10e0934a8f4c79"></a>
 
-Sets the value of Rules using move semantics.
+Sets the value of Rules_Optional and also sets Rules_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearRules`](#structFRHAPI__MatchMakingRuleset_1ac5e27b95f504890017e37f935c478838)`()` <a id="structFRHAPI__MatchMakingRuleset_1ac5e27b95f504890017e37f935c478838"></a>
+
+Clears the value of Rules_Optional and sets Rules_IsSet to false.
 
 #### `public inline ERHAPI_Determiner & `[`GetDeterminer`](#structFRHAPI__MatchMakingRuleset_1a52023e14aad3971fb54eb804c09d5666)`()` <a id="structFRHAPI__MatchMakingRuleset_1a52023e14aad3971fb54eb804c09d5666"></a>
 

--- a/Documentation/md/models/RHAPI_PlayerSession.md
+++ b/Documentation/md/models/RHAPI_PlayerSession.md
@@ -24,6 +24,8 @@ Information about the sessions of a specific type that a player is currently a m
 `public bool `[`SessionIds_IsSet`](#structFRHAPI__PlayerSession_1a029af7107f40207074d7006a2d9ce0ce) | true if SessionIds_Optional has been set to a value
 `public TMap< FString, `[`FRHAPI_PlayerSessionInvite`](RHAPI_PlayerSessionInvite.md#structFRHAPI__PlayerSessionInvite)` > `[`PendingInvites_Optional`](#structFRHAPI__PlayerSession_1a6b9bb557a6e0a39b226c15bd02700ad0) | Pending invites, if any, for the current player in this session type.
 `public bool `[`PendingInvites_IsSet`](#structFRHAPI__PlayerSession_1aba663c2e6b24e60538396ac8a3de5af2) | true if PendingInvites_Optional has been set to a value
+`public TSet< FString > `[`ReservedSessions_Optional`](#structFRHAPI__PlayerSession_1a36aacad4f1ddb069672c659abd92f5fc) | Sessions that the player has a reserved place in, but has not yet been invited.
+`public bool `[`ReservedSessions_IsSet`](#structFRHAPI__PlayerSession_1ac6c94d6b012b91a945e9031c684a9c31) | true if ReservedSessions_Optional has been set to a value
 `public virtual bool `[`FromJson`](#structFRHAPI__PlayerSession_1a8b06f282829c1099c858758efac216dd)`(const TSharedPtr< FJsonValue > & JsonValue)` | Fills this object with data from the passed in JSON.
 `public virtual void `[`WriteJson`](#structFRHAPI__PlayerSession_1a49a41127e076ba0e320cf7307dc44c6b)`(TSharedRef< TJsonWriter<>> & Writer) const` | Writes the data from this object into the specified JSON Writer stream.
 `public inline FString & `[`GetType`](#structFRHAPI__PlayerSession_1a7ff94c4a2229b98fed3c43e0374cb306)`()` | Gets the value of Type.
@@ -48,6 +50,15 @@ Information about the sessions of a specific type that a player is currently a m
 `public inline void `[`SetPendingInvites`](#structFRHAPI__PlayerSession_1a4fd4a8a71532eb7dc2088b7837c1ae44)`(const TMap< FString, `[`FRHAPI_PlayerSessionInvite`](RHAPI_PlayerSessionInvite.md#structFRHAPI__PlayerSessionInvite)` > & NewValue)` | Sets the value of PendingInvites_Optional and also sets PendingInvites_IsSet to true.
 `public inline void `[`SetPendingInvites`](#structFRHAPI__PlayerSession_1a01f8ad57514ec6faa8f348f03937e4ba)`(TMap< FString, `[`FRHAPI_PlayerSessionInvite`](RHAPI_PlayerSessionInvite.md#structFRHAPI__PlayerSessionInvite)` > && NewValue)` | Sets the value of PendingInvites_Optional and also sets PendingInvites_IsSet to true using move semantics.
 `public inline void `[`ClearPendingInvites`](#structFRHAPI__PlayerSession_1a00bfb8f183bf0c2da022701f403bc692)`()` | Clears the value of PendingInvites_Optional and sets PendingInvites_IsSet to false.
+`public inline TSet< FString > & `[`GetReservedSessions`](#structFRHAPI__PlayerSession_1ad0a89fedb9edfaa153614319398afa9e)`()` | Gets the value of ReservedSessions_Optional, regardless of it having been set.
+`public inline const TSet< FString > & `[`GetReservedSessions`](#structFRHAPI__PlayerSession_1a8c84f2653dbd74e0b29230d92ba3d917)`() const` | Gets the value of ReservedSessions_Optional, regardless of it having been set.
+`public inline const TSet< FString > & `[`GetReservedSessions`](#structFRHAPI__PlayerSession_1a1e3704847bf55add300efb3fb7a53b76)`(const TSet< FString > & DefaultValue) const` | Gets the value of ReservedSessions_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetReservedSessions`](#structFRHAPI__PlayerSession_1ad2da624b373fa6b190b7ca037754c7e9)`(TSet< FString > & OutValue) const` | Fills OutValue with the value of ReservedSessions_Optional and returns true if it has been set, otherwise returns false.
+`public inline TSet< FString > * `[`GetReservedSessionsOrNull`](#structFRHAPI__PlayerSession_1a9b4dcb72c3763127886606298f0e8ccf)`()` | Returns a pointer to ReservedSessions_Optional, if it has been set, otherwise returns nullptr.
+`public inline const TSet< FString > * `[`GetReservedSessionsOrNull`](#structFRHAPI__PlayerSession_1aa782abcc71bd7d98deff99dbf2f892aa)`() const` | Returns a pointer to ReservedSessions_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetReservedSessions`](#structFRHAPI__PlayerSession_1a54b45270b6511ce851702da842561e9e)`(const TSet< FString > & NewValue)` | Sets the value of ReservedSessions_Optional and also sets ReservedSessions_IsSet to true.
+`public inline void `[`SetReservedSessions`](#structFRHAPI__PlayerSession_1a432207491da947ca843a94ce76d17ae9)`(TSet< FString > && NewValue)` | Sets the value of ReservedSessions_Optional and also sets ReservedSessions_IsSet to true using move semantics.
+`public inline void `[`ClearReservedSessions`](#structFRHAPI__PlayerSession_1a5b6d166ad566b26e591a928c5bf4f74b)`()` | Clears the value of ReservedSessions_Optional and sets ReservedSessions_IsSet to false.
 
 ### Members
 
@@ -70,6 +81,14 @@ Pending invites, if any, for the current player in this session type.
 #### `public bool `[`PendingInvites_IsSet`](#structFRHAPI__PlayerSession_1aba663c2e6b24e60538396ac8a3de5af2) <a id="structFRHAPI__PlayerSession_1aba663c2e6b24e60538396ac8a3de5af2"></a>
 
 true if PendingInvites_Optional has been set to a value
+
+#### `public TSet< FString > `[`ReservedSessions_Optional`](#structFRHAPI__PlayerSession_1a36aacad4f1ddb069672c659abd92f5fc) <a id="structFRHAPI__PlayerSession_1a36aacad4f1ddb069672c659abd92f5fc"></a>
+
+Sessions that the player has a reserved place in, but has not yet been invited.
+
+#### `public bool `[`ReservedSessions_IsSet`](#structFRHAPI__PlayerSession_1ac6c94d6b012b91a945e9031c684a9c31) <a id="structFRHAPI__PlayerSession_1ac6c94d6b012b91a945e9031c684a9c31"></a>
+
+true if ReservedSessions_Optional has been set to a value
 
 #### `public virtual bool `[`FromJson`](#structFRHAPI__PlayerSession_1a8b06f282829c1099c858758efac216dd)`(const TSharedPtr< FJsonValue > & JsonValue)` <a id="structFRHAPI__PlayerSession_1a8b06f282829c1099c858758efac216dd"></a>
 
@@ -175,4 +194,40 @@ Sets the value of PendingInvites_Optional and also sets PendingInvites_IsSet to 
 #### `public inline void `[`ClearPendingInvites`](#structFRHAPI__PlayerSession_1a00bfb8f183bf0c2da022701f403bc692)`()` <a id="structFRHAPI__PlayerSession_1a00bfb8f183bf0c2da022701f403bc692"></a>
 
 Clears the value of PendingInvites_Optional and sets PendingInvites_IsSet to false.
+
+#### `public inline TSet< FString > & `[`GetReservedSessions`](#structFRHAPI__PlayerSession_1ad0a89fedb9edfaa153614319398afa9e)`()` <a id="structFRHAPI__PlayerSession_1ad0a89fedb9edfaa153614319398afa9e"></a>
+
+Gets the value of ReservedSessions_Optional, regardless of it having been set.
+
+#### `public inline const TSet< FString > & `[`GetReservedSessions`](#structFRHAPI__PlayerSession_1a8c84f2653dbd74e0b29230d92ba3d917)`() const` <a id="structFRHAPI__PlayerSession_1a8c84f2653dbd74e0b29230d92ba3d917"></a>
+
+Gets the value of ReservedSessions_Optional, regardless of it having been set.
+
+#### `public inline const TSet< FString > & `[`GetReservedSessions`](#structFRHAPI__PlayerSession_1a1e3704847bf55add300efb3fb7a53b76)`(const TSet< FString > & DefaultValue) const` <a id="structFRHAPI__PlayerSession_1a1e3704847bf55add300efb3fb7a53b76"></a>
+
+Gets the value of ReservedSessions_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetReservedSessions`](#structFRHAPI__PlayerSession_1ad2da624b373fa6b190b7ca037754c7e9)`(TSet< FString > & OutValue) const` <a id="structFRHAPI__PlayerSession_1ad2da624b373fa6b190b7ca037754c7e9"></a>
+
+Fills OutValue with the value of ReservedSessions_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline TSet< FString > * `[`GetReservedSessionsOrNull`](#structFRHAPI__PlayerSession_1a9b4dcb72c3763127886606298f0e8ccf)`()` <a id="structFRHAPI__PlayerSession_1a9b4dcb72c3763127886606298f0e8ccf"></a>
+
+Returns a pointer to ReservedSessions_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const TSet< FString > * `[`GetReservedSessionsOrNull`](#structFRHAPI__PlayerSession_1aa782abcc71bd7d98deff99dbf2f892aa)`() const` <a id="structFRHAPI__PlayerSession_1aa782abcc71bd7d98deff99dbf2f892aa"></a>
+
+Returns a pointer to ReservedSessions_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline void `[`SetReservedSessions`](#structFRHAPI__PlayerSession_1a54b45270b6511ce851702da842561e9e)`(const TSet< FString > & NewValue)` <a id="structFRHAPI__PlayerSession_1a54b45270b6511ce851702da842561e9e"></a>
+
+Sets the value of ReservedSessions_Optional and also sets ReservedSessions_IsSet to true.
+
+#### `public inline void `[`SetReservedSessions`](#structFRHAPI__PlayerSession_1a432207491da947ca843a94ce76d17ae9)`(TSet< FString > && NewValue)` <a id="structFRHAPI__PlayerSession_1a432207491da947ca843a94ce76d17ae9"></a>
+
+Sets the value of ReservedSessions_Optional and also sets ReservedSessions_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearReservedSessions`](#structFRHAPI__PlayerSession_1a5b6d166ad566b26e591a928c5bf4f74b)`()` <a id="structFRHAPI__PlayerSession_1a5b6d166ad566b26e591a928c5bf4f74b"></a>
+
+Clears the value of ReservedSessions_Optional and sets ReservedSessions_IsSet to false.
 

--- a/Documentation/md/models/RHAPI_QueueJoinRequest.md
+++ b/Documentation/md/models/RHAPI_QueueJoinRequest.md
@@ -24,6 +24,8 @@ A request body to enter into a matchmaking queue.
 `public bool `[`AdditionalJoinParams_IsSet`](#structFRHAPI__QueueJoinRequest_1a3f5faa941b1293875299ecebbd90b2fd) | true if AdditionalJoinParams_Optional has been set to a value
 `public TArray< FString > `[`MapPreferences_Optional`](#structFRHAPI__QueueJoinRequest_1a588de1beb24df35a7a1a7ac8f27e18c9) | List of map preferences in order from most desired, to least desired.
 `public bool `[`MapPreferences_IsSet`](#structFRHAPI__QueueJoinRequest_1a1a60372efe9faff49d483ff34112a6fd) | true if MapPreferences_Optional has been set to a value
+`public int32 `[`PassedQueueTimeSeconds_Optional`](#structFRHAPI__QueueJoinRequest_1a2128baa54a7392d0a26a7e1eca1ec2a3) | Argument to artifcially add queue time to a ticket. Older tickets are considered for lower quaulity matches. This can be used to get faster matches at the expense of quality, or to restore a session's place in queue after a failure.
+`public bool `[`PassedQueueTimeSeconds_IsSet`](#structFRHAPI__QueueJoinRequest_1abbc0d6a7b4bca49f2044e60fe98f60fa) | true if PassedQueueTimeSeconds_Optional has been set to a value
 `public virtual bool `[`FromJson`](#structFRHAPI__QueueJoinRequest_1aca836ceeca7c09ce5239c1e3769baee6)`(const TSharedPtr< FJsonValue > & JsonValue)` | Fills this object with data from the passed in JSON.
 `public virtual void `[`WriteJson`](#structFRHAPI__QueueJoinRequest_1a97acb248466e63b7798eafa5ce7ebcc8)`(TSharedRef< TJsonWriter<>> & Writer) const` | Writes the data from this object into the specified JSON Writer stream.
 `public inline FString & `[`GetQueueId`](#structFRHAPI__QueueJoinRequest_1a04947239245adaac9f29e11bcbeda080)`()` | Gets the value of QueueId.
@@ -48,6 +50,17 @@ A request body to enter into a matchmaking queue.
 `public inline void `[`SetMapPreferences`](#structFRHAPI__QueueJoinRequest_1a462ab879ddfec3e9f608e48b215d9b69)`(const TArray< FString > & NewValue)` | Sets the value of MapPreferences_Optional and also sets MapPreferences_IsSet to true.
 `public inline void `[`SetMapPreferences`](#structFRHAPI__QueueJoinRequest_1ae8267806a4f94fd0ca521c3b45ce4a53)`(TArray< FString > && NewValue)` | Sets the value of MapPreferences_Optional and also sets MapPreferences_IsSet to true using move semantics.
 `public inline void `[`ClearMapPreferences`](#structFRHAPI__QueueJoinRequest_1a60ee35ca85529854b6ecc140d872194a)`()` | Clears the value of MapPreferences_Optional and sets MapPreferences_IsSet to false.
+`public inline int32 & `[`GetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1a9cb4fc3f6f53e900955772d16d6b1d5c)`()` | Gets the value of PassedQueueTimeSeconds_Optional, regardless of it having been set.
+`public inline const int32 & `[`GetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1aff8288f5356471ba5476cbd2439cc7bf)`() const` | Gets the value of PassedQueueTimeSeconds_Optional, regardless of it having been set.
+`public inline const int32 & `[`GetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1aafab1ea2cc8e94d03415d6db93433e9d)`(const int32 & DefaultValue) const` | Gets the value of PassedQueueTimeSeconds_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1a39d515d67df16a74fa1d400a7df9d446)`(int32 & OutValue) const` | Fills OutValue with the value of PassedQueueTimeSeconds_Optional and returns true if it has been set, otherwise returns false.
+`public inline int32 * `[`GetPassedQueueTimeSecondsOrNull`](#structFRHAPI__QueueJoinRequest_1aa228bfe285e79f0efb5a9afa35437c81)`()` | Returns a pointer to PassedQueueTimeSeconds_Optional, if it has been set, otherwise returns nullptr.
+`public inline const int32 * `[`GetPassedQueueTimeSecondsOrNull`](#structFRHAPI__QueueJoinRequest_1a05b99929ded7a9d31ba41dfcccbe5405)`() const` | Returns a pointer to PassedQueueTimeSeconds_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1afc2f57f3ee152b919ed518b7a9bc674e)`(const int32 & NewValue)` | Sets the value of PassedQueueTimeSeconds_Optional and also sets PassedQueueTimeSeconds_IsSet to true.
+`public inline void `[`SetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1a23802eb5d9047b2e32a3daded2ab0007)`(int32 && NewValue)` | Sets the value of PassedQueueTimeSeconds_Optional and also sets PassedQueueTimeSeconds_IsSet to true using move semantics.
+`public inline void `[`ClearPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1a13a9875da64c2dfa43dd1eb2b1630a7b)`()` | Clears the value of PassedQueueTimeSeconds_Optional and sets PassedQueueTimeSeconds_IsSet to false.
+`public inline bool `[`IsPassedQueueTimeSecondsDefaultValue`](#structFRHAPI__QueueJoinRequest_1a8951906c63014e2baee29653f59d962d)`() const` | Returns true if PassedQueueTimeSeconds_Optional is set and matches the default value.
+`public inline void `[`SetPassedQueueTimeSecondsToDefault`](#structFRHAPI__QueueJoinRequest_1a834dc11fc4fff692404341aa96c0f613)`()` | Sets the value of PassedQueueTimeSeconds_Optional to its default and also sets PassedQueueTimeSeconds_IsSet to true.
 
 ### Members
 
@@ -70,6 +83,14 @@ List of map preferences in order from most desired, to least desired.
 #### `public bool `[`MapPreferences_IsSet`](#structFRHAPI__QueueJoinRequest_1a1a60372efe9faff49d483ff34112a6fd) <a id="structFRHAPI__QueueJoinRequest_1a1a60372efe9faff49d483ff34112a6fd"></a>
 
 true if MapPreferences_Optional has been set to a value
+
+#### `public int32 `[`PassedQueueTimeSeconds_Optional`](#structFRHAPI__QueueJoinRequest_1a2128baa54a7392d0a26a7e1eca1ec2a3) <a id="structFRHAPI__QueueJoinRequest_1a2128baa54a7392d0a26a7e1eca1ec2a3"></a>
+
+Argument to artifcially add queue time to a ticket. Older tickets are considered for lower quaulity matches. This can be used to get faster matches at the expense of quality, or to restore a session's place in queue after a failure.
+
+#### `public bool `[`PassedQueueTimeSeconds_IsSet`](#structFRHAPI__QueueJoinRequest_1abbc0d6a7b4bca49f2044e60fe98f60fa) <a id="structFRHAPI__QueueJoinRequest_1abbc0d6a7b4bca49f2044e60fe98f60fa"></a>
+
+true if PassedQueueTimeSeconds_Optional has been set to a value
 
 #### `public virtual bool `[`FromJson`](#structFRHAPI__QueueJoinRequest_1aca836ceeca7c09ce5239c1e3769baee6)`(const TSharedPtr< FJsonValue > & JsonValue)` <a id="structFRHAPI__QueueJoinRequest_1aca836ceeca7c09ce5239c1e3769baee6"></a>
 
@@ -175,4 +196,48 @@ Sets the value of MapPreferences_Optional and also sets MapPreferences_IsSet to 
 #### `public inline void `[`ClearMapPreferences`](#structFRHAPI__QueueJoinRequest_1a60ee35ca85529854b6ecc140d872194a)`()` <a id="structFRHAPI__QueueJoinRequest_1a60ee35ca85529854b6ecc140d872194a"></a>
 
 Clears the value of MapPreferences_Optional and sets MapPreferences_IsSet to false.
+
+#### `public inline int32 & `[`GetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1a9cb4fc3f6f53e900955772d16d6b1d5c)`()` <a id="structFRHAPI__QueueJoinRequest_1a9cb4fc3f6f53e900955772d16d6b1d5c"></a>
+
+Gets the value of PassedQueueTimeSeconds_Optional, regardless of it having been set.
+
+#### `public inline const int32 & `[`GetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1aff8288f5356471ba5476cbd2439cc7bf)`() const` <a id="structFRHAPI__QueueJoinRequest_1aff8288f5356471ba5476cbd2439cc7bf"></a>
+
+Gets the value of PassedQueueTimeSeconds_Optional, regardless of it having been set.
+
+#### `public inline const int32 & `[`GetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1aafab1ea2cc8e94d03415d6db93433e9d)`(const int32 & DefaultValue) const` <a id="structFRHAPI__QueueJoinRequest_1aafab1ea2cc8e94d03415d6db93433e9d"></a>
+
+Gets the value of PassedQueueTimeSeconds_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1a39d515d67df16a74fa1d400a7df9d446)`(int32 & OutValue) const` <a id="structFRHAPI__QueueJoinRequest_1a39d515d67df16a74fa1d400a7df9d446"></a>
+
+Fills OutValue with the value of PassedQueueTimeSeconds_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline int32 * `[`GetPassedQueueTimeSecondsOrNull`](#structFRHAPI__QueueJoinRequest_1aa228bfe285e79f0efb5a9afa35437c81)`()` <a id="structFRHAPI__QueueJoinRequest_1aa228bfe285e79f0efb5a9afa35437c81"></a>
+
+Returns a pointer to PassedQueueTimeSeconds_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const int32 * `[`GetPassedQueueTimeSecondsOrNull`](#structFRHAPI__QueueJoinRequest_1a05b99929ded7a9d31ba41dfcccbe5405)`() const` <a id="structFRHAPI__QueueJoinRequest_1a05b99929ded7a9d31ba41dfcccbe5405"></a>
+
+Returns a pointer to PassedQueueTimeSeconds_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline void `[`SetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1afc2f57f3ee152b919ed518b7a9bc674e)`(const int32 & NewValue)` <a id="structFRHAPI__QueueJoinRequest_1afc2f57f3ee152b919ed518b7a9bc674e"></a>
+
+Sets the value of PassedQueueTimeSeconds_Optional and also sets PassedQueueTimeSeconds_IsSet to true.
+
+#### `public inline void `[`SetPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1a23802eb5d9047b2e32a3daded2ab0007)`(int32 && NewValue)` <a id="structFRHAPI__QueueJoinRequest_1a23802eb5d9047b2e32a3daded2ab0007"></a>
+
+Sets the value of PassedQueueTimeSeconds_Optional and also sets PassedQueueTimeSeconds_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearPassedQueueTimeSeconds`](#structFRHAPI__QueueJoinRequest_1a13a9875da64c2dfa43dd1eb2b1630a7b)`()` <a id="structFRHAPI__QueueJoinRequest_1a13a9875da64c2dfa43dd1eb2b1630a7b"></a>
+
+Clears the value of PassedQueueTimeSeconds_Optional and sets PassedQueueTimeSeconds_IsSet to false.
+
+#### `public inline bool `[`IsPassedQueueTimeSecondsDefaultValue`](#structFRHAPI__QueueJoinRequest_1a8951906c63014e2baee29653f59d962d)`() const` <a id="structFRHAPI__QueueJoinRequest_1a8951906c63014e2baee29653f59d962d"></a>
+
+Returns true if PassedQueueTimeSeconds_Optional is set and matches the default value.
+
+#### `public inline void `[`SetPassedQueueTimeSecondsToDefault`](#structFRHAPI__QueueJoinRequest_1a834dc11fc4fff692404341aa96c0f613)`()` <a id="structFRHAPI__QueueJoinRequest_1a834dc11fc4fff692404341aa96c0f613"></a>
+
+Sets the value of PassedQueueTimeSeconds_Optional to its default and also sets PassedQueueTimeSeconds_IsSet to true.
 

--- a/Documentation/md/models/RHAPI_SessionTemplate.md
+++ b/Documentation/md/models/RHAPI_SessionTemplate.md
@@ -42,8 +42,10 @@ Template used to create new RallyHere sessions of a specific type. Configurable 
 `public bool `[`KeepAliveOnEmpty_IsSet`](#structFRHAPI__SessionTemplate_1a7a021f27573b66f03bddb164ba2baea4) | true if KeepAliveOnEmpty_Optional has been set to a value
 `public TMap< FString, `[`FRHAPI_PlatformSessionTemplate`](RHAPI_PlatformSessionTemplate.md#structFRHAPI__PlatformSessionTemplate)` > `[`PlatformTemplates_Optional`](#structFRHAPI__SessionTemplate_1a4a953d98de7701f09938b03e88dc447d) | Platform-Specific session mappings that are used to coordinate Rally Here sessions with OnlineSubsystem sessions.
 `public bool `[`PlatformTemplates_IsSet`](#structFRHAPI__SessionTemplate_1a98480d277fd8e297e5b90560f3c10f1a) | true if PlatformTemplates_Optional has been set to a value
-`public `[`FRHAPI_InstanceStartupParams`](RHAPI_InstanceStartupParams.md#structFRHAPI__InstanceStartupParams)` `[`AutoStartupParams_Optional`](#structFRHAPI__SessionTemplate_1a32d9a060ff0208b639415cee5d9f7287) | Parameters used to start an instance for this session when it is created.
+`public `[`FRHAPI_InstanceStartupParams`](RHAPI_InstanceStartupParams.md#structFRHAPI__InstanceStartupParams)` `[`AutoStartupParams_Optional`](#structFRHAPI__SessionTemplate_1a32d9a060ff0208b639415cee5d9f7287) | Parameters used to start an instance for this session when it is created. Has lower priority than auto_startup_instance_template_id.
 `public bool `[`AutoStartupParams_IsSet`](#structFRHAPI__SessionTemplate_1a1ae179a6de476981a9a38197758b7e14) | true if AutoStartupParams_Optional has been set to a value
+`public FGuid `[`AutoStartupInstanceTemplateId_Optional`](#structFRHAPI__SessionTemplate_1a2a49d5a8a5818e817ca11e6d123d9ba1) | ID of instance request template to be used to automatically request an instance on creation of a session of this type. Takes priority over auto_startup_params.
+`public bool `[`AutoStartupInstanceTemplateId_IsSet`](#structFRHAPI__SessionTemplate_1acf91e44fde96ae8bf3bbdfca666cc444) | true if AutoStartupInstanceTemplateId_Optional has been set to a value
 `public int32 `[`MinSessionCount_Optional`](#structFRHAPI__SessionTemplate_1aecf6bdd55d8dc8e92bf1d6e2dc032fc6) | Minimum number of this type of session to be running at any given time per region.
 `public bool `[`MinSessionCount_IsSet`](#structFRHAPI__SessionTemplate_1a067eb5ca1f241b90407f3a373cb0bd79) | true if MinSessionCount_Optional has been set to a value
 `public TMap< FString, FString > `[`CustomData_Optional`](#structFRHAPI__SessionTemplate_1a8dc395b5c32a277ba6a8098613b19c90) | Product-defined custom data about this session type.
@@ -54,6 +56,8 @@ Template used to create new RallyHere sessions of a specific type. Configurable 
 `public bool `[`PlayersPerTeam_IsSet`](#structFRHAPI__SessionTemplate_1a4351b4b52f5240e0bff65fb92b36b3a2) | true if PlayersPerTeam_Optional has been set to a value
 `public bool `[`CanChangeOwnTeam_Optional`](#structFRHAPI__SessionTemplate_1aa2d67a98c7bcf96cc848ae81ca3387e3) | Whether or not a player can change which team they are on. If true, they are able to. If False, they player's team can only be changed by an admin.
 `public bool `[`CanChangeOwnTeam_IsSet`](#structFRHAPI__SessionTemplate_1ad6b80d668b66266c71f70affb0cae587) | true if CanChangeOwnTeam_Optional has been set to a value
+`public bool `[`NotifyOnReservation_Optional`](#structFRHAPI__SessionTemplate_1a5c0c06cf8165a39442dfc4ab5e830343) | If players should be notified when they are reserved in this type of session instead of waiting until they're invited.
+`public bool `[`NotifyOnReservation_IsSet`](#structFRHAPI__SessionTemplate_1a9fc86e1548fa8e1e0ea7c861f984f15b) | true if NotifyOnReservation_Optional has been set to a value
 `public virtual bool `[`FromJson`](#structFRHAPI__SessionTemplate_1a4a45fc40eed406ae864f33e45c0eadf2)`(const TSharedPtr< FJsonValue > & JsonValue)` | Fills this object with data from the passed in JSON.
 `public virtual void `[`WriteJson`](#structFRHAPI__SessionTemplate_1a8ddb8c09f6817591c4927b4a5c49df76)`(TSharedRef< TJsonWriter<>> & Writer) const` | Writes the data from this object into the specified JSON Writer stream.
 `public inline FString & `[`GetSessionType`](#structFRHAPI__SessionTemplate_1a7772fb5d40d6b5c69dc188065146a39c)`()` | Gets the value of SessionType.
@@ -186,6 +190,15 @@ Template used to create new RallyHere sessions of a specific type. Configurable 
 `public inline void `[`SetAutoStartupParams`](#structFRHAPI__SessionTemplate_1aa59440ea3fe08b7645432484d67097d2)`(const `[`FRHAPI_InstanceStartupParams`](RHAPI_InstanceStartupParams.md#structFRHAPI__InstanceStartupParams)` & NewValue)` | Sets the value of AutoStartupParams_Optional and also sets AutoStartupParams_IsSet to true.
 `public inline void `[`SetAutoStartupParams`](#structFRHAPI__SessionTemplate_1a8a5bc47e88fe94a0ac5cc851f66b9b6b)`(`[`FRHAPI_InstanceStartupParams`](RHAPI_InstanceStartupParams.md#structFRHAPI__InstanceStartupParams)` && NewValue)` | Sets the value of AutoStartupParams_Optional and also sets AutoStartupParams_IsSet to true using move semantics.
 `public inline void `[`ClearAutoStartupParams`](#structFRHAPI__SessionTemplate_1a41041ffbd8775231d249554a072116d7)`()` | Clears the value of AutoStartupParams_Optional and sets AutoStartupParams_IsSet to false.
+`public inline FGuid & `[`GetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a613437211fadf3e44d3a28240bcb0185)`()` | Gets the value of AutoStartupInstanceTemplateId_Optional, regardless of it having been set.
+`public inline const FGuid & `[`GetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a3e6d3d4b473ce367d6add241b647ccaf)`() const` | Gets the value of AutoStartupInstanceTemplateId_Optional, regardless of it having been set.
+`public inline const FGuid & `[`GetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a5430fde6d440e7b612f56b65e33d1e6f)`(const FGuid & DefaultValue) const` | Gets the value of AutoStartupInstanceTemplateId_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1ae35f80049d7dc1521c2ddccd8addc87e)`(FGuid & OutValue) const` | Fills OutValue with the value of AutoStartupInstanceTemplateId_Optional and returns true if it has been set, otherwise returns false.
+`public inline FGuid * `[`GetAutoStartupInstanceTemplateIdOrNull`](#structFRHAPI__SessionTemplate_1a8992bc3eaaf0a09efdbda4d5a2f9858a)`()` | Returns a pointer to AutoStartupInstanceTemplateId_Optional, if it has been set, otherwise returns nullptr.
+`public inline const FGuid * `[`GetAutoStartupInstanceTemplateIdOrNull`](#structFRHAPI__SessionTemplate_1a351067b1dbcf1fc106d4a222606a68d9)`() const` | Returns a pointer to AutoStartupInstanceTemplateId_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a5309a18ed5a3de1bafcb9cbfabedfc46)`(const FGuid & NewValue)` | Sets the value of AutoStartupInstanceTemplateId_Optional and also sets AutoStartupInstanceTemplateId_IsSet to true.
+`public inline void `[`SetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a0335c7e457802515a793b2597691dc9f)`(FGuid && NewValue)` | Sets the value of AutoStartupInstanceTemplateId_Optional and also sets AutoStartupInstanceTemplateId_IsSet to true using move semantics.
+`public inline void `[`ClearAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a34645ae41e39de740fe31869d3e1a64f)`()` | Clears the value of AutoStartupInstanceTemplateId_Optional and sets AutoStartupInstanceTemplateId_IsSet to false.
 `public inline int32 & `[`GetMinSessionCount`](#structFRHAPI__SessionTemplate_1aab1a67e445ca5338fbb66baa3d3bcb9f)`()` | Gets the value of MinSessionCount_Optional, regardless of it having been set.
 `public inline const int32 & `[`GetMinSessionCount`](#structFRHAPI__SessionTemplate_1ab7376fd46c054e32668b755907ac0d90)`() const` | Gets the value of MinSessionCount_Optional, regardless of it having been set.
 `public inline const int32 & `[`GetMinSessionCount`](#structFRHAPI__SessionTemplate_1a1e5c95d760b8e9f40c01e6fb729c5398)`(const int32 & DefaultValue) const` | Gets the value of MinSessionCount_Optional, if it has been set, otherwise it returns DefaultValue.
@@ -239,6 +252,17 @@ Template used to create new RallyHere sessions of a specific type. Configurable 
 `public inline void `[`ClearCanChangeOwnTeam`](#structFRHAPI__SessionTemplate_1a9aa2afa1842ee1cab22a7b1a9a772c08)`()` | Clears the value of CanChangeOwnTeam_Optional and sets CanChangeOwnTeam_IsSet to false.
 `public inline bool `[`IsCanChangeOwnTeamDefaultValue`](#structFRHAPI__SessionTemplate_1a26a5ebe40250064f888d423e23531bfa)`() const` | Returns true if CanChangeOwnTeam_Optional is set and matches the default value.
 `public inline void `[`SetCanChangeOwnTeamToDefault`](#structFRHAPI__SessionTemplate_1ac1a42404ac65f492acfd7e7fe75e4afb)`()` | Sets the value of CanChangeOwnTeam_Optional to its default and also sets CanChangeOwnTeam_IsSet to true.
+`public inline bool & `[`GetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1afbde769cfdc7a6da59fb3ef7ffe29dcf)`()` | Gets the value of NotifyOnReservation_Optional, regardless of it having been set.
+`public inline const bool & `[`GetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1adec73b54a082a1e7beefd51ac8cd7f1f)`() const` | Gets the value of NotifyOnReservation_Optional, regardless of it having been set.
+`public inline const bool & `[`GetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1a2f0f47192526678f96dc58de8e8c5f09)`(const bool & DefaultValue) const` | Gets the value of NotifyOnReservation_Optional, if it has been set, otherwise it returns DefaultValue.
+`public inline bool `[`GetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1ad328d77d407db71c5bc4f162280751f7)`(bool & OutValue) const` | Fills OutValue with the value of NotifyOnReservation_Optional and returns true if it has been set, otherwise returns false.
+`public inline bool * `[`GetNotifyOnReservationOrNull`](#structFRHAPI__SessionTemplate_1a96c19d6229435cf27a687b65cce3ec47)`()` | Returns a pointer to NotifyOnReservation_Optional, if it has been set, otherwise returns nullptr.
+`public inline const bool * `[`GetNotifyOnReservationOrNull`](#structFRHAPI__SessionTemplate_1a1097a8f6fafac101f69a803102e869d5)`() const` | Returns a pointer to NotifyOnReservation_Optional, if it has been set, otherwise returns nullptr.
+`public inline void `[`SetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1a987bbef32e73963afa90d7e617393876)`(const bool & NewValue)` | Sets the value of NotifyOnReservation_Optional and also sets NotifyOnReservation_IsSet to true.
+`public inline void `[`SetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1a9fb66e4cd55fe694e458248c10d17927)`(bool && NewValue)` | Sets the value of NotifyOnReservation_Optional and also sets NotifyOnReservation_IsSet to true using move semantics.
+`public inline void `[`ClearNotifyOnReservation`](#structFRHAPI__SessionTemplate_1a09e9ca121b22271ccc7debde5c98afd1)`()` | Clears the value of NotifyOnReservation_Optional and sets NotifyOnReservation_IsSet to false.
+`public inline bool `[`IsNotifyOnReservationDefaultValue`](#structFRHAPI__SessionTemplate_1a5178c473b0e58f10f8cecfa32f155623)`() const` | Returns true if NotifyOnReservation_Optional is set and matches the default value.
+`public inline void `[`SetNotifyOnReservationToDefault`](#structFRHAPI__SessionTemplate_1afbd6260244e4d1471d0049560f3c4ba8)`()` | Sets the value of NotifyOnReservation_Optional to its default and also sets NotifyOnReservation_IsSet to true.
 
 ### Members
 
@@ -336,11 +360,19 @@ true if PlatformTemplates_Optional has been set to a value
 
 #### `public `[`FRHAPI_InstanceStartupParams`](RHAPI_InstanceStartupParams.md#structFRHAPI__InstanceStartupParams)` `[`AutoStartupParams_Optional`](#structFRHAPI__SessionTemplate_1a32d9a060ff0208b639415cee5d9f7287) <a id="structFRHAPI__SessionTemplate_1a32d9a060ff0208b639415cee5d9f7287"></a>
 
-Parameters used to start an instance for this session when it is created.
+Parameters used to start an instance for this session when it is created. Has lower priority than auto_startup_instance_template_id.
 
 #### `public bool `[`AutoStartupParams_IsSet`](#structFRHAPI__SessionTemplate_1a1ae179a6de476981a9a38197758b7e14) <a id="structFRHAPI__SessionTemplate_1a1ae179a6de476981a9a38197758b7e14"></a>
 
 true if AutoStartupParams_Optional has been set to a value
+
+#### `public FGuid `[`AutoStartupInstanceTemplateId_Optional`](#structFRHAPI__SessionTemplate_1a2a49d5a8a5818e817ca11e6d123d9ba1) <a id="structFRHAPI__SessionTemplate_1a2a49d5a8a5818e817ca11e6d123d9ba1"></a>
+
+ID of instance request template to be used to automatically request an instance on creation of a session of this type. Takes priority over auto_startup_params.
+
+#### `public bool `[`AutoStartupInstanceTemplateId_IsSet`](#structFRHAPI__SessionTemplate_1acf91e44fde96ae8bf3bbdfca666cc444) <a id="structFRHAPI__SessionTemplate_1acf91e44fde96ae8bf3bbdfca666cc444"></a>
+
+true if AutoStartupInstanceTemplateId_Optional has been set to a value
 
 #### `public int32 `[`MinSessionCount_Optional`](#structFRHAPI__SessionTemplate_1aecf6bdd55d8dc8e92bf1d6e2dc032fc6) <a id="structFRHAPI__SessionTemplate_1aecf6bdd55d8dc8e92bf1d6e2dc032fc6"></a>
 
@@ -381,6 +413,14 @@ Whether or not a player can change which team they are on. If true, they are abl
 #### `public bool `[`CanChangeOwnTeam_IsSet`](#structFRHAPI__SessionTemplate_1ad6b80d668b66266c71f70affb0cae587) <a id="structFRHAPI__SessionTemplate_1ad6b80d668b66266c71f70affb0cae587"></a>
 
 true if CanChangeOwnTeam_Optional has been set to a value
+
+#### `public bool `[`NotifyOnReservation_Optional`](#structFRHAPI__SessionTemplate_1a5c0c06cf8165a39442dfc4ab5e830343) <a id="structFRHAPI__SessionTemplate_1a5c0c06cf8165a39442dfc4ab5e830343"></a>
+
+If players should be notified when they are reserved in this type of session instead of waiting until they're invited.
+
+#### `public bool `[`NotifyOnReservation_IsSet`](#structFRHAPI__SessionTemplate_1a9fc86e1548fa8e1e0ea7c861f984f15b) <a id="structFRHAPI__SessionTemplate_1a9fc86e1548fa8e1e0ea7c861f984f15b"></a>
+
+true if NotifyOnReservation_Optional has been set to a value
 
 #### `public virtual bool `[`FromJson`](#structFRHAPI__SessionTemplate_1a4a45fc40eed406ae864f33e45c0eadf2)`(const TSharedPtr< FJsonValue > & JsonValue)` <a id="structFRHAPI__SessionTemplate_1a4a45fc40eed406ae864f33e45c0eadf2"></a>
 
@@ -919,6 +959,42 @@ Sets the value of AutoStartupParams_Optional and also sets AutoStartupParams_IsS
 
 Clears the value of AutoStartupParams_Optional and sets AutoStartupParams_IsSet to false.
 
+#### `public inline FGuid & `[`GetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a613437211fadf3e44d3a28240bcb0185)`()` <a id="structFRHAPI__SessionTemplate_1a613437211fadf3e44d3a28240bcb0185"></a>
+
+Gets the value of AutoStartupInstanceTemplateId_Optional, regardless of it having been set.
+
+#### `public inline const FGuid & `[`GetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a3e6d3d4b473ce367d6add241b647ccaf)`() const` <a id="structFRHAPI__SessionTemplate_1a3e6d3d4b473ce367d6add241b647ccaf"></a>
+
+Gets the value of AutoStartupInstanceTemplateId_Optional, regardless of it having been set.
+
+#### `public inline const FGuid & `[`GetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a5430fde6d440e7b612f56b65e33d1e6f)`(const FGuid & DefaultValue) const` <a id="structFRHAPI__SessionTemplate_1a5430fde6d440e7b612f56b65e33d1e6f"></a>
+
+Gets the value of AutoStartupInstanceTemplateId_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1ae35f80049d7dc1521c2ddccd8addc87e)`(FGuid & OutValue) const` <a id="structFRHAPI__SessionTemplate_1ae35f80049d7dc1521c2ddccd8addc87e"></a>
+
+Fills OutValue with the value of AutoStartupInstanceTemplateId_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline FGuid * `[`GetAutoStartupInstanceTemplateIdOrNull`](#structFRHAPI__SessionTemplate_1a8992bc3eaaf0a09efdbda4d5a2f9858a)`()` <a id="structFRHAPI__SessionTemplate_1a8992bc3eaaf0a09efdbda4d5a2f9858a"></a>
+
+Returns a pointer to AutoStartupInstanceTemplateId_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const FGuid * `[`GetAutoStartupInstanceTemplateIdOrNull`](#structFRHAPI__SessionTemplate_1a351067b1dbcf1fc106d4a222606a68d9)`() const` <a id="structFRHAPI__SessionTemplate_1a351067b1dbcf1fc106d4a222606a68d9"></a>
+
+Returns a pointer to AutoStartupInstanceTemplateId_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline void `[`SetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a5309a18ed5a3de1bafcb9cbfabedfc46)`(const FGuid & NewValue)` <a id="structFRHAPI__SessionTemplate_1a5309a18ed5a3de1bafcb9cbfabedfc46"></a>
+
+Sets the value of AutoStartupInstanceTemplateId_Optional and also sets AutoStartupInstanceTemplateId_IsSet to true.
+
+#### `public inline void `[`SetAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a0335c7e457802515a793b2597691dc9f)`(FGuid && NewValue)` <a id="structFRHAPI__SessionTemplate_1a0335c7e457802515a793b2597691dc9f"></a>
+
+Sets the value of AutoStartupInstanceTemplateId_Optional and also sets AutoStartupInstanceTemplateId_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearAutoStartupInstanceTemplateId`](#structFRHAPI__SessionTemplate_1a34645ae41e39de740fe31869d3e1a64f)`()` <a id="structFRHAPI__SessionTemplate_1a34645ae41e39de740fe31869d3e1a64f"></a>
+
+Clears the value of AutoStartupInstanceTemplateId_Optional and sets AutoStartupInstanceTemplateId_IsSet to false.
+
 #### `public inline int32 & `[`GetMinSessionCount`](#structFRHAPI__SessionTemplate_1aab1a67e445ca5338fbb66baa3d3bcb9f)`()` <a id="structFRHAPI__SessionTemplate_1aab1a67e445ca5338fbb66baa3d3bcb9f"></a>
 
 Gets the value of MinSessionCount_Optional, regardless of it having been set.
@@ -1130,4 +1206,48 @@ Returns true if CanChangeOwnTeam_Optional is set and matches the default value.
 #### `public inline void `[`SetCanChangeOwnTeamToDefault`](#structFRHAPI__SessionTemplate_1ac1a42404ac65f492acfd7e7fe75e4afb)`()` <a id="structFRHAPI__SessionTemplate_1ac1a42404ac65f492acfd7e7fe75e4afb"></a>
 
 Sets the value of CanChangeOwnTeam_Optional to its default and also sets CanChangeOwnTeam_IsSet to true.
+
+#### `public inline bool & `[`GetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1afbde769cfdc7a6da59fb3ef7ffe29dcf)`()` <a id="structFRHAPI__SessionTemplate_1afbde769cfdc7a6da59fb3ef7ffe29dcf"></a>
+
+Gets the value of NotifyOnReservation_Optional, regardless of it having been set.
+
+#### `public inline const bool & `[`GetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1adec73b54a082a1e7beefd51ac8cd7f1f)`() const` <a id="structFRHAPI__SessionTemplate_1adec73b54a082a1e7beefd51ac8cd7f1f"></a>
+
+Gets the value of NotifyOnReservation_Optional, regardless of it having been set.
+
+#### `public inline const bool & `[`GetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1a2f0f47192526678f96dc58de8e8c5f09)`(const bool & DefaultValue) const` <a id="structFRHAPI__SessionTemplate_1a2f0f47192526678f96dc58de8e8c5f09"></a>
+
+Gets the value of NotifyOnReservation_Optional, if it has been set, otherwise it returns DefaultValue.
+
+#### `public inline bool `[`GetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1ad328d77d407db71c5bc4f162280751f7)`(bool & OutValue) const` <a id="structFRHAPI__SessionTemplate_1ad328d77d407db71c5bc4f162280751f7"></a>
+
+Fills OutValue with the value of NotifyOnReservation_Optional and returns true if it has been set, otherwise returns false.
+
+#### `public inline bool * `[`GetNotifyOnReservationOrNull`](#structFRHAPI__SessionTemplate_1a96c19d6229435cf27a687b65cce3ec47)`()` <a id="structFRHAPI__SessionTemplate_1a96c19d6229435cf27a687b65cce3ec47"></a>
+
+Returns a pointer to NotifyOnReservation_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline const bool * `[`GetNotifyOnReservationOrNull`](#structFRHAPI__SessionTemplate_1a1097a8f6fafac101f69a803102e869d5)`() const` <a id="structFRHAPI__SessionTemplate_1a1097a8f6fafac101f69a803102e869d5"></a>
+
+Returns a pointer to NotifyOnReservation_Optional, if it has been set, otherwise returns nullptr.
+
+#### `public inline void `[`SetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1a987bbef32e73963afa90d7e617393876)`(const bool & NewValue)` <a id="structFRHAPI__SessionTemplate_1a987bbef32e73963afa90d7e617393876"></a>
+
+Sets the value of NotifyOnReservation_Optional and also sets NotifyOnReservation_IsSet to true.
+
+#### `public inline void `[`SetNotifyOnReservation`](#structFRHAPI__SessionTemplate_1a9fb66e4cd55fe694e458248c10d17927)`(bool && NewValue)` <a id="structFRHAPI__SessionTemplate_1a9fb66e4cd55fe694e458248c10d17927"></a>
+
+Sets the value of NotifyOnReservation_Optional and also sets NotifyOnReservation_IsSet to true using move semantics.
+
+#### `public inline void `[`ClearNotifyOnReservation`](#structFRHAPI__SessionTemplate_1a09e9ca121b22271ccc7debde5c98afd1)`()` <a id="structFRHAPI__SessionTemplate_1a09e9ca121b22271ccc7debde5c98afd1"></a>
+
+Clears the value of NotifyOnReservation_Optional and sets NotifyOnReservation_IsSet to false.
+
+#### `public inline bool `[`IsNotifyOnReservationDefaultValue`](#structFRHAPI__SessionTemplate_1a5178c473b0e58f10f8cecfa32f155623)`() const` <a id="structFRHAPI__SessionTemplate_1a5178c473b0e58f10f8cecfa32f155623"></a>
+
+Returns true if NotifyOnReservation_Optional is set and matches the default value.
+
+#### `public inline void `[`SetNotifyOnReservationToDefault`](#structFRHAPI__SessionTemplate_1afbd6260244e4d1471d0049560f3c4ba8)`()` <a id="structFRHAPI__SessionTemplate_1afbd6260244e4d1471d0049560f3c4ba8"></a>
+
+Sets the value of NotifyOnReservation_Optional to its default and also sets NotifyOnReservation_IsSet to true.
 

--- a/OnlineSubsystemHotfix/Source/Private/OnlineTitleFileHotfix.cpp
+++ b/OnlineSubsystemHotfix/Source/Private/OnlineTitleFileHotfix.cpp
@@ -187,17 +187,6 @@ bool FOnlineTitleFileHotfix::EnumerateFiles(const FPagedQuery& Page /*= FPagedQu
 			}
 		}
 	}
-	for (const auto& SettingPair : pConfig->GetSecretKVs())
-	{
-		if (SettingPair.Key.StartsWith(HotfixPrefix) && SettingPair.Key != strHotfixEnable && SettingPair.Value.Len() > 0)
-		{
-			FText OutErrorReason;
-			if (!ProcessHotfixSetting(SettingPair.Value, OutErrorReason))
-			{
-				UE_LOG(LogOnlineHotfix, Warning, TEXT("%s error: %s"), *SettingPair.Key, *OutErrorReason.ToString());
-			}
-		}
-	}
 
 	TriggerOnEnumerateFilesCompleteDelegates(true, TEXT(""));
 	return true;

--- a/RallyHereAPI/Source/RallyHereAPI/Private/DeserterConfig.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/DeserterConfig.cpp
@@ -24,6 +24,11 @@ void FRHAPI_DeserterConfig::WriteJson(TSharedRef<TJsonWriter<>>& Writer) const
 	Writer->WriteObjectStart();
 	Writer->WriteIdentifierPrefix(TEXT("deserter_id"));
 	RallyHereAPI::WriteJsonValue(Writer, DeserterId);
+	if (LastClearedTimestamp_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("last_cleared_timestamp"));
+		RallyHereAPI::WriteJsonValue(Writer, LastClearedTimestamp_Optional);
+	}
 	Writer->WriteObjectEnd();
 }
 
@@ -37,6 +42,12 @@ bool FRHAPI_DeserterConfig::FromJson(const TSharedPtr<FJsonValue>& JsonValue)
 
 	const TSharedPtr<FJsonValue> JsonDeserterIdField = (*Object)->TryGetField(TEXT("deserter_id"));
 	ParseSuccess &= JsonDeserterIdField.IsValid() && !JsonDeserterIdField->IsNull() && TryGetJsonValue(JsonDeserterIdField, DeserterId);
+	const TSharedPtr<FJsonValue> JsonLastClearedTimestampField = (*Object)->TryGetField(TEXT("last_cleared_timestamp"));
+	if (JsonLastClearedTimestampField.IsValid() && !JsonLastClearedTimestampField->IsNull())
+	{
+		LastClearedTimestamp_IsSet = TryGetJsonValue(JsonLastClearedTimestampField, LastClearedTimestamp_Optional);
+		ParseSuccess &= LastClearedTimestamp_IsSet;
+	}
 
 	return ParseSuccess;
 }

--- a/RallyHereAPI/Source/RallyHereAPI/Private/InstanceNotificationAPI.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/InstanceNotificationAPI.cpp
@@ -180,7 +180,7 @@ FString FResponse_InstanceCreateNotification::GetHttpResponseCodeDescription(EHt
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -411,7 +411,7 @@ FString FResponse_InstanceGetNotificationById::GetHttpResponseCodeDescription(EH
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 404:
 		return TEXT(" Error Codes: - resource_not_found - Notification could not be found ");
 	case 409:
@@ -677,7 +677,7 @@ FString FResponse_InstanceGetNotificationsPage::GetHttpResponseCodeDescription(E
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -927,7 +927,7 @@ FString FResponse_InstanceLongPollForNotifications::GetHttpResponseCodeDescripti
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:

--- a/RallyHereAPI/Source/RallyHereAPI/Private/InstanceRequest.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/InstanceRequest.cpp
@@ -32,8 +32,16 @@ void FRHAPI_InstanceRequest::WriteJson(TSharedRef<TJsonWriter<>>& Writer) const
 		Writer->WriteIdentifierPrefix(TEXT("instance_startup_params"));
 		RallyHereAPI::WriteJsonValue(Writer, InstanceStartupParams_Optional);
 	}
-	Writer->WriteIdentifierPrefix(TEXT("host_type"));
-	RallyHereAPI::WriteJsonValue(Writer, EnumToString(HostType));
+	if (HostType_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("host_type"));
+		RallyHereAPI::WriteJsonValue(Writer, EnumToString(HostType_Optional));
+	}
+	if (InstanceRequestTemplateId_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("instance_request_template_id"));
+		RallyHereAPI::WriteJsonValue(Writer, InstanceRequestTemplateId_Optional);
+	}
 	if (HostPlayerUuid_IsSet)
 	{
 		Writer->WriteIdentifierPrefix(TEXT("host_player_uuid"));
@@ -68,7 +76,17 @@ bool FRHAPI_InstanceRequest::FromJson(const TSharedPtr<FJsonValue>& JsonValue)
 		ParseSuccess &= InstanceStartupParams_IsSet;
 	}
 	const TSharedPtr<FJsonValue> JsonHostTypeField = (*Object)->TryGetField(TEXT("host_type"));
-	ParseSuccess &= JsonHostTypeField.IsValid() && !JsonHostTypeField->IsNull() && TryGetJsonValue(JsonHostTypeField, HostType);
+	if (JsonHostTypeField.IsValid() && !JsonHostTypeField->IsNull())
+	{
+		HostType_IsSet = TryGetJsonValue(JsonHostTypeField, HostType_Optional);
+		ParseSuccess &= HostType_IsSet;
+	}
+	const TSharedPtr<FJsonValue> JsonInstanceRequestTemplateIdField = (*Object)->TryGetField(TEXT("instance_request_template_id"));
+	if (JsonInstanceRequestTemplateIdField.IsValid() && !JsonInstanceRequestTemplateIdField->IsNull())
+	{
+		InstanceRequestTemplateId_IsSet = TryGetJsonValue(JsonInstanceRequestTemplateIdField, InstanceRequestTemplateId_Optional);
+		ParseSuccess &= InstanceRequestTemplateId_IsSet;
+	}
 	const TSharedPtr<FJsonValue> JsonHostPlayerUuidField = (*Object)->TryGetField(TEXT("host_player_uuid"));
 	if (JsonHostPlayerUuidField.IsValid() && !JsonHostPlayerUuidField->IsNull())
 	{

--- a/RallyHereAPI/Source/RallyHereAPI/Private/KVsResponseV2.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/KVsResponseV2.cpp
@@ -32,6 +32,11 @@ void FRHAPI_KVsResponseV2::WriteJson(TSharedRef<TJsonWriter<>>& Writer) const
 		Writer->WriteIdentifierPrefix(TEXT("secret_kvs"));
 		RallyHereAPI::WriteJsonValue(Writer, SecretKvs_Optional);
 	}
+	if (KickBeforeHint_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("kick_before_hint"));
+		RallyHereAPI::WriteJsonValue(Writer, KickBeforeHint_Optional);
+	}
 	Writer->WriteObjectEnd();
 }
 
@@ -54,6 +59,12 @@ bool FRHAPI_KVsResponseV2::FromJson(const TSharedPtr<FJsonValue>& JsonValue)
 	{
 		SecretKvs_IsSet = TryGetJsonValue(JsonSecretKvsField, SecretKvs_Optional);
 		ParseSuccess &= SecretKvs_IsSet;
+	}
+	const TSharedPtr<FJsonValue> JsonKickBeforeHintField = (*Object)->TryGetField(TEXT("kick_before_hint"));
+	if (JsonKickBeforeHintField.IsValid() && !JsonKickBeforeHintField->IsNull())
+	{
+		KickBeforeHint_IsSet = TryGetJsonValue(JsonKickBeforeHintField, KickBeforeHint_Optional);
+		ParseSuccess &= KickBeforeHint_IsSet;
 	}
 
 	return ParseSuccess;

--- a/RallyHereAPI/Source/RallyHereAPI/Private/MatchMakingProfileV2.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/MatchMakingProfileV2.cpp
@@ -61,6 +61,11 @@ void FRHAPI_MatchMakingProfileV2::WriteJson(TSharedRef<TJsonWriter<>>& Writer) c
 		Writer->WriteIdentifierPrefix(TEXT("deserter_id"));
 		RallyHereAPI::WriteJsonValue(Writer, DeserterId_Optional);
 	}
+	if (SessionTemplateId_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("session_template_id"));
+		RallyHereAPI::WriteJsonValue(Writer, SessionTemplateId_Optional);
+	}
 	Writer->WriteObjectEnd();
 }
 
@@ -117,6 +122,12 @@ bool FRHAPI_MatchMakingProfileV2::FromJson(const TSharedPtr<FJsonValue>& JsonVal
 	{
 		DeserterId_IsSet = TryGetJsonValue(JsonDeserterIdField, DeserterId_Optional);
 		ParseSuccess &= DeserterId_IsSet;
+	}
+	const TSharedPtr<FJsonValue> JsonSessionTemplateIdField = (*Object)->TryGetField(TEXT("session_template_id"));
+	if (JsonSessionTemplateIdField.IsValid() && !JsonSessionTemplateIdField->IsNull())
+	{
+		SessionTemplateId_IsSet = TryGetJsonValue(JsonSessionTemplateIdField, SessionTemplateId_Optional);
+		ParseSuccess &= SessionTemplateId_IsSet;
 	}
 
 	return ParseSuccess;

--- a/RallyHereAPI/Source/RallyHereAPI/Private/MatchMakingRuleset.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/MatchMakingRuleset.cpp
@@ -22,8 +22,11 @@ using RallyHereAPI::TryGetJsonValue;
 void FRHAPI_MatchMakingRuleset::WriteJson(TSharedRef<TJsonWriter<>>& Writer) const
 {
 	Writer->WriteObjectStart();
-	Writer->WriteIdentifierPrefix(TEXT("rules"));
-	RallyHereAPI::WriteJsonValue(Writer, Rules);
+	if (Rules_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("rules"));
+		RallyHereAPI::WriteJsonValue(Writer, Rules_Optional);
+	}
 	if (Determiner_IsSet)
 	{
 		Writer->WriteIdentifierPrefix(TEXT("determiner"));
@@ -41,7 +44,11 @@ bool FRHAPI_MatchMakingRuleset::FromJson(const TSharedPtr<FJsonValue>& JsonValue
 	bool ParseSuccess = true;
 
 	const TSharedPtr<FJsonValue> JsonRulesField = (*Object)->TryGetField(TEXT("rules"));
-	ParseSuccess &= JsonRulesField.IsValid() && !JsonRulesField->IsNull() && TryGetJsonValue(JsonRulesField, Rules);
+	if (JsonRulesField.IsValid() && !JsonRulesField->IsNull())
+	{
+		Rules_IsSet = TryGetJsonValue(JsonRulesField, Rules_Optional);
+		ParseSuccess &= Rules_IsSet;
+	}
 	const TSharedPtr<FJsonValue> JsonDeterminerField = (*Object)->TryGetField(TEXT("determiner"));
 	if (JsonDeterminerField.IsValid() && !JsonDeterminerField->IsNull())
 	{

--- a/RallyHereAPI/Source/RallyHereAPI/Private/PlayerIdNotificationAPI.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/PlayerIdNotificationAPI.cpp
@@ -180,7 +180,7 @@ FString FResponse_PlayeridCreateNotification::GetHttpResponseCodeDescription(EHt
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -416,7 +416,7 @@ FString FResponse_PlayeridCreateNotificationSelf::GetHttpResponseCodeDescription
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -647,7 +647,7 @@ FString FResponse_PlayeridGetNotificationById::GetHttpResponseCodeDescription(EH
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 404:
 		return TEXT(" Error Codes: - resource_not_found - Notification could not be found ");
 	case 409:
@@ -889,7 +889,7 @@ FString FResponse_PlayeridGetNotificationByIdSelf::GetHttpResponseCodeDescriptio
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 404:
 		return TEXT(" Error Codes: - resource_not_found - Notification could not be found ");
 	case 409:
@@ -1155,7 +1155,7 @@ FString FResponse_PlayeridGetNotificationsPage::GetHttpResponseCodeDescription(E
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -1404,7 +1404,7 @@ FString FResponse_PlayeridGetNotificationsPageSelf::GetHttpResponseCodeDescripti
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -1654,7 +1654,7 @@ FString FResponse_PlayeridLongPollForNotifications::GetHttpResponseCodeDescripti
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -1899,7 +1899,7 @@ FString FResponse_PlayeridLongPollForNotificationsSelf::GetHttpResponseCodeDescr
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:

--- a/RallyHereAPI/Source/RallyHereAPI/Private/PlayerNotificationAPI.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/PlayerNotificationAPI.cpp
@@ -180,7 +180,7 @@ FString FResponse_PlayerCreateNotification::GetHttpResponseCodeDescription(EHttp
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -416,7 +416,7 @@ FString FResponse_PlayerCreateNotificationSelf::GetHttpResponseCodeDescription(E
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -647,7 +647,7 @@ FString FResponse_PlayerGetNotificationById::GetHttpResponseCodeDescription(EHtt
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 404:
 		return TEXT(" Error Codes: - resource_not_found - Notification could not be found ");
 	case 409:
@@ -889,7 +889,7 @@ FString FResponse_PlayerGetNotificationByIdSelf::GetHttpResponseCodeDescription(
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 404:
 		return TEXT(" Error Codes: - resource_not_found - Notification could not be found ");
 	case 409:
@@ -1155,7 +1155,7 @@ FString FResponse_PlayerGetNotificationsPage::GetHttpResponseCodeDescription(EHt
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -1404,7 +1404,7 @@ FString FResponse_PlayerGetNotificationsPageSelf::GetHttpResponseCodeDescription
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -1654,7 +1654,7 @@ FString FResponse_PlayerLongPollForNotifications::GetHttpResponseCodeDescription
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:
@@ -1899,7 +1899,7 @@ FString FResponse_PlayerLongPollForNotificationsSelf::GetHttpResponseCodeDescrip
 	case 400:
 		return TEXT(" Error Codes: - bad_id - Passed client id is not a valid id ");
 	case 403:
-		return TEXT(" Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired ");
+		return TEXT(" Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization ");
 	case 409:
 		return TEXT(" Error Codes: - too_many_listening_to_single_client - An enumeration. ");
 	case 422:

--- a/RallyHereAPI/Source/RallyHereAPI/Private/PlayerSession.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/PlayerSession.cpp
@@ -34,6 +34,11 @@ void FRHAPI_PlayerSession::WriteJson(TSharedRef<TJsonWriter<>>& Writer) const
 		Writer->WriteIdentifierPrefix(TEXT("pending_invites"));
 		RallyHereAPI::WriteJsonValue(Writer, PendingInvites_Optional);
 	}
+	if (ReservedSessions_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("reserved_sessions"));
+		RallyHereAPI::WriteJsonValue(Writer, ReservedSessions_Optional);
+	}
 	Writer->WriteObjectEnd();
 }
 
@@ -58,6 +63,12 @@ bool FRHAPI_PlayerSession::FromJson(const TSharedPtr<FJsonValue>& JsonValue)
 	{
 		PendingInvites_IsSet = TryGetJsonValue(JsonPendingInvitesField, PendingInvites_Optional);
 		ParseSuccess &= PendingInvites_IsSet;
+	}
+	const TSharedPtr<FJsonValue> JsonReservedSessionsField = (*Object)->TryGetField(TEXT("reserved_sessions"));
+	if (JsonReservedSessionsField.IsValid() && !JsonReservedSessionsField->IsNull())
+	{
+		ReservedSessions_IsSet = TryGetJsonValue(JsonReservedSessionsField, ReservedSessions_Optional);
+		ParseSuccess &= ReservedSessions_IsSet;
 	}
 
 	return ParseSuccess;

--- a/RallyHereAPI/Source/RallyHereAPI/Private/QueueJoinRequest.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/QueueJoinRequest.cpp
@@ -34,6 +34,11 @@ void FRHAPI_QueueJoinRequest::WriteJson(TSharedRef<TJsonWriter<>>& Writer) const
 		Writer->WriteIdentifierPrefix(TEXT("map_preferences"));
 		RallyHereAPI::WriteJsonValue(Writer, MapPreferences_Optional);
 	}
+	if (PassedQueueTimeSeconds_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("passed_queue_time_seconds"));
+		RallyHereAPI::WriteJsonValue(Writer, PassedQueueTimeSeconds_Optional);
+	}
 	Writer->WriteObjectEnd();
 }
 
@@ -58,6 +63,12 @@ bool FRHAPI_QueueJoinRequest::FromJson(const TSharedPtr<FJsonValue>& JsonValue)
 	{
 		MapPreferences_IsSet = TryGetJsonValue(JsonMapPreferencesField, MapPreferences_Optional);
 		ParseSuccess &= MapPreferences_IsSet;
+	}
+	const TSharedPtr<FJsonValue> JsonPassedQueueTimeSecondsField = (*Object)->TryGetField(TEXT("passed_queue_time_seconds"));
+	if (JsonPassedQueueTimeSecondsField.IsValid() && !JsonPassedQueueTimeSecondsField->IsNull())
+	{
+		PassedQueueTimeSeconds_IsSet = TryGetJsonValue(JsonPassedQueueTimeSecondsField, PassedQueueTimeSeconds_Optional);
+		ParseSuccess &= PassedQueueTimeSeconds_IsSet;
 	}
 
 	return ParseSuccess;

--- a/RallyHereAPI/Source/RallyHereAPI/Private/SessionTemplate.cpp
+++ b/RallyHereAPI/Source/RallyHereAPI/Private/SessionTemplate.cpp
@@ -84,6 +84,11 @@ void FRHAPI_SessionTemplate::WriteJson(TSharedRef<TJsonWriter<>>& Writer) const
 		Writer->WriteIdentifierPrefix(TEXT("auto_startup_params"));
 		RallyHereAPI::WriteJsonValue(Writer, AutoStartupParams_Optional);
 	}
+	if (AutoStartupInstanceTemplateId_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("auto_startup_instance_template_id"));
+		RallyHereAPI::WriteJsonValue(Writer, AutoStartupInstanceTemplateId_Optional);
+	}
 	if (MinSessionCount_IsSet)
 	{
 		Writer->WriteIdentifierPrefix(TEXT("min_session_count"));
@@ -108,6 +113,11 @@ void FRHAPI_SessionTemplate::WriteJson(TSharedRef<TJsonWriter<>>& Writer) const
 	{
 		Writer->WriteIdentifierPrefix(TEXT("can_change_own_team"));
 		RallyHereAPI::WriteJsonValue(Writer, CanChangeOwnTeam_Optional);
+	}
+	if (NotifyOnReservation_IsSet)
+	{
+		Writer->WriteIdentifierPrefix(TEXT("notify_on_reservation"));
+		RallyHereAPI::WriteJsonValue(Writer, NotifyOnReservation_Optional);
 	}
 	Writer->WriteObjectEnd();
 }
@@ -194,6 +204,12 @@ bool FRHAPI_SessionTemplate::FromJson(const TSharedPtr<FJsonValue>& JsonValue)
 		AutoStartupParams_IsSet = TryGetJsonValue(JsonAutoStartupParamsField, AutoStartupParams_Optional);
 		ParseSuccess &= AutoStartupParams_IsSet;
 	}
+	const TSharedPtr<FJsonValue> JsonAutoStartupInstanceTemplateIdField = (*Object)->TryGetField(TEXT("auto_startup_instance_template_id"));
+	if (JsonAutoStartupInstanceTemplateIdField.IsValid() && !JsonAutoStartupInstanceTemplateIdField->IsNull())
+	{
+		AutoStartupInstanceTemplateId_IsSet = TryGetJsonValue(JsonAutoStartupInstanceTemplateIdField, AutoStartupInstanceTemplateId_Optional);
+		ParseSuccess &= AutoStartupInstanceTemplateId_IsSet;
+	}
 	const TSharedPtr<FJsonValue> JsonMinSessionCountField = (*Object)->TryGetField(TEXT("min_session_count"));
 	if (JsonMinSessionCountField.IsValid() && !JsonMinSessionCountField->IsNull())
 	{
@@ -223,6 +239,12 @@ bool FRHAPI_SessionTemplate::FromJson(const TSharedPtr<FJsonValue>& JsonValue)
 	{
 		CanChangeOwnTeam_IsSet = TryGetJsonValue(JsonCanChangeOwnTeamField, CanChangeOwnTeam_Optional);
 		ParseSuccess &= CanChangeOwnTeam_IsSet;
+	}
+	const TSharedPtr<FJsonValue> JsonNotifyOnReservationField = (*Object)->TryGetField(TEXT("notify_on_reservation"));
+	if (JsonNotifyOnReservationField.IsValid() && !JsonNotifyOnReservationField->IsNull())
+	{
+		NotifyOnReservation_IsSet = TryGetJsonValue(JsonNotifyOnReservationField, NotifyOnReservation_Optional);
+		ParseSuccess &= NotifyOnReservation_IsSet;
 	}
 
 	return ParseSuccess;

--- a/RallyHereAPI/Source/RallyHereAPI/Public/DeserterConfig.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/DeserterConfig.h
@@ -50,6 +50,31 @@ struct RALLYHEREAPI_API FRHAPI_DeserterConfig : public FRHAPI_Model
 	void SetDeserterId(const FGuid& NewValue) { DeserterId = NewValue;  }
 	/** @brief Sets the value of DeserterId using move semantics */
 	void SetDeserterId(FGuid&& NewValue) { DeserterId = NewValue;  }
+
+	/** @brief Datetime that enforces that a timezone is given. Unix timestamps are allowed and forced into the UTC time zone */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	FDateTime LastClearedTimestamp_Optional{  };
+	/** @brief true if LastClearedTimestamp_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool LastClearedTimestamp_IsSet{ false };
+	/** @brief Gets the value of LastClearedTimestamp_Optional, regardless of it having been set */
+	FDateTime& GetLastClearedTimestamp() { return LastClearedTimestamp_Optional; }
+	/** @brief Gets the value of LastClearedTimestamp_Optional, regardless of it having been set */
+	const FDateTime& GetLastClearedTimestamp() const { return LastClearedTimestamp_Optional; }
+	/** @brief Gets the value of LastClearedTimestamp_Optional, if it has been set, otherwise it returns DefaultValue */
+	const FDateTime& GetLastClearedTimestamp(const FDateTime& DefaultValue) const { if (LastClearedTimestamp_IsSet) return LastClearedTimestamp_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of LastClearedTimestamp_Optional and returns true if it has been set, otherwise returns false */
+	bool GetLastClearedTimestamp(FDateTime& OutValue) const { if (LastClearedTimestamp_IsSet) OutValue = LastClearedTimestamp_Optional; return LastClearedTimestamp_IsSet; }
+	/** @brief Returns a pointer to LastClearedTimestamp_Optional, if it has been set, otherwise returns nullptr */
+	FDateTime* GetLastClearedTimestampOrNull() { if (LastClearedTimestamp_IsSet) return &LastClearedTimestamp_Optional; return nullptr; }
+	/** @brief Returns a pointer to LastClearedTimestamp_Optional, if it has been set, otherwise returns nullptr */
+	const FDateTime* GetLastClearedTimestampOrNull() const { if (LastClearedTimestamp_IsSet) return &LastClearedTimestamp_Optional; return nullptr; }
+	/** @brief Sets the value of LastClearedTimestamp_Optional and also sets LastClearedTimestamp_IsSet to true */
+	void SetLastClearedTimestamp(const FDateTime& NewValue) { LastClearedTimestamp_Optional = NewValue; LastClearedTimestamp_IsSet = true; }
+	/** @brief Sets the value of LastClearedTimestamp_Optional and also sets LastClearedTimestamp_IsSet to true using move semantics */
+	void SetLastClearedTimestamp(FDateTime&& NewValue) { LastClearedTimestamp_Optional = NewValue; LastClearedTimestamp_IsSet = true; }
+	 /** @brief Clears the value of LastClearedTimestamp_Optional and sets LastClearedTimestamp_IsSet to false */
+	void ClearLastClearedTimestamp() { LastClearedTimestamp_IsSet = false; }
 };
 
 /** @} */

--- a/RallyHereAPI/Source/RallyHereAPI/Public/InstanceNotificationAPI.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/InstanceNotificationAPI.h
@@ -104,7 +104,7 @@ struct RALLYHEREAPI_API FResponse_InstanceCreateNotification : public FResponse
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -185,7 +185,7 @@ struct RALLYHEREAPI_API FResponse_InstanceGetNotificationById : public FResponse
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -290,7 +290,7 @@ struct RALLYHEREAPI_API FResponse_InstanceGetNotificationsPage : public FRespons
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -384,7 +384,7 @@ struct RALLYHEREAPI_API FResponse_InstanceLongPollForNotifications : public FRes
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 

--- a/RallyHereAPI/Source/RallyHereAPI/Public/InstanceRequest.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/InstanceRequest.h
@@ -93,15 +93,53 @@ struct RALLYHEREAPI_API FRHAPI_InstanceRequest : public FRHAPI_Model
 
 	/** @brief Type of the host */
 	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
-	ERHAPI_HostType HostType{  };
-	/** @brief Gets the value of HostType */
-	ERHAPI_HostType& GetHostType() { return HostType; }
-	/** @brief Gets the value of HostType */
-	const ERHAPI_HostType& GetHostType() const { return HostType; }
-	/** @brief Sets the value of HostType */
-	void SetHostType(const ERHAPI_HostType& NewValue) { HostType = NewValue;  }
-	/** @brief Sets the value of HostType using move semantics */
-	void SetHostType(ERHAPI_HostType&& NewValue) { HostType = NewValue;  }
+	ERHAPI_HostType HostType_Optional{  };
+	/** @brief true if HostType_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool HostType_IsSet{ false };
+	/** @brief Gets the value of HostType_Optional, regardless of it having been set */
+	ERHAPI_HostType& GetHostType() { return HostType_Optional; }
+	/** @brief Gets the value of HostType_Optional, regardless of it having been set */
+	const ERHAPI_HostType& GetHostType() const { return HostType_Optional; }
+	/** @brief Gets the value of HostType_Optional, if it has been set, otherwise it returns DefaultValue */
+	const ERHAPI_HostType& GetHostType(const ERHAPI_HostType& DefaultValue) const { if (HostType_IsSet) return HostType_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of HostType_Optional and returns true if it has been set, otherwise returns false */
+	bool GetHostType(ERHAPI_HostType& OutValue) const { if (HostType_IsSet) OutValue = HostType_Optional; return HostType_IsSet; }
+	/** @brief Returns a pointer to HostType_Optional, if it has been set, otherwise returns nullptr */
+	ERHAPI_HostType* GetHostTypeOrNull() { if (HostType_IsSet) return &HostType_Optional; return nullptr; }
+	/** @brief Returns a pointer to HostType_Optional, if it has been set, otherwise returns nullptr */
+	const ERHAPI_HostType* GetHostTypeOrNull() const { if (HostType_IsSet) return &HostType_Optional; return nullptr; }
+	/** @brief Sets the value of HostType_Optional and also sets HostType_IsSet to true */
+	void SetHostType(const ERHAPI_HostType& NewValue) { HostType_Optional = NewValue; HostType_IsSet = true; }
+	/** @brief Sets the value of HostType_Optional and also sets HostType_IsSet to true using move semantics */
+	void SetHostType(ERHAPI_HostType&& NewValue) { HostType_Optional = NewValue; HostType_IsSet = true; }
+	 /** @brief Clears the value of HostType_Optional and sets HostType_IsSet to false */
+	void ClearHostType() { HostType_IsSet = false; }
+
+	/** @brief Which instance request template should be used to request this instance. Takes priority over instance_startup_params and host_type */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	FGuid InstanceRequestTemplateId_Optional{  };
+	/** @brief true if InstanceRequestTemplateId_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool InstanceRequestTemplateId_IsSet{ false };
+	/** @brief Gets the value of InstanceRequestTemplateId_Optional, regardless of it having been set */
+	FGuid& GetInstanceRequestTemplateId() { return InstanceRequestTemplateId_Optional; }
+	/** @brief Gets the value of InstanceRequestTemplateId_Optional, regardless of it having been set */
+	const FGuid& GetInstanceRequestTemplateId() const { return InstanceRequestTemplateId_Optional; }
+	/** @brief Gets the value of InstanceRequestTemplateId_Optional, if it has been set, otherwise it returns DefaultValue */
+	const FGuid& GetInstanceRequestTemplateId(const FGuid& DefaultValue) const { if (InstanceRequestTemplateId_IsSet) return InstanceRequestTemplateId_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of InstanceRequestTemplateId_Optional and returns true if it has been set, otherwise returns false */
+	bool GetInstanceRequestTemplateId(FGuid& OutValue) const { if (InstanceRequestTemplateId_IsSet) OutValue = InstanceRequestTemplateId_Optional; return InstanceRequestTemplateId_IsSet; }
+	/** @brief Returns a pointer to InstanceRequestTemplateId_Optional, if it has been set, otherwise returns nullptr */
+	FGuid* GetInstanceRequestTemplateIdOrNull() { if (InstanceRequestTemplateId_IsSet) return &InstanceRequestTemplateId_Optional; return nullptr; }
+	/** @brief Returns a pointer to InstanceRequestTemplateId_Optional, if it has been set, otherwise returns nullptr */
+	const FGuid* GetInstanceRequestTemplateIdOrNull() const { if (InstanceRequestTemplateId_IsSet) return &InstanceRequestTemplateId_Optional; return nullptr; }
+	/** @brief Sets the value of InstanceRequestTemplateId_Optional and also sets InstanceRequestTemplateId_IsSet to true */
+	void SetInstanceRequestTemplateId(const FGuid& NewValue) { InstanceRequestTemplateId_Optional = NewValue; InstanceRequestTemplateId_IsSet = true; }
+	/** @brief Sets the value of InstanceRequestTemplateId_Optional and also sets InstanceRequestTemplateId_IsSet to true using move semantics */
+	void SetInstanceRequestTemplateId(FGuid&& NewValue) { InstanceRequestTemplateId_Optional = NewValue; InstanceRequestTemplateId_IsSet = true; }
+	 /** @brief Clears the value of InstanceRequestTemplateId_Optional and sets InstanceRequestTemplateId_IsSet to false */
+	void ClearInstanceRequestTemplateId() { InstanceRequestTemplateId_IsSet = false; }
 
 	/** @brief Player UUID of the host, if the host type is player */
 	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")

--- a/RallyHereAPI/Source/RallyHereAPI/Public/KVsResponseV2.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/KVsResponseV2.h
@@ -64,7 +64,7 @@ struct RALLYHEREAPI_API FRHAPI_KVsResponseV2 : public FRHAPI_Model
 	 /** @brief Clears the value of Kvs_Optional and sets Kvs_IsSet to false */
 	void ClearKvs() { Kvs_IsSet = false; }
 
-	/** @brief The list of secret key/value pairs */
+	/** @brief *DEPRECATED* The list of permissioned key/value pairs */
 	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
 	TMap<FString, FString> SecretKvs_Optional{  };
 	/** @brief true if SecretKvs_Optional has been set to a value */
@@ -88,6 +88,31 @@ struct RALLYHEREAPI_API FRHAPI_KVsResponseV2 : public FRHAPI_Model
 	void SetSecretKvs(TMap<FString, FString>&& NewValue) { SecretKvs_Optional = NewValue; SecretKvs_IsSet = true; }
 	 /** @brief Clears the value of SecretKvs_Optional and sets SecretKvs_IsSet to false */
 	void ClearSecretKvs() { SecretKvs_IsSet = false; }
+
+	/** @brief Datetime that enforces that a timezone is given. Unix timestamps are allowed and forced into the UTC time zone */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	FDateTime KickBeforeHint_Optional{  };
+	/** @brief true if KickBeforeHint_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool KickBeforeHint_IsSet{ false };
+	/** @brief Gets the value of KickBeforeHint_Optional, regardless of it having been set */
+	FDateTime& GetKickBeforeHint() { return KickBeforeHint_Optional; }
+	/** @brief Gets the value of KickBeforeHint_Optional, regardless of it having been set */
+	const FDateTime& GetKickBeforeHint() const { return KickBeforeHint_Optional; }
+	/** @brief Gets the value of KickBeforeHint_Optional, if it has been set, otherwise it returns DefaultValue */
+	const FDateTime& GetKickBeforeHint(const FDateTime& DefaultValue) const { if (KickBeforeHint_IsSet) return KickBeforeHint_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of KickBeforeHint_Optional and returns true if it has been set, otherwise returns false */
+	bool GetKickBeforeHint(FDateTime& OutValue) const { if (KickBeforeHint_IsSet) OutValue = KickBeforeHint_Optional; return KickBeforeHint_IsSet; }
+	/** @brief Returns a pointer to KickBeforeHint_Optional, if it has been set, otherwise returns nullptr */
+	FDateTime* GetKickBeforeHintOrNull() { if (KickBeforeHint_IsSet) return &KickBeforeHint_Optional; return nullptr; }
+	/** @brief Returns a pointer to KickBeforeHint_Optional, if it has been set, otherwise returns nullptr */
+	const FDateTime* GetKickBeforeHintOrNull() const { if (KickBeforeHint_IsSet) return &KickBeforeHint_Optional; return nullptr; }
+	/** @brief Sets the value of KickBeforeHint_Optional and also sets KickBeforeHint_IsSet to true */
+	void SetKickBeforeHint(const FDateTime& NewValue) { KickBeforeHint_Optional = NewValue; KickBeforeHint_IsSet = true; }
+	/** @brief Sets the value of KickBeforeHint_Optional and also sets KickBeforeHint_IsSet to true using move semantics */
+	void SetKickBeforeHint(FDateTime&& NewValue) { KickBeforeHint_Optional = NewValue; KickBeforeHint_IsSet = true; }
+	 /** @brief Clears the value of KickBeforeHint_Optional and sets KickBeforeHint_IsSet to false */
+	void ClearKickBeforeHint() { KickBeforeHint_IsSet = false; }
 };
 
 /** @} */

--- a/RallyHereAPI/Source/RallyHereAPI/Public/MatchMakingProfileV2.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/MatchMakingProfileV2.h
@@ -250,6 +250,31 @@ struct RALLYHEREAPI_API FRHAPI_MatchMakingProfileV2 : public FRHAPI_Model
 	void SetDeserterId(FString&& NewValue) { DeserterId_Optional = NewValue; DeserterId_IsSet = true; }
 	 /** @brief Clears the value of DeserterId_Optional and sets DeserterId_IsSet to false */
 	void ClearDeserterId() { DeserterId_IsSet = false; }
+
+	/** @brief What type of session should result from matchmaking on this profile */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	FGuid SessionTemplateId_Optional{  };
+	/** @brief true if SessionTemplateId_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool SessionTemplateId_IsSet{ false };
+	/** @brief Gets the value of SessionTemplateId_Optional, regardless of it having been set */
+	FGuid& GetSessionTemplateId() { return SessionTemplateId_Optional; }
+	/** @brief Gets the value of SessionTemplateId_Optional, regardless of it having been set */
+	const FGuid& GetSessionTemplateId() const { return SessionTemplateId_Optional; }
+	/** @brief Gets the value of SessionTemplateId_Optional, if it has been set, otherwise it returns DefaultValue */
+	const FGuid& GetSessionTemplateId(const FGuid& DefaultValue) const { if (SessionTemplateId_IsSet) return SessionTemplateId_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of SessionTemplateId_Optional and returns true if it has been set, otherwise returns false */
+	bool GetSessionTemplateId(FGuid& OutValue) const { if (SessionTemplateId_IsSet) OutValue = SessionTemplateId_Optional; return SessionTemplateId_IsSet; }
+	/** @brief Returns a pointer to SessionTemplateId_Optional, if it has been set, otherwise returns nullptr */
+	FGuid* GetSessionTemplateIdOrNull() { if (SessionTemplateId_IsSet) return &SessionTemplateId_Optional; return nullptr; }
+	/** @brief Returns a pointer to SessionTemplateId_Optional, if it has been set, otherwise returns nullptr */
+	const FGuid* GetSessionTemplateIdOrNull() const { if (SessionTemplateId_IsSet) return &SessionTemplateId_Optional; return nullptr; }
+	/** @brief Sets the value of SessionTemplateId_Optional and also sets SessionTemplateId_IsSet to true */
+	void SetSessionTemplateId(const FGuid& NewValue) { SessionTemplateId_Optional = NewValue; SessionTemplateId_IsSet = true; }
+	/** @brief Sets the value of SessionTemplateId_Optional and also sets SessionTemplateId_IsSet to true using move semantics */
+	void SetSessionTemplateId(FGuid&& NewValue) { SessionTemplateId_Optional = NewValue; SessionTemplateId_IsSet = true; }
+	 /** @brief Clears the value of SessionTemplateId_Optional and sets SessionTemplateId_IsSet to false */
+	void ClearSessionTemplateId() { SessionTemplateId_IsSet = false; }
 };
 
 /** @} */

--- a/RallyHereAPI/Source/RallyHereAPI/Public/MatchMakingRuleset.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/MatchMakingRuleset.h
@@ -43,15 +43,28 @@ struct RALLYHEREAPI_API FRHAPI_MatchMakingRuleset : public FRHAPI_Model
 
 	/** @brief A list of the rules to be checked for this ruleset */
 	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
-	TArray<FRHAPI_Rule> Rules{  };
-	/** @brief Gets the value of Rules */
-	TArray<FRHAPI_Rule>& GetRules() { return Rules; }
-	/** @brief Gets the value of Rules */
-	const TArray<FRHAPI_Rule>& GetRules() const { return Rules; }
-	/** @brief Sets the value of Rules */
-	void SetRules(const TArray<FRHAPI_Rule>& NewValue) { Rules = NewValue;  }
-	/** @brief Sets the value of Rules using move semantics */
-	void SetRules(TArray<FRHAPI_Rule>&& NewValue) { Rules = NewValue;  }
+	TArray<FRHAPI_Rule> Rules_Optional{  };
+	/** @brief true if Rules_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool Rules_IsSet{ false };
+	/** @brief Gets the value of Rules_Optional, regardless of it having been set */
+	TArray<FRHAPI_Rule>& GetRules() { return Rules_Optional; }
+	/** @brief Gets the value of Rules_Optional, regardless of it having been set */
+	const TArray<FRHAPI_Rule>& GetRules() const { return Rules_Optional; }
+	/** @brief Gets the value of Rules_Optional, if it has been set, otherwise it returns DefaultValue */
+	const TArray<FRHAPI_Rule>& GetRules(const TArray<FRHAPI_Rule>& DefaultValue) const { if (Rules_IsSet) return Rules_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of Rules_Optional and returns true if it has been set, otherwise returns false */
+	bool GetRules(TArray<FRHAPI_Rule>& OutValue) const { if (Rules_IsSet) OutValue = Rules_Optional; return Rules_IsSet; }
+	/** @brief Returns a pointer to Rules_Optional, if it has been set, otherwise returns nullptr */
+	TArray<FRHAPI_Rule>* GetRulesOrNull() { if (Rules_IsSet) return &Rules_Optional; return nullptr; }
+	/** @brief Returns a pointer to Rules_Optional, if it has been set, otherwise returns nullptr */
+	const TArray<FRHAPI_Rule>* GetRulesOrNull() const { if (Rules_IsSet) return &Rules_Optional; return nullptr; }
+	/** @brief Sets the value of Rules_Optional and also sets Rules_IsSet to true */
+	void SetRules(const TArray<FRHAPI_Rule>& NewValue) { Rules_Optional = NewValue; Rules_IsSet = true; }
+	/** @brief Sets the value of Rules_Optional and also sets Rules_IsSet to true using move semantics */
+	void SetRules(TArray<FRHAPI_Rule>&& NewValue) { Rules_Optional = NewValue; Rules_IsSet = true; }
+	 /** @brief Clears the value of Rules_Optional and sets Rules_IsSet to false */
+	void ClearRules() { Rules_IsSet = false; }
 
 	/** @brief Determiner of how many rules must be satisfied in this rulest (all, any, one, none) */
 	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")

--- a/RallyHereAPI/Source/RallyHereAPI/Public/PlayerIdNotificationAPI.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/PlayerIdNotificationAPI.h
@@ -124,7 +124,7 @@ struct RALLYHEREAPI_API FResponse_PlayeridCreateNotification : public FResponse
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -199,7 +199,7 @@ struct RALLYHEREAPI_API FResponse_PlayeridCreateNotificationSelf : public FRespo
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -280,7 +280,7 @@ struct RALLYHEREAPI_API FResponse_PlayeridGetNotificationById : public FResponse
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -361,7 +361,7 @@ struct RALLYHEREAPI_API FResponse_PlayeridGetNotificationByIdSelf : public FResp
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -466,7 +466,7 @@ struct RALLYHEREAPI_API FResponse_PlayeridGetNotificationsPage : public FRespons
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -561,7 +561,7 @@ struct RALLYHEREAPI_API FResponse_PlayeridGetNotificationsPageSelf : public FRes
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -655,7 +655,7 @@ struct RALLYHEREAPI_API FResponse_PlayeridLongPollForNotifications : public FRes
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -744,7 +744,7 @@ struct RALLYHEREAPI_API FResponse_PlayeridLongPollForNotificationsSelf : public 
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 

--- a/RallyHereAPI/Source/RallyHereAPI/Public/PlayerNotificationAPI.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/PlayerNotificationAPI.h
@@ -124,7 +124,7 @@ struct RALLYHEREAPI_API FResponse_PlayerCreateNotification : public FResponse
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -199,7 +199,7 @@ struct RALLYHEREAPI_API FResponse_PlayerCreateNotificationSelf : public FRespons
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -280,7 +280,7 @@ struct RALLYHEREAPI_API FResponse_PlayerGetNotificationById : public FResponse
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -361,7 +361,7 @@ struct RALLYHEREAPI_API FResponse_PlayerGetNotificationByIdSelf : public FRespon
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -466,7 +466,7 @@ struct RALLYHEREAPI_API FResponse_PlayerGetNotificationsPage : public FResponse
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -561,7 +561,7 @@ struct RALLYHEREAPI_API FResponse_PlayerGetNotificationsPageSelf : public FRespo
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -655,7 +655,7 @@ struct RALLYHEREAPI_API FResponse_PlayerLongPollForNotifications : public FRespo
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 
@@ -744,7 +744,7 @@ struct RALLYHEREAPI_API FResponse_PlayerLongPollForNotificationsSelf : public FR
 	bool TryGetContentFor400(FRHAPI_HzApiErrorModel& OutContent) const;
 
 	/* Response 403
-	 Error Codes: - insufficient_permissions - Insufficient Permissions - auth_not_jwt - Invalid Authorization - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_invalid_version - Invalid Authorization - version - auth_token_unknown - Failed to parse token - auth_token_format - Invalid Authorization - {} - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_token_expired - Token is expired 
+	 Error Codes: - auth_invalid_version - Invalid Authorization - version - auth_token_invalid_claim - Token contained invalid claim value: {} - auth_invalid_key_id - Invalid Authorization - Invalid Key ID in Access Token - auth_malformed_access - Invalid Authorization - malformed access token - auth_token_sig_invalid - Token Signature is invalid - auth_token_format - Invalid Authorization - {} - auth_token_expired - Token is expired - insufficient_permissions - Insufficient Permissions - auth_token_unknown - Failed to parse token - auth_not_jwt - Invalid Authorization 
 	*/
 	bool TryGetContentFor403(FRHAPI_HzApiErrorModel& OutContent) const;
 

--- a/RallyHereAPI/Source/RallyHereAPI/Public/PlayerSession.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/PlayerSession.h
@@ -102,6 +102,31 @@ struct RALLYHEREAPI_API FRHAPI_PlayerSession : public FRHAPI_Model
 	void SetPendingInvites(TMap<FString, FRHAPI_PlayerSessionInvite>&& NewValue) { PendingInvites_Optional = NewValue; PendingInvites_IsSet = true; }
 	 /** @brief Clears the value of PendingInvites_Optional and sets PendingInvites_IsSet to false */
 	void ClearPendingInvites() { PendingInvites_IsSet = false; }
+
+	/** @brief Sessions that the player has a reserved place in, but has not yet been invited */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	TSet<FString> ReservedSessions_Optional{  };
+	/** @brief true if ReservedSessions_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool ReservedSessions_IsSet{ false };
+	/** @brief Gets the value of ReservedSessions_Optional, regardless of it having been set */
+	TSet<FString>& GetReservedSessions() { return ReservedSessions_Optional; }
+	/** @brief Gets the value of ReservedSessions_Optional, regardless of it having been set */
+	const TSet<FString>& GetReservedSessions() const { return ReservedSessions_Optional; }
+	/** @brief Gets the value of ReservedSessions_Optional, if it has been set, otherwise it returns DefaultValue */
+	const TSet<FString>& GetReservedSessions(const TSet<FString>& DefaultValue) const { if (ReservedSessions_IsSet) return ReservedSessions_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of ReservedSessions_Optional and returns true if it has been set, otherwise returns false */
+	bool GetReservedSessions(TSet<FString>& OutValue) const { if (ReservedSessions_IsSet) OutValue = ReservedSessions_Optional; return ReservedSessions_IsSet; }
+	/** @brief Returns a pointer to ReservedSessions_Optional, if it has been set, otherwise returns nullptr */
+	TSet<FString>* GetReservedSessionsOrNull() { if (ReservedSessions_IsSet) return &ReservedSessions_Optional; return nullptr; }
+	/** @brief Returns a pointer to ReservedSessions_Optional, if it has been set, otherwise returns nullptr */
+	const TSet<FString>* GetReservedSessionsOrNull() const { if (ReservedSessions_IsSet) return &ReservedSessions_Optional; return nullptr; }
+	/** @brief Sets the value of ReservedSessions_Optional and also sets ReservedSessions_IsSet to true */
+	void SetReservedSessions(const TSet<FString>& NewValue) { ReservedSessions_Optional = NewValue; ReservedSessions_IsSet = true; }
+	/** @brief Sets the value of ReservedSessions_Optional and also sets ReservedSessions_IsSet to true using move semantics */
+	void SetReservedSessions(TSet<FString>&& NewValue) { ReservedSessions_Optional = NewValue; ReservedSessions_IsSet = true; }
+	 /** @brief Clears the value of ReservedSessions_Optional and sets ReservedSessions_IsSet to false */
+	void ClearReservedSessions() { ReservedSessions_IsSet = false; }
 };
 
 /** @} */

--- a/RallyHereAPI/Source/RallyHereAPI/Public/QueueJoinRequest.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/QueueJoinRequest.h
@@ -101,6 +101,35 @@ struct RALLYHEREAPI_API FRHAPI_QueueJoinRequest : public FRHAPI_Model
 	void SetMapPreferences(TArray<FString>&& NewValue) { MapPreferences_Optional = NewValue; MapPreferences_IsSet = true; }
 	 /** @brief Clears the value of MapPreferences_Optional and sets MapPreferences_IsSet to false */
 	void ClearMapPreferences() { MapPreferences_IsSet = false; }
+
+	/** @brief Argument to artifcially add queue time to a ticket. Older tickets are considered for lower quaulity matches. This can be used to get faster matches at the expense of quality, or to restore a session's place in queue after a failure */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	int32 PassedQueueTimeSeconds_Optional{  };
+	/** @brief true if PassedQueueTimeSeconds_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool PassedQueueTimeSeconds_IsSet{ false };
+	/** @brief Gets the value of PassedQueueTimeSeconds_Optional, regardless of it having been set */
+	int32& GetPassedQueueTimeSeconds() { return PassedQueueTimeSeconds_Optional; }
+	/** @brief Gets the value of PassedQueueTimeSeconds_Optional, regardless of it having been set */
+	const int32& GetPassedQueueTimeSeconds() const { return PassedQueueTimeSeconds_Optional; }
+	/** @brief Gets the value of PassedQueueTimeSeconds_Optional, if it has been set, otherwise it returns DefaultValue */
+	const int32& GetPassedQueueTimeSeconds(const int32& DefaultValue) const { if (PassedQueueTimeSeconds_IsSet) return PassedQueueTimeSeconds_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of PassedQueueTimeSeconds_Optional and returns true if it has been set, otherwise returns false */
+	bool GetPassedQueueTimeSeconds(int32& OutValue) const { if (PassedQueueTimeSeconds_IsSet) OutValue = PassedQueueTimeSeconds_Optional; return PassedQueueTimeSeconds_IsSet; }
+	/** @brief Returns a pointer to PassedQueueTimeSeconds_Optional, if it has been set, otherwise returns nullptr */
+	int32* GetPassedQueueTimeSecondsOrNull() { if (PassedQueueTimeSeconds_IsSet) return &PassedQueueTimeSeconds_Optional; return nullptr; }
+	/** @brief Returns a pointer to PassedQueueTimeSeconds_Optional, if it has been set, otherwise returns nullptr */
+	const int32* GetPassedQueueTimeSecondsOrNull() const { if (PassedQueueTimeSeconds_IsSet) return &PassedQueueTimeSeconds_Optional; return nullptr; }
+	/** @brief Sets the value of PassedQueueTimeSeconds_Optional and also sets PassedQueueTimeSeconds_IsSet to true */
+	void SetPassedQueueTimeSeconds(const int32& NewValue) { PassedQueueTimeSeconds_Optional = NewValue; PassedQueueTimeSeconds_IsSet = true; }
+	/** @brief Sets the value of PassedQueueTimeSeconds_Optional and also sets PassedQueueTimeSeconds_IsSet to true using move semantics */
+	void SetPassedQueueTimeSeconds(int32&& NewValue) { PassedQueueTimeSeconds_Optional = NewValue; PassedQueueTimeSeconds_IsSet = true; }
+	 /** @brief Clears the value of PassedQueueTimeSeconds_Optional and sets PassedQueueTimeSeconds_IsSet to false */
+	void ClearPassedQueueTimeSeconds() { PassedQueueTimeSeconds_Optional = 0; PassedQueueTimeSeconds_IsSet = false; }
+	/** @brief Returns true if PassedQueueTimeSeconds_Optional is set and matches the default value */
+	bool IsPassedQueueTimeSecondsDefaultValue() const { return PassedQueueTimeSeconds_IsSet && PassedQueueTimeSeconds_Optional == 0; }
+	/** @brief Sets the value of PassedQueueTimeSeconds_Optional to its default and also sets PassedQueueTimeSeconds_IsSet to true */
+	void SetPassedQueueTimeSecondsToDefault() { PassedQueueTimeSeconds_Optional = 0; PassedQueueTimeSeconds_IsSet = true; }
 };
 
 /** @} */

--- a/RallyHereAPI/Source/RallyHereAPI/Public/ReportsAPI.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/ReportsAPI.h
@@ -64,7 +64,7 @@ private:
  *
  * Create a new report for a target player
  * Required Permissions:
- * If `source_player_uuid` is not provided, or is the same as the active player: any of: `sanction:report:create:any`, `sanction:*`, `sanction:report:create:self`
+ * If `source_player_uuid` is not provided, or is the same as the active player: any of: `sanction:report:create:self`, `sanction:report:create:any`, `sanction:*`
  * Otherwise: any of: `sanction:report:create:any`, `sanction:*`
 */
 struct RALLYHEREAPI_API FRequest_CreateReportForTargetPlayerUuid : public FRequest
@@ -142,7 +142,7 @@ struct RALLYHEREAPI_API Traits_CreateReportForTargetPlayerUuid
  * 
  * Source players will be empty without the Required Permissions:
  * 
- * - For any player (including themselves) any of: `sanction:*`, `sanction:report:read:source-any`
+ * - For any player (including themselves) any of: `sanction:report:read:source-any`, `sanction:*`
  * 
  * - For the player themselves : `sanction:report:read:source-self`
 */
@@ -218,7 +218,7 @@ struct RALLYHEREAPI_API Traits_GetReportsForTargetPlayerUuid
  * 
  * Source players will be empty without the Required Permissions:
  * 
- * - For any player (including themselves) any of: `sanction:*`, `sanction:report:read:source-any`
+ * - For any player (including themselves) any of: `sanction:report:read:source-any`, `sanction:*`
  * 
  * - For the player themselves : `sanction:report:read:source-self`
 */
@@ -287,7 +287,7 @@ struct RALLYHEREAPI_API Traits_GetReportsForTargetPlayerUuidSelf
  * Get reports from a source player
  * Required Permissions:
  * 
- * - For any player (including themselves) any of: `sanction:*`, `sanction:report:read:source-any`
+ * - For any player (including themselves) any of: `sanction:report:read:source-any`, `sanction:*`
  * 
  * - For the player themselves : `sanction:report:read:source-self`
 */
@@ -357,7 +357,7 @@ struct RALLYHEREAPI_API Traits_GetReportsFromSourcePlayerUuid
  * Get reports from a source player
  * Required Permissions:
  * 
- * - For any player (including themselves) any of: `sanction:*`, `sanction:report:read:source-any`
+ * - For any player (including themselves) any of: `sanction:report:read:source-any`, `sanction:*`
  * 
  * - For the player themselves : `sanction:report:read:source-self`
 */

--- a/RallyHereAPI/Source/RallyHereAPI/Public/SessionTemplate.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/SessionTemplate.h
@@ -364,7 +364,7 @@ struct RALLYHEREAPI_API FRHAPI_SessionTemplate : public FRHAPI_Model
 	 /** @brief Clears the value of PlatformTemplates_Optional and sets PlatformTemplates_IsSet to false */
 	void ClearPlatformTemplates() { PlatformTemplates_IsSet = false; }
 
-	/** @brief Parameters used to start an instance for this session when it is created */
+	/** @brief Parameters used to start an instance for this session when it is created. Has lower priority than auto_startup_instance_template_id */
 	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
 	FRHAPI_InstanceStartupParams AutoStartupParams_Optional{  };
 	/** @brief true if AutoStartupParams_Optional has been set to a value */
@@ -388,6 +388,31 @@ struct RALLYHEREAPI_API FRHAPI_SessionTemplate : public FRHAPI_Model
 	void SetAutoStartupParams(FRHAPI_InstanceStartupParams&& NewValue) { AutoStartupParams_Optional = NewValue; AutoStartupParams_IsSet = true; }
 	 /** @brief Clears the value of AutoStartupParams_Optional and sets AutoStartupParams_IsSet to false */
 	void ClearAutoStartupParams() { AutoStartupParams_IsSet = false; }
+
+	/** @brief ID of instance request template to be used to automatically request an instance on creation of a session of this type. Takes priority over auto_startup_params */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	FGuid AutoStartupInstanceTemplateId_Optional{  };
+	/** @brief true if AutoStartupInstanceTemplateId_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool AutoStartupInstanceTemplateId_IsSet{ false };
+	/** @brief Gets the value of AutoStartupInstanceTemplateId_Optional, regardless of it having been set */
+	FGuid& GetAutoStartupInstanceTemplateId() { return AutoStartupInstanceTemplateId_Optional; }
+	/** @brief Gets the value of AutoStartupInstanceTemplateId_Optional, regardless of it having been set */
+	const FGuid& GetAutoStartupInstanceTemplateId() const { return AutoStartupInstanceTemplateId_Optional; }
+	/** @brief Gets the value of AutoStartupInstanceTemplateId_Optional, if it has been set, otherwise it returns DefaultValue */
+	const FGuid& GetAutoStartupInstanceTemplateId(const FGuid& DefaultValue) const { if (AutoStartupInstanceTemplateId_IsSet) return AutoStartupInstanceTemplateId_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of AutoStartupInstanceTemplateId_Optional and returns true if it has been set, otherwise returns false */
+	bool GetAutoStartupInstanceTemplateId(FGuid& OutValue) const { if (AutoStartupInstanceTemplateId_IsSet) OutValue = AutoStartupInstanceTemplateId_Optional; return AutoStartupInstanceTemplateId_IsSet; }
+	/** @brief Returns a pointer to AutoStartupInstanceTemplateId_Optional, if it has been set, otherwise returns nullptr */
+	FGuid* GetAutoStartupInstanceTemplateIdOrNull() { if (AutoStartupInstanceTemplateId_IsSet) return &AutoStartupInstanceTemplateId_Optional; return nullptr; }
+	/** @brief Returns a pointer to AutoStartupInstanceTemplateId_Optional, if it has been set, otherwise returns nullptr */
+	const FGuid* GetAutoStartupInstanceTemplateIdOrNull() const { if (AutoStartupInstanceTemplateId_IsSet) return &AutoStartupInstanceTemplateId_Optional; return nullptr; }
+	/** @brief Sets the value of AutoStartupInstanceTemplateId_Optional and also sets AutoStartupInstanceTemplateId_IsSet to true */
+	void SetAutoStartupInstanceTemplateId(const FGuid& NewValue) { AutoStartupInstanceTemplateId_Optional = NewValue; AutoStartupInstanceTemplateId_IsSet = true; }
+	/** @brief Sets the value of AutoStartupInstanceTemplateId_Optional and also sets AutoStartupInstanceTemplateId_IsSet to true using move semantics */
+	void SetAutoStartupInstanceTemplateId(FGuid&& NewValue) { AutoStartupInstanceTemplateId_Optional = NewValue; AutoStartupInstanceTemplateId_IsSet = true; }
+	 /** @brief Clears the value of AutoStartupInstanceTemplateId_Optional and sets AutoStartupInstanceTemplateId_IsSet to false */
+	void ClearAutoStartupInstanceTemplateId() { AutoStartupInstanceTemplateId_IsSet = false; }
 
 	/** @brief Minimum number of this type of session to be running at any given time per region. */
 	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
@@ -529,6 +554,35 @@ struct RALLYHEREAPI_API FRHAPI_SessionTemplate : public FRHAPI_Model
 	bool IsCanChangeOwnTeamDefaultValue() const { return CanChangeOwnTeam_IsSet && CanChangeOwnTeam_Optional == true; }
 	/** @brief Sets the value of CanChangeOwnTeam_Optional to its default and also sets CanChangeOwnTeam_IsSet to true */
 	void SetCanChangeOwnTeamToDefault() { CanChangeOwnTeam_Optional = true; CanChangeOwnTeam_IsSet = true; }
+
+	/** @brief If players should be notified when they are reserved in this type of session instead of waiting until they're invited */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool NotifyOnReservation_Optional{  };
+	/** @brief true if NotifyOnReservation_Optional has been set to a value */
+	UPROPERTY(BlueprintReadWrite, Category = "RallyHere")
+	bool NotifyOnReservation_IsSet{ false };
+	/** @brief Gets the value of NotifyOnReservation_Optional, regardless of it having been set */
+	bool& GetNotifyOnReservation() { return NotifyOnReservation_Optional; }
+	/** @brief Gets the value of NotifyOnReservation_Optional, regardless of it having been set */
+	const bool& GetNotifyOnReservation() const { return NotifyOnReservation_Optional; }
+	/** @brief Gets the value of NotifyOnReservation_Optional, if it has been set, otherwise it returns DefaultValue */
+	const bool& GetNotifyOnReservation(const bool& DefaultValue) const { if (NotifyOnReservation_IsSet) return NotifyOnReservation_Optional; return DefaultValue; }
+	/** @brief Fills OutValue with the value of NotifyOnReservation_Optional and returns true if it has been set, otherwise returns false */
+	bool GetNotifyOnReservation(bool& OutValue) const { if (NotifyOnReservation_IsSet) OutValue = NotifyOnReservation_Optional; return NotifyOnReservation_IsSet; }
+	/** @brief Returns a pointer to NotifyOnReservation_Optional, if it has been set, otherwise returns nullptr */
+	bool* GetNotifyOnReservationOrNull() { if (NotifyOnReservation_IsSet) return &NotifyOnReservation_Optional; return nullptr; }
+	/** @brief Returns a pointer to NotifyOnReservation_Optional, if it has been set, otherwise returns nullptr */
+	const bool* GetNotifyOnReservationOrNull() const { if (NotifyOnReservation_IsSet) return &NotifyOnReservation_Optional; return nullptr; }
+	/** @brief Sets the value of NotifyOnReservation_Optional and also sets NotifyOnReservation_IsSet to true */
+	void SetNotifyOnReservation(const bool& NewValue) { NotifyOnReservation_Optional = NewValue; NotifyOnReservation_IsSet = true; }
+	/** @brief Sets the value of NotifyOnReservation_Optional and also sets NotifyOnReservation_IsSet to true using move semantics */
+	void SetNotifyOnReservation(bool&& NewValue) { NotifyOnReservation_Optional = NewValue; NotifyOnReservation_IsSet = true; }
+	 /** @brief Clears the value of NotifyOnReservation_Optional and sets NotifyOnReservation_IsSet to false */
+	void ClearNotifyOnReservation() { NotifyOnReservation_Optional = true; NotifyOnReservation_IsSet = false; }
+	/** @brief Returns true if NotifyOnReservation_Optional is set and matches the default value */
+	bool IsNotifyOnReservationDefaultValue() const { return NotifyOnReservation_IsSet && NotifyOnReservation_Optional == true; }
+	/** @brief Sets the value of NotifyOnReservation_Optional to its default and also sets NotifyOnReservation_IsSet to true */
+	void SetNotifyOnReservationToDefault() { NotifyOnReservation_Optional = true; NotifyOnReservation_IsSet = true; }
 };
 
 /** @} */

--- a/RallyHereDebugTool/Source/Private/RHDTW_Config.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Config.cpp
@@ -102,27 +102,6 @@ void FRHDTW_Config::DoKVsTab(URH_ConfigSubsystem* pRH_ConfigSubsystem)
 
 		ImGui::EndTable();
 	}
-
-	ImGui::Separator();
-
-	if (ImGui::BeginTable("SecetKVssMapTable", 2, RH_TableFlagsPropSizing))
-	{
-		// Header
-		ImGui::TableSetupColumn("Key");
-		ImGui::TableSetupColumn("Value");
-		ImGui::TableHeadersRow();
-
-		for (const auto& KV : pRH_ConfigSubsystem->GetSecretKVs())
-		{
-			ImGui::TableNextRow();
-			ImGui::TableNextColumn();
-			ImGuiDisplayCopyableValue(KV.Key, TEXT(""), ECopyMode::Key);
-			ImGui::TableNextColumn();
-			ImGuiDisplayCopyableValue(TEXT(""), KV.Value, ECopyMode::Value);
-		}
-
-		ImGui::EndTable();
-	}
 }
 
 void FRHDTW_Config::HandleFetchKVs(bool bSuccess, const FRH_ErrorInfo& ErrorInfo)

--- a/RallyHereDebugTool/Source/Private/RHDTW_Config.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Config.cpp
@@ -84,6 +84,9 @@ void FRHDTW_Config::DoKVsTab(URH_ConfigSubsystem* pRH_ConfigSubsystem)
 
 	ImGui::Separator();
 
+	auto KickBeforeHint = pRH_ConfigSubsystem->GetKickBeforeHint() == FDateTime::MinValue() ? TOptional<FDateTime>() : TOptional<FDateTime>(pRH_ConfigSubsystem->GetKickBeforeHint());
+	ImGuiDisplayCopyableValue(TEXT("KickBeforeHint"), KickBeforeHint, ECopyMode::KeyValue);
+	
 	if (ImGui::BeginTable("KVssMapTable", 2, RH_TableFlagsPropSizing))
 	{
 		// Header

--- a/RallyHereDebugTool/Source/Private/RallyHereDebugToolSettings.h
+++ b/RallyHereDebugTool/Source/Private/RallyHereDebugToolSettings.h
@@ -121,6 +121,9 @@ public:
 
 	UPROPERTY(Config, EditAnywhere, Category = "Rally Here Debug Tool")
 	FString DefaultSessionGameMiscParams;
+	
+	UPROPERTY(Config, EditAnywhere, Category = "Rally Here Debug Tool")
+	FString DefaultSessionLaunchTemplateId;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Rally Here Debug Tool")
 	FString DefaultWindowPositions;

--- a/RallyHereDebugTool/Source/Public/RHDTW_Session.h
+++ b/RallyHereDebugTool/Source/Public/RHDTW_Session.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "RH_DebugToolWindow.h"
+#include "RH_GameInstanceSubsystem.h"
 #include "SessionsAPI.h"
 
 #include "RH_SessionData.h"
@@ -36,11 +37,31 @@ public:
 	int32 InvitePlayerTeam;
 	TArray<ANSICHAR> InviteSessionString;
 	TArray<ANSICHAR> JoinQueueByIdString;
+	
+	struct FInstanceLaunchParamsDisplay
+	{
+		FString TemplateIdString;
+		FRHAPI_InstanceRequest Request;
+		FImGuiCustomDataStager InstanceCustomDataStager, InstanceStartupCustomDataStager;
+		bool bMakeBeaconInstance;
 
-	TArray<ANSICHAR> MapName;
-	TArray<ANSICHAR> GameModeName;
-	TArray<ANSICHAR> GameMiscParams;
-	bool bMakeBeaconInstance;
+		FString RequestError;
+
+		FInstanceLaunchParamsDisplay()
+		{
+			ResetToDefaults();
+		}
+		void ResetToDefaults();
+		void Clear()
+		{
+			TemplateIdString.Empty();
+			Request = FRHAPI_InstanceRequest();
+			InstanceCustomDataStager.Clear();
+			InstanceStartupCustomDataStager.Clear();
+			bMakeBeaconInstance = false;
+		}
+	};
+	TSharedRef<FInstanceLaunchParamsDisplay> InstanceLaunchParamsDisplay;
 
 	TArray<ANSICHAR> UpdateSessionRegionIdString;
 
@@ -63,6 +84,7 @@ public:
 protected:
 	// helpers used for multiple tabs
 	void ImGuiDisplayInstance(const FRHAPI_InstanceInfo& Info, URH_SessionView* RHSession, URH_GameInstanceSessionSubsystem* pGISessionSubsystem);
+	void ImGuiDisplayInstanceRequest(TSharedRef<FInstanceLaunchParamsDisplay>& InstanceLaunchParams, URH_GameInstanceSubsystem* pGISubsystem, URH_JoinedSession* Session);
 	void ImGuiDisplayMatch(const FRHAPI_MatchInfo& Info);
 	void ImGuiDisplaySessionPlayer(URH_SessionView* RHSession, const FRHAPI_SessionPlayer& Player, int32 TeamId, URH_GameInstanceSessionSubsystem* pGISessionSubsystem);
 	void ImGuiDisplayPlatformSession(const FRHAPI_PlatformSession& Info);
@@ -101,8 +123,7 @@ protected:
 	int32 SetDeserterTime[3] = {0,0,0};
 	int32 SetDeserterCount = 0;
 	FImGuiCustomDataStager SetDeserterCustomDataStager;
-
-	FImGuiCustomDataStager InstanceStartupCustomDataStager;
+	
 	FImGuiCustomDataStager InstanceCustomDataStager;
 	FImGuiCustomDataStager InvitePlayerCustomDataStager;
 	FImGuiCustomDataStager BrowserCustomDataStager;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_ConfigSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_ConfigSubsystem.cpp
@@ -60,8 +60,7 @@ void URH_ConfigSubsystem::Deinitialize()
 void URH_ConfigSubsystem::InitPropertiesWithDefaultValues()
 {
 	KVs.Empty();
-	SecretKVs.Empty();
-
+	
 	// Load Default Feature Flags
 	FKeyValueSink Visitor;
 	Visitor.BindLambda([&](const FString& Key, const FString& Value) { KVs.Add(Key, Value); });
@@ -101,7 +100,6 @@ void URH_ConfigSubsystem::OnFetchKVs(const GetKVsAPIType::Response& Resp)
 	{
 		// clear out old KVs
 		KVs.Reset();
-		SecretKVs.Reset();
 
 		// Load Default Feature Flags
 		FKeyValueSink Visitor;
@@ -117,16 +115,7 @@ void URH_ConfigSubsystem::OnFetchKVs(const GetKVsAPIType::Response& Resp)
 				KVs.Add(KV.Key, KV.Value);
 			}
 		}
-		// process Secret KVs
-		const auto ResponseSecretKVs = Resp.Content.GetSecretKvsOrNull();
-		if (ResponseSecretKVs != nullptr)
-		{
-			for (const auto& KV : *ResponseSecretKVs)
-			{
-				SecretKVs.Add(KV.Key, KV.Value);
-			}
-		}
-
+		
 		KVsETag = Resp.ETag.Get(TEXT(""));
 
 		{

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_ConfigSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_ConfigSubsystem.cpp
@@ -15,7 +15,7 @@
 URH_ConfigSubsystem::URH_ConfigSubsystem(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
-
+	KickBeforeHint = FDateTime::MinValue();
 }
 
 void URH_ConfigSubsystem::Initialize()
@@ -114,6 +114,15 @@ void URH_ConfigSubsystem::OnFetchKVs(const GetKVsAPIType::Response& Resp)
 			{
 				KVs.Add(KV.Key, KV.Value);
 			}
+		}
+
+		if (auto RespKickBeforeHint = Resp.Content.GetKickBeforeHintOrNull())
+		{
+			KickBeforeHint = Resp.Content.GetKickBeforeHint();	
+		}
+		else
+		{
+			KickBeforeHint = FDateTime::MinValue();
 		}
 		
 		KVsETag = Resp.ETag.Get(TEXT(""));

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_SessionHelpers.h
@@ -515,18 +515,27 @@ protected:
 			{
 				for (auto pair : *SessionsMap)
 				{
+					// extract any sessions the owner is a member of
 					const auto SessionIdSet = pair.Value.GetSessionIdsOrNull();
 					if (SessionIdSet && SessionIdSet->Num() > 0)
 					{
 						SessionIds.Append(SessionIdSet->Array());
 					}
 
+					// extract any sessions the owner is invited to
 					const auto PendingInvites = pair.Value.GetPendingInvitesOrNull();
 					if (PendingInvites && PendingInvites->Num() > 0)
 					{
 						TArray<FString> InviteSessionIds;
 						PendingInvites->GenerateKeyArray(InviteSessionIds);
 						SessionIds.Append(InviteSessionIds);
+					}
+
+					// extract any sessions the owner is reserved in
+					const auto ReservedSessions = pair.Value.GetReservedSessionsOrNull();
+					if (ReservedSessions && ReservedSessions->Num() > 0)
+					{
+						SessionIds.Append(ReservedSessions->Array());
 					}
 				}
 			}

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_ConfigSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_ConfigSubsystem.h
@@ -155,15 +155,6 @@ public:
 		return KVs;
 	}
 	/**
-	* @brief Gets the map of all the Secret KVs and their values.
-	* @return Map of all the Secret KVs and their values
-	*/
-	UFUNCTION(BlueprintGetter, Category = "Config")
-	const TMap<FString, FString>& GetSecretKVs() const
-	{
-		return SecretKVs;
-	}
-	/**
 	* @brief Gets the value of a specific Publc KV.
 	* @param [in] Key Key of the KV to get the value of.
 	* @param [out] Value Value of the KV.
@@ -181,24 +172,7 @@ public:
 		return false;
 	}
 	/**
-	* @brief Gets the value of a specific Secret KV.
-	* @param [in] Key Key of the KV to get the value of.
-	* @param [out] Value Value of the KV.
-	* @return if true, a Value was found for the Key.
-	*/
-	UFUNCTION(BlueprintPure, Category = "Config")
-	bool GetSecretKV(const FString& Key, FString& Value) const
-	{
-		const auto KVValue = SecretKVs.Find(Key);
-		if (KVValue != nullptr)
-		{
-			Value = *KVValue;
-			return true;
-		}
-		return false;
-	}
-	/**
-	* @brief Gets the value of a specific Publc or Secret KV (secret takes precidence.
+	* @brief Gets the value of a specific KV (wrapper for if multiple KV sources are present).
 	* @param [in] Key Key of the KV to get the value of.
 	* @param [out] Value Value of the KV.
 	* @return if true, a Value was found for the Key.
@@ -206,10 +180,6 @@ public:
 	UFUNCTION(BlueprintPure, Category = "Config")
 	bool GetAnyKV(const FString& Key, FString& Value) const
 	{
-		if (GetSecretKV(Key, Value))
-		{
-			return true;
-		}
 		return GetKV(Key, Value);
 	}
 	/**
@@ -313,9 +283,6 @@ protected:
 	/** @brief Map of KVs by Key. */
 	UPROPERTY(VisibleInstanceOnly, BlueprintGetter=GetKVs, Category = "Config")
 	TMap<FString, FString> KVs;
-	/** @brief Map of secret (permissioned) KVs by Key. */
-	UPROPERTY(VisibleInstanceOnly, BlueprintGetter = GetSecretKVs, Category = "Config")
-	TMap<FString, FString> SecretKVs;
 	/** @brief ETag of last GetKVs call response. */
 	UPROPERTY(VisibleInstanceOnly, Category = "Config")
 	FString KVsETag;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_ConfigSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_ConfigSubsystem.h
@@ -183,6 +183,11 @@ public:
 		return GetKV(Key, Value);
 	}
 	/**
+	 * @brief Time for which any player logins older than should log out (staggered kick all players support).
+	 */
+	UFUNCTION(BlueprintPure, Category = "Config")
+	FDateTime GetKickBeforeHint() const { return KickBeforeHint; }	
+	/**
 	* @brief Requests the server for the latest App Settings.
 	* @param [in] Delegate Delegate to call when the request is complete.
 	*/
@@ -283,6 +288,9 @@ protected:
 	/** @brief Map of KVs by Key. */
 	UPROPERTY(VisibleInstanceOnly, BlueprintGetter=GetKVs, Category = "Config")
 	TMap<FString, FString> KVs;
+	/** @brief Time for which any player logins older than should log out (staggered kick all players support). */
+	UPROPERTY(VisibleInstanceOnly, BlueprintGetter=GetKickBeforeHint, Category = "Config")
+	FDateTime KickBeforeHint;
 	/** @brief ETag of last GetKVs call response. */
 	UPROPERTY(VisibleInstanceOnly, Category = "Config")
 	FString KVsETag;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerSubsystem.h
@@ -259,6 +259,12 @@ protected:
 	}
 
 	/**
+	 * @brief Called whenever the config subsystem KV list is updated.
+	 * @param ConfigSubsystem The config subsystem that was updated.
+	 */
+	virtual void OnConfigKVsUpdated(class URH_ConfigSubsystem* ConfigSubsystem); 
+	
+	/**
 	 * @brief Called whenever the user logs in.
 	 * @param [in] bSuccess True if the login was successful, false otherwise.
 	 */
@@ -303,6 +309,8 @@ protected:
 	TWeakObjectPtr<URH_PlayerInfo> PlayerInfoCache;
 	/** The Local Players auth context. */
 	FAuthContextPtr AuthContext;
+	/** The timestamp of the last successful login. */
+	TOptional<FDateTime> LastLoginTime;
 
 	/** The Analytics Provider for the player. */
 	TSharedPtr<class IAnalyticsProvider> AnalyticsProvider;


### PR DESCRIPTION
This encompasses a few different changes based on a new API generation run and implementing changes from it.

This change is breaking because of the changes to SecretKVs

Notably:
Config:
- Remove SecretKVs support.  They were never fully implemented in the API layer, and any future work along those lines will be a bit different
- Add KickBeforeHint, which triggers a logoff if the login time is before the specified time.  Note that this is checked on config update, which is polled slowly, so should slowly drain out players over the config poll cycle.

Session:
- Add support for retrieving and storing sessions in the Reserved state (where a player is earmarked for a session but is not yet invited, primarily used by matchmaking flow)
- Add support to debug tool for launching an instance by template id