### PR TITLE
When using json serializer serialize arrays and objects directly without an identifier, rather than with an empty identifier

### DIFF
--- a/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIHelpers.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIHelpers.h
@@ -520,7 +520,20 @@ inline void WriteJsonValue(TSharedRef<TJsonWriter<>>& Writer, const TSharedPtr<F
 {
 	if (Value.IsValid())
 	{
-		FJsonSerializer::Serialize(Value.ToSharedRef(), "", Writer, false);
+		// prefer to use the serialize function that does not take an idenitfier, as we are trying to just write a value
+		if (Value->Type == EJson::Object)
+		{
+			FJsonSerializer::Serialize(Value->AsObject().ToSharedRef(), Writer, false);
+		}
+		else if (Value->Type == EJson::Array)
+		{
+			FJsonSerializer::Serialize(Value->AsArray(), Writer, false);
+		}
+		else
+		{
+			// there is not a serialize function that does not take identifiers for other types, so pass in an empty identifier which should get ignored
+			FJsonSerializer::Serialize(Value.ToSharedRef(), "", Writer, false);
+		}
 	}
 	else
 	{

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/helpers-header.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/helpers-header.mustache
@@ -532,7 +532,20 @@ inline void WriteJsonValue(TSharedRef<TJsonWriter<>>& Writer, const TSharedPtr<F
 {
 	if (Value.IsValid())
 	{
-		FJsonSerializer::Serialize(Value.ToSharedRef(), "", Writer, false);
+		// prefer to use the serialize function that does not take an idenitfier, as we are trying to just write a value
+		if (Value->Type == EJson::Object)
+		{
+			FJsonSerializer::Serialize(Value->AsObject().ToSharedRef(), Writer, false);
+		}
+		else if (Value->Type == EJson::Array)
+		{
+			FJsonSerializer::Serialize(Value->AsArray(), Writer, false);
+		}
+		else
+		{
+			// there is not a serialize function that does not take identifiers for other types, so pass in an empty identifier which should get ignored
+			FJsonSerializer::Serialize(Value.ToSharedRef(), "", Writer, false);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
This caused issues in UE 5.4.1, where it would write a blank identifier rather than just the value.