### PR TITLE
Fix issue reported when a player reconnects with the same engine player id while the old connection is still active

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Beacons.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Beacons.cpp
@@ -75,9 +75,10 @@ bool ARH_OnlineBeaconHost::CommonVerifyAuthentication(const FUniqueNetId& Player
 		UNetConnection* pConnection = nullptr;
 		if (NetDriver != nullptr && NetDriver->ClientConnections.Num() > 0)
 		{
-			for (auto Client : NetDriver->ClientConnections)
+			for (int i = NetDriver->ClientConnections.Num() - 1; i >= 0; --i)
 			{
-				if (Client->PlayerId == PlayerId)
+				auto Client = NetDriver->ClientConnections[i];
+				if (Client->PlayerId == PlayerId && Client->ClientLoginState == EClientLoginState::LoggingIn)
 				{
 					pConnection = Client;
 					break;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceSessionSubsystem.cpp
@@ -687,9 +687,11 @@ void URH_GameInstanceSessionSubsystem::GameModePreloginEvent(class AGameModeBase
 	FString RequestURL;
 	if (pWorld->NetDriver != nullptr && pWorld->NetDriver->ClientConnections.Num() > 0)
 	{
-		for (auto Client : pWorld->NetDriver->ClientConnections)
+		const auto NetDriver = pWorld->NetDriver;
+		for (int i = NetDriver->ClientConnections.Num() - 1; i >= 0; --i)
 		{
-			if (Client->PlayerId == NewPlayer)
+			auto Client = NetDriver->ClientConnections[i];
+			if (Client->PlayerId == NewPlayer && Client->ClientLoginState == EClientLoginState::LoggingIn)
 			{
 				ValidateIncomingConnection(Client, ErrorMessage);
 				break;


### PR DESCRIPTION
The validation logic may find the old connection and validate it instead of the new connection.  This makes it prefer newer connections that have not yet logged in