### PR TITLE
Add simple deferral mechanism to bootstrap failure handler and route most calls through it

### DIFF
--- a/Documentation/md/GameInstance.md
+++ b/Documentation/md/GameInstance.md
@@ -154,6 +154,7 @@ Server Bootstrapper for the Game Instance.
 `protected virtual void `[`HandleAppTerminatedGameThread`](#classURH__GameInstanceServerBootstrapper_1a1ec1c5bb9f2a33ab6046cf66d8b4b152)`()` | Callback binding for the default engine SIGTERM / CTRL - C(Windows) handlers - these are indicating an IMMEDIATE shutdown - runs in the game thread.
 `protected virtual void `[`BestEffortLeaveSession`](#classURH__GameInstanceServerBootstrapper_1a14524147b04e9d0a6c2e2f4e7e1de9bf)`()` | Fallback routine that does its best to leave the session we have loaded.
 `protected virtual void `[`UpdateBootstrapStep`](#classURH__GameInstanceServerBootstrapper_1ad3057c819da82f1bd348bbfc8eeb1850)`(`[`ERH_ServerBootstrapFlowStep`](undefined.md#group__GameInstance_1ga70ec3ebac3b063bae8ad728c7cdd4d36)` NewStep)` | Updates the current bootstrapping step, and handles step change logic.
+`protected virtual void `[`DeferBootstrappingFailed`](#classURH__GameInstanceServerBootstrapper_1a6aaac8bf0886e7884b656ef45ef7dc64)`(const FString & FailureReason)` | Bootstrapping Flow [Failed] - trigger a deferred bootstrapping failure to be processed a later time (generally next tick). Useful for handling failures that occur during a callback or in a different thread.
 `protected virtual void `[`OnBootstrappingFailed`](#classURH__GameInstanceServerBootstrapper_1a0153222bb4308545e9f1270882ddab4f)`(const FString & FailureReason)` | Bootstrapping Flow [Failed] - trigger bootstrapping failure and handles failure logic.
 `protected virtual void `[`OnBootstrappingComplete`](#classURH__GameInstanceServerBootstrapper_1a2882f79445b73579a19dbb92e8b859df)`()` | Bootstrapping Flow [Complete] - trigger bootstrapping complete and handles completion logic. Note that recycling may start a new bootstrapping flow.
 `protected virtual void `[`BeginServerLogin`](#classURH__GameInstanceServerBootstrapper_1a924d64924d1e13251752ae00763ea765)`()` | Bootstrapping Flow [LoggingIn] - begin the login process to the RallyHere API.
@@ -476,6 +477,10 @@ Updates the current bootstrapping step, and handles step change logic.
 
 #### Parameters
 * `NewStep` The new step to transition to
+
+#### `protected virtual void `[`DeferBootstrappingFailed`](#classURH__GameInstanceServerBootstrapper_1a6aaac8bf0886e7884b656ef45ef7dc64)`(const FString & FailureReason)` <a id="classURH__GameInstanceServerBootstrapper_1a6aaac8bf0886e7884b656ef45ef7dc64"></a>
+
+Bootstrapping Flow [Failed] - trigger a deferred bootstrapping failure to be processed a later time (generally next tick). Useful for handling failures that occur during a callback or in a different thread.
 
 #### `protected virtual void `[`OnBootstrappingFailed`](#classURH__GameInstanceServerBootstrapper_1a0153222bb4308545e9f1270882ddab4f)`(const FString & FailureReason)` <a id="classURH__GameInstanceServerBootstrapper_1a0153222bb4308545e9f1270882ddab4f"></a>
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_GameInstanceBootstrappers.h
@@ -249,6 +249,10 @@ protected:
 	virtual void UpdateBootstrapStep(ERH_ServerBootstrapFlowStep NewStep);
 
 	/**
+	* @brief Bootstrapping Flow [Failed] - trigger a deferred bootstrapping failure to be processed a later time (generally next tick).  Useful for handling failures that occur during a callback or in a different thread
+	*/
+	virtual void DeferBootstrappingFailed(const FString& FailureReason);
+	/**
 	* @brief Bootstrapping Flow [Failed] - trigger bootstrapping failure and handles failure logic
 	*/
 	virtual void OnBootstrappingFailed(const FString& FailureReason);


### PR DESCRIPTION
This fixes cases where failure would delete resources that were the source of the callbacks, which once the call chain returned up the stack would cause crashes.