### PR TITLE
Set flushes from bootstrapper to use Default type rather than FullFlush

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -540,7 +540,7 @@ void URH_GameInstanceServerBootstrapper::OnBootstrappingFailed(const FString& Fa
 		}
 
 #if RH_FROM_ENGINE_VERSION(5,0)
-		FHttpModule::Get().GetHttpManager().Flush(EHttpFlushReason::FullFlush);
+		FHttpModule::Get().GetHttpManager().Flush(EHttpFlushReason::Default);
 #else
 		FHttpModule::Get().GetHttpManager().Flush(false);
 #endif
@@ -1401,7 +1401,7 @@ void URH_GameInstanceServerBootstrapper::ConditionalRecycle()
 
 			// flush the HTTP manager
 #if RH_FROM_ENGINE_VERSION(5,0)
-			FHttpModule::Get().GetHttpManager().Flush(EHttpFlushReason::FullFlush);
+			FHttpModule::Get().GetHttpManager().Flush(EHttpFlushReason::Default);
 #else
 			FHttpModule::Get().GetHttpManager().Flush(false);
 #endif


### PR DESCRIPTION
FullFlush defaults to infinite wait.  A problem on http side can then make shutdown sequence stall indefinitely.