### PR TITLE
Respect the return value of the Begin() call when drawing a window. 

### DIFF
--- a/RallyHereDebugTool/Source/Private/RH_DebugToolWindow.cpp
+++ b/RallyHereDebugTool/Source/Private/RH_DebugToolWindow.cpp
@@ -154,7 +154,10 @@ void FRH_DebugToolWindow::RenderWindow()
 
 	ImGuiWindowFlags windowFlags = bShowMenuBar ? ImGuiWindowFlags_MenuBar : ImGuiWindowFlags_None;
 	windowFlags |= AdditionalWindowFlags;
-	ImGui::Begin(TCHAR_TO_ANSI(*Name) , nullptr, windowFlags);
-	Do();
+	if (ImGui::Begin(TCHAR_TO_ANSI(*Name) , nullptr, windowFlags))
+	{
+		Do();
+	}
+	// per docs, ImGui::End() must be called even if Begin() returns false
 	ImGui::End();
 }


### PR DESCRIPTION
It returns false if a window's contents is not currently being displayed, which for always-open windows like in a docked window setup is a major optimization.