### PR TITLE
Rework iterator to not check GetNode() and instead use boolean operator

### DIFF
--- a/RallyHereDebugTool/Source/Private/RHDTW_Analytics.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_Analytics.cpp
@@ -408,7 +408,7 @@ void FRHDTW_Analytics::DoTimelinePlot(FRH_WebRequests* WebRequestsTracker, const
 	TimelineCountByTimeAndKey.SetNum(SecondsInOneMinute);
 	TArray<FName> ItemsByFName;
 	TDoubleLinkedListIterator<TDoubleLinkedList<TSharedPtr<FRH_WebRequest>>::TDoubleLinkedListNode, TSharedPtr<FRH_WebRequest>>  requestsIterator(TrackedRequests.GetTail());
-	for (; requestsIterator.GetNode() != nullptr; --requestsIterator)
+	for (; requestsIterator; --requestsIterator)
 	{
 		auto request = requestsIterator.GetNode()->GetValue().Get();
 		if (!request)

--- a/RallyHereDebugTool/Source/Private/RHDTW_WebRequests.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_WebRequests.cpp
@@ -159,7 +159,7 @@ void FRHDTW_WebRequests::DoViewRequests(FRH_WebRequests* WebRequestsTracker)
 	TDoubleLinkedListIterator<TDoubleLinkedList<TSharedPtr<FRH_WebRequest>>::TDoubleLinkedListNode, TSharedPtr<FRH_WebRequest>>  requestsIterator(TrackedRequests.GetTail());
 
 	int indexId = 0; // Index for IDing the ImGui buttons
-	for (; requestsIterator.GetNode() != nullptr; --requestsIterator)
+	for (; requestsIterator; --requestsIterator)
 	{
 		auto request = requestsIterator.GetNode()->GetValue().Get();
 		if (!request)


### PR DESCRIPTION
This is to fix a checkSlow() in debug builds, which assert on GetNode() when it is nullptr