### PR TITLE
Entitlement processor rework and fix various unguarded OSS UniqueNetId retrievals

### DIFF
--- a/Documentation/md/LocalPlayer.md
+++ b/Documentation/md/LocalPlayer.md
@@ -37,6 +37,8 @@ Fail_MustAcceptAgreements            | User must accept all required agreements.
 Fail_RHDenied            | RH web login was denied. There are many reasons that can cause this, including misconfiguration of OSS IDs with the Rally Here APIs
 Fail_LocalPlayerMissing            | Local player went missing during login process
 Fail_ReloginWithoutSavedCredentials            | Relogin called without saved credentials
+Fail_InvalidAuthContext            | The auth context has become invalid over the course of the login process
+Fail_InvalidOSSUniqueNetId            | The OSS unique id is invalid after it was required to be valid in the login process
 Fail_RHUnknown            | RH web login failed for an unknown reason. This usually means there was a server error of some kind.
 
 Login Results.

--- a/RallyHereIntegration/Config/BaseRallyHereIntegration.ini
+++ b/RallyHereIntegration/Config/BaseRallyHereIntegration.ini
@@ -58,6 +58,15 @@ GDK=true
 [SessionNamesAreCaseInsensitiveOSSNameMap]
 GDK=true
 
+[SkipEntitlementFinalizationFromOSSName]
+EOS=true
+EOSPLUS=true
+
+[RH_UsesSonyEntitlementTokensFromOSSName]
+PS4=true
+PS4_Crossgen=true
+PS5=true
+
 ; This assumes that the following are consistent with the LocalPlatformName on the relevant platforms (the engine does not map this consistently in the OSS layer, so it may require configuration changes)
 [PlatformNameFromPlatformEnumMap]
 XboxLive=XBL

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Common.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_Common.cpp
@@ -131,6 +131,16 @@ bool RH_UseRecentPlayersFromOSSName(FName OSSName)
 	return RH_LookupBoolOSSOverride(OSSName, TEXT("UseRecentPlayersFromOSSName"));
 }
 
+bool RH_SkipEntitlementFinalization(FName OSSName)
+{
+	return RH_LookupBoolOSSOverride(OSSName, TEXT("SkipEntitlementFinalizationFromOSSName"));
+}
+
+bool RH_UsesSonyEntitlementTokens(FName OSSName)
+{
+	return RH_LookupBoolOSSOverride(OSSName, TEXT("RH_UsesSonyEntitlementTokensFromOSSName"));
+}
+
 FString RH_GetPlatformNameFromPlatformEnum(const ERHAPI_Platform Platform)
 {
 	FString PlatformName;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_EntitlementHelpers.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_EntitlementHelpers.h
@@ -513,7 +513,7 @@ protected:
 
 		// EOS subsystems redeem purchases inside of the FinalizeReceiptValidationInfo, which does not conform to the other subsystems.
 		// Skip that step for Epic, and proceed directly to processing the inventory so it can be redeemed on the RHAPI side
-		if (OSSData.SubsystemName == EOS_SUBSYSTEM || OSSData.SubsystemName == EOSPLUS_SUBSYSTEM)
+		if (RH_SkipEntitlementFinalization(OSSData.SubsystemName))
 		{
 			bShouldFinalize = false;
 		}
@@ -552,7 +552,7 @@ protected:
 		{
 			// PS4 and PS5 pass through auth token as the first token in a colon delimited string in the validation token.  Parse it out and use it as the auth token.
 			// this cannot be retrieved later, so we need to do it here
-			if (OSSData.SubsystemName == PS4_SUBSYSTEM || OSSData.SubsystemName == PS5_SUBSYSTEM)
+			if (RH_UsesSonyEntitlementTokens(OSSData.SubsystemName))
 			{
 				TArray<FString> ValidationTokens;
 				ValidationInfo.ParseIntoArray(ValidationTokens, TEXT(":"), false);

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_EntitlementSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_EntitlementSubsystem.cpp
@@ -135,7 +135,7 @@ TMap<FString, FRHAPI_PlatformEntitlementProcessResult>* URH_EntitlementSubsystem
 	return &EntitlementProcessResultMap;
 }
 
-IOnlineSubsystem* URH_EntitlementSubsystem::GetOSS() const
+IOnlineSubsystemPtr URH_EntitlementSubsystem::GetOSS() const
 {
 	if (URH_LocalPlayerSubsystem* LPSS = GetLocalPlayerSubsystem())
 	{
@@ -144,13 +144,13 @@ IOnlineSubsystem* URH_EntitlementSubsystem::GetOSS() const
 			return nullptr;
 		}
 
-		IOnlineSubsystem* oss = LPSS->GetOSS(EntitlementOSSName);
-		if (oss == nullptr)
+		IOnlineSubsystemPtr OSS = MakeShareable(LPSS->GetOSS(EntitlementOSSName));
+		if (OSS.IsValid())
 		{
 			return nullptr;
 		}
 
-		return oss;
+		return OSS;
 	}
 
 	return nullptr;
@@ -158,7 +158,8 @@ IOnlineSubsystem* URH_EntitlementSubsystem::GetOSS() const
 
 IOnlinePurchasePtr URH_EntitlementSubsystem::GetPurchaseSubsystem() const
 {
-	if (IOnlineSubsystem* OSS = GetOSS())
+	auto OSS = GetOSS();
+	if (OSS.IsValid())
 	{
 		IOnlinePurchasePtr purchase = OSS->GetPurchaseInterface();
 		return purchase;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_EntitlementSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_EntitlementSubsystem.cpp
@@ -68,33 +68,36 @@ void URH_EntitlementSubsystem::HandleNotification(const FRHAPI_Notification& Not
 
 void URH_EntitlementSubsystem::SubmitEntitlementsForLoggedInOSS(const FRH_ProcessEntitlementCompletedDelegate& EntitlementProcessorCompleteDelegate, TOptional<ERHAPI_PlatformRegion> Region)
 {
-	auto Helper = MakeShared<FRH_EntitlementProcessor>(this,
-			GetOSS(),
-			GetPurchaseSubsystem(),
-			GetRH_LocalPlayerSubsystem()->GetPlatformUserId(),
-			GetRH_LocalPlayerSubsystem()->GetOSSUniqueId().GetUniqueNetId(),
+	FRH_EntitlementProcessorOSSPurchase::FEntitlementOSSData EntitlementOSSData(GetOSS(), GetRH_LocalPlayerSubsystem()->GetPlatformUserId());;
+	
+	auto Helper = MakeShared<FRH_EntitlementProcessorOSSPurchase>(
+			GetAuthContext(),
+			this,
+			EntitlementOSSData,
 			GetTimerManager(),
 			EntitlementProcessorCompleteDelegate,
 			Region,
-			TOptional<ERHAPI_Platform>(),
 			GetRH_LocalPlayerSubsystem()->GetAnalyticsProvider()
 		);
+	
 	Helper->Start();
 }
 
 void URH_EntitlementSubsystem::SubmitEntitlementsForPlatform(ERHAPI_Platform Platform, const FRH_ProcessEntitlementCompletedDelegate& EntitlementProcessorCompleteDelegate, TOptional<ERHAPI_PlatformRegion> Region)
 {
-	auto Helper = MakeShared<FRH_EntitlementProcessor>(this,
-			nullptr,
-			GetPurchaseSubsystem(),
-			GetRH_LocalPlayerSubsystem()->GetPlatformUserId(),
-			GetRH_LocalPlayerSubsystem()->GetOSSUniqueId().GetUniqueNetId(),
+	auto ClientType = RH_GetClientTypeFromOSSName(GetEntitlementOSSName());
+
+	auto Helper = MakeShared<FRH_EntitlementProcessor>(
+			GetAuthContext(),
+			this,
 			GetTimerManager(),
 			EntitlementProcessorCompleteDelegate,
 			Region,
 			Platform,
+			ClientType,
 			GetRH_LocalPlayerSubsystem()->GetAnalyticsProvider()
 		);
+	
 	Helper->Start();
 }
 
@@ -135,7 +138,7 @@ TMap<FString, FRHAPI_PlatformEntitlementProcessResult>* URH_EntitlementSubsystem
 	return &EntitlementProcessResultMap;
 }
 
-IOnlineSubsystemPtr URH_EntitlementSubsystem::GetOSS() const
+IOnlineSubsystem* URH_EntitlementSubsystem::GetOSS() const
 {
 	if (URH_LocalPlayerSubsystem* LPSS = GetLocalPlayerSubsystem())
 	{
@@ -144,13 +147,7 @@ IOnlineSubsystemPtr URH_EntitlementSubsystem::GetOSS() const
 			return nullptr;
 		}
 
-		IOnlineSubsystemPtr OSS = MakeShareable(LPSS->GetOSS(EntitlementOSSName));
-		if (OSS.IsValid())
-		{
-			return nullptr;
-		}
-
-		return OSS;
+		return LPSS->GetOSS(EntitlementOSSName);
 	}
 
 	return nullptr;
@@ -159,7 +156,7 @@ IOnlineSubsystemPtr URH_EntitlementSubsystem::GetOSS() const
 IOnlinePurchasePtr URH_EntitlementSubsystem::GetPurchaseSubsystem() const
 {
 	auto OSS = GetOSS();
-	if (OSS.IsValid())
+	if (OSS != nullptr)
 	{
 		IOnlinePurchasePtr purchase = OSS->GetPurchaseInterface();
 		return purchase;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_FriendSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_FriendSubsystem.cpp
@@ -864,8 +864,15 @@ void URH_FriendSubsystem::OnOSSBlockListChanged(int32 LocalUserNum, const FStrin
 		return;
 	}
 
+	auto UniquePlayerId = OSSIdentityInterface->GetUniquePlayerId(LocalUserNum);
+	if (!UniquePlayerId.IsValid())
+	{
+		UE_LOG(LogRallyHereIntegration, Warning, TEXT("[%s] failed to get unique player id"), ANSI_TO_TCHAR(__FUNCTION__));
+		return;
+	}
+	
 	TArray<TSharedRef<FOnlineBlockedPlayer>> BlockedPlayers;
-	if (!OSSFriendsInterface->GetBlockedPlayers(*OSSIdentityInterface->GetUniquePlayerId(LocalUserNum), BlockedPlayers))
+	if (!OSSFriendsInterface->GetBlockedPlayers(*UniquePlayerId, BlockedPlayers))
 	{
 		UE_LOG(LogRallyHereIntegration, Warning, TEXT("[%s] failed to get list of blocked players"), ANSI_TO_TCHAR(__FUNCTION__));
 		return;

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
@@ -83,6 +83,8 @@ TOptional<ERHAPI_GrantType> RALLYHEREINTEGRATION_API RH_GetGrantTypeFromOSSName(
 bool RALLYHEREINTEGRATION_API RH_UseGetAuthTokenFallbackFromOSSName(FName OSSName);
 bool RALLYHEREINTEGRATION_API RH_PlatformSessionsTypeIsCaseInsensitive(FName SessionType);
 bool RALLYHEREINTEGRATION_API RH_UseRecentPlayersFromOSSName(FName OSSName);
+bool RALLYHEREINTEGRATION_API RH_SkipEntitlementFinalization(FName OSSName);
+bool RALLYHEREINTEGRATION_API RH_UsesSonyEntitlementTokens(FName OSSName);
 FString RALLYHEREINTEGRATION_API RH_GetPlatformNameFromPlatformEnum(const ERHAPI_Platform Platform);
 
 ERHAPI_InventoryBucket RALLYHEREINTEGRATION_API RH_GetInventoryBucketFromPlatform(ERHAPI_Platform PlatformType);

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_EntitlementSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_EntitlementSubsystem.h
@@ -146,7 +146,7 @@ protected:
 	/** @brief Map of results from Entitlement Process calls. */
 	TMap<FString, FRHAPI_PlatformEntitlementProcessResult> EntitlementProcessResultMap;
 	/** @brief Helper to the online subsystem. */
-	IOnlineSubsystemPtr GetOSS() const;
+	IOnlineSubsystem* GetOSS() const;
 	/** @brief Helper to the online purchase subsystem. */
 	IOnlinePurchasePtr GetPurchaseSubsystem() const;
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_EntitlementSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_EntitlementSubsystem.h
@@ -146,7 +146,7 @@ protected:
 	/** @brief Map of results from Entitlement Process calls. */
 	TMap<FString, FRHAPI_PlatformEntitlementProcessResult> EntitlementProcessResultMap;
 	/** @brief Helper to the online subsystem. */
-	IOnlineSubsystem* GetOSS() const;
+	IOnlineSubsystemPtr GetOSS() const;
 	/** @brief Helper to the online purchase subsystem. */
 	IOnlinePurchasePtr GetPurchaseSubsystem() const;
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerLoginSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_LocalPlayerLoginSubsystem.h
@@ -80,6 +80,12 @@ enum class ERHAPI_LoginResult : uint8
 	/** Relogin called without saved credentials */
 	Fail_ReloginWithoutSavedCredentials,
 
+	/** The auth context has become invalid over the course of the login process */
+	Fail_InvalidAuthContext,
+	
+	/** The OSS unique id is invalid after it was required to be valid in the login process */
+	Fail_InvalidOSSUniqueNetId,
+
     /** RH web login failed for an unknown reason.  This usually means there was a server error of some kind. */
     Fail_RHUnknown,
 };


### PR DESCRIPTION
Splits the entitlement processor into a base class that handles simple platform id based redemption, and a derived class that checks with and online subsystem to retrieve receipt information and redeem receipt based entitlements.

This is intended to have no functional change, just organizational to properly split the two workflows, and to remove a lot of validity checking after each asynchronous step.  The OSS based redemption now cached data and shared pointers on startup, and verifies them, so it does not need to check at each step (since the shared pointers will keep the elements alive).  The base class no longer has to check at all as it no longer has code dependent upon those elements.

Tested with Steam Redemption (full success) and Twitch Redemption (successful return, but no entitlements processed).  Since the processing of redeemed entitlements is shared between the two workflows, this should have tested all the major elements.

Note - some other locations with unguarded OSS lookups were also fixed, as this was originally investigating crashes due to invalid OSS pointers.