### PR TITLE
Fix auto variables not being reference types when updating settings cache

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlayerInfoSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlayerInfoSubsystem.cpp
@@ -584,7 +584,7 @@ void URH_PlayerInfo::OnGetPlayerSettingsResponse(const GetSettings::Response& Re
 		if (bIsPartial)
 		{
 			// Update the local cache with the new settings (certain legacy setting types can affect multiple keys, so process all entries in the list)
-			auto SettingWrapper = PlayerSettingsByTypeId.FindOrAdd(SettingTypeId);
+			auto& SettingWrapper = PlayerSettingsByTypeId.FindOrAdd(SettingTypeId);
 
 			for (const auto& Key : OptionalKeys.GetValue())
 			{
@@ -731,7 +731,7 @@ void URH_PlayerInfo::SetPlayerSetting(const FString& SettingTypeId, const FStrin
 					UpdatedContent->Content = *Content;
 
 					// Update the local cache with the new settings (certain legacy setting types can affect multiple keys, so process all entries in the list)
-					auto SettingWrapper = PlayerSettingsByTypeId.FindOrAdd(SettingTypeId);
+					auto& SettingWrapper = PlayerSettingsByTypeId.FindOrAdd(SettingTypeId);
 
 					for (const auto& Pair : UpdatedContent->Content)
 					{


### PR DESCRIPTION
Being non references caused the cache updates to instead update temporary copies.