### PR TITLE
Add more verbose logging to the simple helper during failure cases.

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_Common.h
@@ -475,7 +475,17 @@ public:
 		}
 		else
 		{
-			Failed(TEXT("Query Failed"));
+			FString FailureReason = FString::Printf(TEXT("Query Failed with Code: %d"), Resp.GetHttpResponseCode());
+			if (ErrorInfo.bIsRHCommonError)
+			{
+				FailureReason += TEXT(", ") +  FString::Printf(TEXT("Common Error: Code: %s, Desc: %s"), *ErrorInfo.RHCommonError.GetErrorCode(), *ErrorInfo.RHCommonError.GetDesc());
+			}
+			else if (ErrorInfo.bIsRHValidationError)
+			{
+				FailureReason += TEXT(", ") +  FString::Printf(TEXT("Validation Error: Type: %s, Msg: %s"), *ErrorInfo.RHValidationError.GetType(), *ErrorInfo.RHValidationError.GetMsg());
+			}
+			
+			Failed(FailureReason);
 		}
 	}
 


### PR DESCRIPTION
Since the simple query helper task is not a bespoke helper with custom error messages at each step, it can be difficult to tell why something failed without more verbose logging