### PR TITLE
Make order watches internally poll inventory if it has not been polled yet, before starting order polling

### DIFF
--- a/Documentation/md/Inventory.md
+++ b/Documentation/md/Inventory.md
@@ -479,6 +479,7 @@ Inventory Subsystem created per player for tracking and updating player inventor
 `public void `[`ClearPendingOrder`](#classURH__PlayerInventory_1a1023ef83a9e1d7a88d3da06246aa7637)`(const `[`FRHAPI_PlayerOrder`](models/RHAPI_PlayerOrder.md#structFRHAPI__PlayerOrder)` & OrderResult)` | Used by the PendingOrder to clear itself from the pending order list when it completes.
 `public void `[`ParseOrderResult`](#classURH__PlayerInventory_1a0a3af764f187ffbd05955fb16a8bd5d7)`(const `[`FRHAPI_PlayerOrder`](models/RHAPI_PlayerOrder.md#structFRHAPI__PlayerOrder)` & Content)` | Parses a player order result API into a [URH_PlayerOrderEntry](Inventory.md#classURH__PlayerOrderEntry).
 `protected TMap< int32, TArray< `[`FRH_ItemInventory`](Inventory.md#structFRH__ItemInventory)` > > `[`InventoryCache`](#classURH__PlayerInventory_1a5d5179ccce89d685f086005d1b907ad8) | Inventory cache map of Item Id to inventory records.
+`protected TOptional< FDateTime > `[`LastFullInventoryTime`](#classURH__PlayerInventory_1aa0850ee414c71713fc6bfb385759aa83) | Last time the full inventory has been retrieved since this watch was created.
 `protected TArray< FString > `[`ParsedInventoryOrders`](#classURH__PlayerInventory_1a76a82d3bb8f00ae1427129887e83952b) | Array of inventory orders that have recently been parsed to prevent double parsing orders through normal polling.
 `protected FRH_AutoPollerPtr `[`InventoryPoller`](#classURH__PlayerInventory_1a9b073e90506714df4cff00f456168580) | Poller for inventory updates.
 `protected FRH_AutoPollerPtr `[`PendingInventoryPoller`](#classURH__PlayerInventory_1ad2760c4c21398d38fad0929a5ab3b9ff) | Polled for pending inventory.
@@ -809,6 +810,10 @@ Parses a player order result API into a [URH_PlayerOrderEntry](Inventory.md#clas
 #### `protected TMap< int32, TArray< `[`FRH_ItemInventory`](Inventory.md#structFRH__ItemInventory)` > > `[`InventoryCache`](#classURH__PlayerInventory_1a5d5179ccce89d685f086005d1b907ad8) <a id="classURH__PlayerInventory_1a5d5179ccce89d685f086005d1b907ad8"></a>
 
 Inventory cache map of Item Id to inventory records.
+
+#### `protected TOptional< FDateTime > `[`LastFullInventoryTime`](#classURH__PlayerInventory_1aa0850ee414c71713fc6bfb385759aa83) <a id="classURH__PlayerInventory_1aa0850ee414c71713fc6bfb385759aa83"></a>
+
+Last time the full inventory has been retrieved since this watch was created.
 
 #### `protected TArray< FString > `[`ParsedInventoryOrders`](#classURH__PlayerInventory_1a76a82d3bb8f00ae1427129887e83952b) <a id="classURH__PlayerInventory_1a76a82d3bb8f00ae1427129887e83952b"></a>
 

--- a/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIBaseModel.h
+++ b/RallyHereAPI/Source/RallyHereAPI/Public/RallyHereAPIBaseModel.h
@@ -404,26 +404,26 @@ public:
 	 * @param [out] OutValue A string to store the header value to, if found
 	 * @return Whether or not the header was found
 	 */
-	bool TryGetHeader(const FString& Header, FString& OutValue) const { const auto OutValuePtr = HeadersMap.Find(Header); if (OutValuePtr != nullptr) OutValue = *OutValuePtr; else OutValue = FString(); return OutValuePtr != nullptr; }
+	FORCEINLINE bool TryGetHeader(const FString& Header, FString& OutValue) const { const auto OutValuePtr = HeadersMap.Find(Header); if (OutValuePtr != nullptr) OutValue = *OutValuePtr; else OutValue = FString(); return OutValuePtr != nullptr; }
 	/**
 	 * @brief Attempt to fetch a header by name
 	 * @param [in] Header The name of the header to fetch
 	 * @param [out] OutValue A TOptional<FString> to store the header value to, if found
 	 * @return Whether or not the header was found
 	 */
-	bool TryGetHeader(const FString& Header, TOptional<FString>& OutValue) const { const auto OutValuePtr = HeadersMap.Find(Header); if (OutValuePtr != nullptr) OutValue = *OutValuePtr; else OutValue.Reset(); return OutValuePtr != nullptr; }
+	FORCEINLINE bool TryGetHeader(const FString& Header, TOptional<FString>& OutValue) const { const auto OutValuePtr = HeadersMap.Find(Header); if (OutValuePtr != nullptr) OutValue = *OutValuePtr; else OutValue.Reset(); return OutValuePtr != nullptr; }
 	/**
 	 * @brief Attempt to fetch a header by name
 	 * @param [in] Header The name of the header to fetch
 	 * @return A pointer to the header string value, if found.  The memory is owned by the response object!
 	 */
-	const FString* TryGetHeaderAsPointer(const FString& Header) const { return HeadersMap.Find(Header); }
+	FORCEINLINE const FString* TryGetHeaderAsPointer(const FString& Header) const { return HeadersMap.Find(Header); }
 	/**
 	 * @brief Attempt to fetch a header by name
 	 * @param [in] Header The name of the header to fetch
 	 * @return An optional string of the header string value, if found.  The memory is owned by the returned optional object, which contains a copy of the value if valid.
 	 */
-	const TOptional<FString> TryGetHeaderAsOptional(const FString& Header) const { const auto Ptr = HeadersMap.Find(Header); return Ptr != nullptr ? *Ptr : TOptional<FString>(); }
+	FORCEINLINE const TOptional<FString> TryGetHeaderAsOptional(const FString& Header) const { const auto Ptr = HeadersMap.Find(Header); return Ptr != nullptr ? *Ptr : TOptional<FString>(); }
 
 };
 

--- a/RallyHereDebugTool/Source/Private/RHDTW_PlayerInventory.cpp
+++ b/RallyHereDebugTool/Source/Private/RHDTW_PlayerInventory.cpp
@@ -78,6 +78,12 @@ FRHDTW_PlayerInventory::FRHDTW_PlayerInventory()
 	InputExpires.SetNumZeroed(RH_STRINGENTRY_GUIDSIZE);
 	ModifyInventoryIdInput.SetNumZeroed(RH_STRINGENTRY_GUIDSIZE);
 
+	// bind orders block to an empty lambda, so it is valid
+	OrderDetailsBlock = FRH_OrderDetailsDelegate::CreateLambda([](const TArray<FRHAPI_PlayerOrder>& Orders)
+	{
+		
+	});
+
 	CustomDataStager.SetName(TEXT("Inventory Change"));
 }
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInventory.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerInventory.h
@@ -44,8 +44,8 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FRH_GetInventoryStateDynamicDelegate, bool, Is
 DECLARE_DELEGATE_OneParam(FRH_GetInventoryStateDelegate, bool);
 DECLARE_RH_DELEGATE_BLOCK(FRH_GetInventoryStateBlock, FRH_GetInventoryStateDelegate, FRH_GetInventoryStateDynamicDelegate, bool)
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FRH_InventoryUpdatedDynamicDelegate, const TArray<int32>&, ItemIds);
-DECLARE_DELEGATE_TwoParams(FRH_InventoryUpdatedDelegate, const TArray<int32>&, URH_PlayerInfo*);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FRH_InventoryUpdatedDynamicDelegate, const TArray<int32>&, ItemIds, URH_PlayerInfo*, PlayerInfo);
+DECLARE_MULTICAST_DELEGATE_TwoParams(FRH_InventoryUpdatedDelegate, const TArray<int32>&, URH_PlayerInfo*);
 
 UDELEGATE()
 DECLARE_DYNAMIC_DELEGATE_OneParam(FRH_OnInventorySessionUpdateDynamicDelegate, bool, bSuccess);
@@ -276,7 +276,7 @@ public:
 	 * @brief List of delegates listening for order.
 	 */
 	TArray<FRH_OrderDetailsBlock> Delegates;
-
+	
 protected:
 	/**
 	* @brief Handles the response to a Get Player Order call.
@@ -1070,6 +1070,8 @@ public:
 protected:
 	/** @brief Inventory cache map of Item Id to inventory records. */
 	TMap<int32, TArray<FRH_ItemInventory>> InventoryCache;
+	/** Last time the full inventory has been retrieved since this watch was created. */
+	TOptional<FDateTime> LastFullInventoryTime;
 	/** @brief Array of inventory orders that have recently been parsed to prevent double parsing orders through normal polling. */
 	TArray<FString> ParsedInventoryOrders;
 	/** @brief Poller for inventory updates. */
@@ -1149,8 +1151,8 @@ protected:
 	void BroadcastOnInventoryCacheUpdated(const TArray<int32>& ItemIds)
 	{
 		SCOPED_NAMED_EVENT(RallyHere_BroadcastInventoryCacheUpdated, FColor::Purple);
-		OnInventoryCacheUpdated.ExecuteIfBound(ItemIds, PlayerInfo);
-		OnInventoryCacheUpdatedBP.Broadcast(ItemIds);
+		OnInventoryCacheUpdated.Broadcast(ItemIds, PlayerInfo);
+		OnInventoryCacheUpdatedBP.Broadcast(ItemIds, PlayerInfo);
 	}
 	/** @brief Callback that occurs whenever the local player this subsystem is associated with changes. */
 	void OnUserChanged();

--- a/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/model-base-header.mustache
+++ b/openapi-generator-rh-cpp-unreal/src/main/resources/rh-cpp-ue4/model-base-header.mustache
@@ -416,26 +416,26 @@ public:
 	 * @param [out] OutValue A string to store the header value to, if found
 	 * @return Whether or not the header was found
 	 */
-	bool TryGetHeader(const FString& Header, FString& OutValue) const { const auto OutValuePtr = HeadersMap.Find(Header); if (OutValuePtr != nullptr) OutValue = *OutValuePtr; else OutValue = FString(); return OutValuePtr != nullptr; }
+	FORCEINLINE bool TryGetHeader(const FString& Header, FString& OutValue) const { const auto OutValuePtr = HeadersMap.Find(Header); if (OutValuePtr != nullptr) OutValue = *OutValuePtr; else OutValue = FString(); return OutValuePtr != nullptr; }
 	/**
 	 * @brief Attempt to fetch a header by name
 	 * @param [in] Header The name of the header to fetch
 	 * @param [out] OutValue A TOptional<FString> to store the header value to, if found
 	 * @return Whether or not the header was found
 	 */
-	bool TryGetHeader(const FString& Header, TOptional<FString>& OutValue) const { const auto OutValuePtr = HeadersMap.Find(Header); if (OutValuePtr != nullptr) OutValue = *OutValuePtr; else OutValue.Reset(); return OutValuePtr != nullptr; }
+	FORCEINLINE bool TryGetHeader(const FString& Header, TOptional<FString>& OutValue) const { const auto OutValuePtr = HeadersMap.Find(Header); if (OutValuePtr != nullptr) OutValue = *OutValuePtr; else OutValue.Reset(); return OutValuePtr != nullptr; }
 	/**
 	 * @brief Attempt to fetch a header by name
 	 * @param [in] Header The name of the header to fetch
 	 * @return A pointer to the header string value, if found.  The memory is owned by the response object!
 	 */
-	const FString* TryGetHeaderAsPointer(const FString& Header) const { return HeadersMap.Find(Header); }
+	FORCEINLINE const FString* TryGetHeaderAsPointer(const FString& Header) const { return HeadersMap.Find(Header); }
 	/**
 	 * @brief Attempt to fetch a header by name
 	 * @param [in] Header The name of the header to fetch
 	 * @return An optional string of the header string value, if found.  The memory is owned by the returned optional object, which contains a copy of the value if valid.
 	 */
-	const TOptional<FString> TryGetHeaderAsOptional(const FString& Header) const { const auto Ptr = HeadersMap.Find(Header); return Ptr != nullptr ? *Ptr : TOptional<FString>(); }
+	FORCEINLINE const TOptional<FString> TryGetHeaderAsOptional(const FString& Header) const { const auto Ptr = HeadersMap.Find(Header); return Ptr != nullptr ? *Ptr : TOptional<FString>(); }
 
 };
 


### PR DESCRIPTION
This has some breaking changes around the inventory callback delegates.  Specifically the native delegate was not labelled as multicast, and the blueprint and native delegates passed different parameters and now are uniform.