### PR TITLE
Fix error logging in remote file subsystem

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_RemoteFileSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_RemoteFileSubsystem.cpp
@@ -44,20 +44,21 @@ void URH_RemoteFileSubsystem::UploadFile(const FRH_RemoteFileApiDirectory& Direc
 		FileInput.SetContentType(TEXT("application/octet-stream"));
 	}
 	Request.File = FileInput;
-
+	
 	auto Helper = MakeShared<FRH_SimpleQueryHelper<BaseType>>(
-		BaseType::Delegate::CreateWeakLambda(this, [this, Directory, RemoteFileName, LocalFilePath](const BaseType::Response& Response)
+		BaseType::Delegate(),
+		FRH_GenericSuccessWithErrorDelegate::CreateWeakLambda(this, [LocalFilePath, Directory, RemoteFileName, Delegate](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
+		{
+			if (bSuccess)
 			{
-				if (Response.IsSuccessful())
-				{
-					UE_LOG(LogRallyHereIntegration, Log, TEXT("File %s uploaded successfully to %s::%s"), *LocalFilePath, *Directory.ToDescriptionString(), *RemoteFileName);
-				}
-				else
-				{
-					UE_LOG(LogRallyHereIntegration, Error, TEXT("Failed to upload file %s to %s::%s"), *LocalFilePath, *Directory.ToDescriptionString(), *RemoteFileName);
-				}
-			}),
-		Delegate,
+				UE_LOG(LogRallyHereIntegration, Log, TEXT("Uploaded file %s to %s::%s"), *LocalFilePath, *Directory.ToDescriptionString(), *RemoteFileName);
+			}
+			else
+			{
+				UE_LOG(LogRallyHereIntegration, Error, TEXT("Failed to upload file %s to %s::%s"), *LocalFilePath, *Directory.ToDescriptionString(), *RemoteFileName);
+			}
+			Delegate.ExecuteIfBound(bSuccess, ErrorInfo);
+		}),
 		GetDefault<URH_IntegrationSettings>()->FileUploadPriority
 	);
 
@@ -128,12 +129,19 @@ void URH_RemoteFileSubsystem::DownloadFile(const FRH_RemoteFileApiDirectory& Dir
 						UE_LOG(LogRallyHereIntegration, Error, TEXT("Successfully downloaded %s::%s, but type is unknown so cannot save to %s"), *Directory.ToDescriptionString(), *RemoteFileName, *LocalFilePath);
 					}
 				}
+			}),
+			FRH_GenericSuccessWithErrorDelegate::CreateWeakLambda(this, [LocalFilePath, Directory, RemoteFileName, Delegate](bool bSuccess, const FRH_ErrorInfo& ErrorInfo)
+			{
+				if (bSuccess)
+				{
+					//UE_LOG(LogRallyHereIntegration, Log, TEXT("Uploaded file %s to %s::%s"), *LocalFilePath, *Directory.ToDescriptionString(), *RemoteFileName);
+				}
 				else
 				{
 					UE_LOG(LogRallyHereIntegration, Error, TEXT("Failed to download file %s::%s to %s"), *Directory.ToDescriptionString(), *RemoteFileName, *LocalFilePath);
 				}
+				Delegate.ExecuteIfBound(bSuccess, ErrorInfo);
 			}),
-		Delegate,
 		GetDefault<URH_IntegrationSettings>()->FileDownloadPriority
 	);
 


### PR DESCRIPTION
The log statements were only called on success (due to being in the update callback rather than the complete callback)