### PR TITLE
Remove auto lookup for blocked players, and do not bind for presence updates.

### DIFF
--- a/Documentation/md/Friends.md
+++ b/Documentation/md/Friends.md
@@ -512,7 +512,6 @@ Friends Subsystem for handling a users relationships with other players.
 `public `[`URH_RHFriendAndPlatformFriend`](Friends.md#classURH__RHFriendAndPlatformFriend)` * `[`GetFriendByPlatformId`](#classURH__FriendSubsystem_1af97f126a67a75dd74416eadf099f4968)`(const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlatformPlayerId) const` | Gets the cached friend wrapper for the specified player.
 `public `[`URH_RHFriendAndPlatformFriend`](Friends.md#classURH__RHFriendAndPlatformFriend)` * `[`GetFriendByUuidOrPlatformId`](#classURH__FriendSubsystem_1af887af8839847c43703f0883912f9030)`(const FGuid & PlayerUuid,const `[`FRH_PlayerPlatformId`](Common.md#structFRH__PlayerPlatformId)` & PlatformPlayerId) const` | Gets the cached friend wrapper for the specified player.
 `public inline bool `[`IsFriendBlocked`](#classURH__FriendSubsystem_1aef429e16fb76c76f805ed37a2c8bb35d)`(const `[`URH_RHFriendAndPlatformFriend`](Friends.md#classURH__RHFriendAndPlatformFriend)` * Player) const` | Gets if the specified player is blocked via platform or Rally Here.
-`public inline bool `[`IsFriendPlatformBlocked`](#classURH__FriendSubsystem_1a0013b0ca7d5c98f0b20fed4d8d2f7649)`(const `[`URH_RHFriendAndPlatformFriend`](Friends.md#classURH__RHFriendAndPlatformFriend)` * Player) const` | Gets if the specified player is blocked via platform.
 `public inline bool `[`IsPlayerBlocked`](#classURH__FriendSubsystem_1a796323262a6d65dbd3871600ec67333a)`(const FGuid & PlayerUuid) const` | Gets if the specified player is blocked via platform or Rally Here.
 `public inline bool `[`IsPlayerPlatformBlocked`](#classURH__FriendSubsystem_1a5daea0768eab9487eb4d07b6eec7bcc0)`(const FGuid & PlayerUuid) const` | Gets if the specified player is blocked via platform.
 `public inline bool `[`IsPlayerRhBlocked`](#classURH__FriendSubsystem_1a7729188985902b5d94f5f0e6f4c5a99a)`(const FGuid & PlayerUuid) const` | Gets if the specified player is blocked via Rally Here.
@@ -790,13 +789,6 @@ Gets the cached friend wrapper for the specified player.
 #### `public inline bool `[`IsFriendBlocked`](#classURH__FriendSubsystem_1aef429e16fb76c76f805ed37a2c8bb35d)`(const `[`URH_RHFriendAndPlatformFriend`](Friends.md#classURH__RHFriendAndPlatformFriend)` * Player) const` <a id="classURH__FriendSubsystem_1aef429e16fb76c76f805ed37a2c8bb35d"></a>
 
 Gets if the specified player is blocked via platform or Rally Here.
-
-#### Parameters
-* `Player` Pointer to the friend representation of the player
-
-#### `public inline bool `[`IsFriendPlatformBlocked`](#classURH__FriendSubsystem_1a0013b0ca7d5c98f0b20fed4d8d2f7649)`(const `[`URH_RHFriendAndPlatformFriend`](Friends.md#classURH__RHFriendAndPlatformFriend)` * Player) const` <a id="classURH__FriendSubsystem_1a0013b0ca7d5c98f0b20fed4d8d2f7649"></a>
-
-Gets if the specified player is blocked via platform.
 
 #### Parameters
 * `Player` Pointer to the friend representation of the player

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_FriendSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_FriendSubsystem.h
@@ -920,7 +920,7 @@ public:
 	 * @param [in] Player Pointer to the friend representation of the player
 	 */
 	UFUNCTION(BlueprintPure, Category = "Friend Subsystem")
-	bool IsFriendPlatformBlocked(const URH_RHFriendAndPlatformFriend* Player) const
+	static bool IsFriendPlatformBlocked(const URH_RHFriendAndPlatformFriend* Player)
 	{
 		if (IsValid(Player))
 		{


### PR DESCRIPTION
If you need to look up a player uuid for blocked players, use URH_RHFriendAndPlatformFriend::GetRHPlayerUuidAsync()