### PR TITLE
Move delegate call to after local state changes are complete, 

### DIFF
--- a/Documentation/md/Catalog.md
+++ b/Documentation/md/Catalog.md
@@ -790,7 +790,7 @@ Notify that a vendor has failed to be received.
 * `VendorId` The VendorID that failed 
 
 #### Returns
-Whether the vendor was awaited and the request should be completed
+Whether the vendor was awaited and the request should be failed
 
 #### `public TArray< int32 > `[`GetAllKnownVendorIds`](#structFRH__VendorRequestState_1ab1bb3e584f61c7cbe90dd387516fdbad)`() const` <a id="structFRH__VendorRequestState_1ab1bb3e584f61c7cbe90dd387516fdbad"></a>
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_CatalogSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_CatalogSubsystem.cpp
@@ -535,7 +535,10 @@ void URH_CatalogSubsystem::ProcessVendorRequests()
 		TArray<int32> AwaitedVendors;
 		if (Request.IsComplete(AwaitedVendors))
 		{
+			// copy the delegate and remove the request (the request will be invalid once removed from the list)
+			auto Delegate = Request.Request.Delegate;
 			VendorRequests.RemoveAt(i);
+			Delegate.ExecuteIfBound(true);
 		}
 		else
 		{

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_CatalogSubsystem.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_CatalogSubsystem.cpp
@@ -469,14 +469,24 @@ void URH_CatalogSubsystem::OnGetCatalogVendorResponse(const TGetCatalogVendor::R
 	}
 	else
 	{
+		TArray<FRH_CatalogCallBlock> CompletedRequestDelegates;
+		
 		// vendor could not be retrieved, fail any requests that were expecting this vendor
 		for (int32 i = VendorRequests.Num() - 1; i >= 0; i--)
 		{
 			if (VendorRequests[i].NotifyVendorFailure(VendorId))
 			{
+				CompletedRequestDelegates.Add(VendorRequests[i].Request.Delegate);
 				VendorRequests.RemoveAt(i);
 			}
 		}
+
+		// execute any completed request delegates (this happens last so that the processing state is complete before the delegates are executed)
+		for (const auto& Delegate : CompletedRequestDelegates)
+		{
+			Delegate.ExecuteIfBound(false);
+		}
+		
 		return;
 	}
 
@@ -525,6 +535,8 @@ void URH_CatalogSubsystem::ProcessVendorRequests()
 {
 	// keep track of any subvendors we need to request (that are newly added to any request, and thus were not already kicked off)
 	TArray<int32> VendorsToRequest;
+
+	TArray<FRH_CatalogCallBlock> CompletedRequestDelegates;
 	
 	// scan through requests, fulfilling them as needed
 	for (int32 i = VendorRequests.Num() - 1; i >= 0; i--)
@@ -536,9 +548,8 @@ void URH_CatalogSubsystem::ProcessVendorRequests()
 		if (Request.IsComplete(AwaitedVendors))
 		{
 			// copy the delegate and remove the request (the request will be invalid once removed from the list)
-			auto Delegate = Request.Request.Delegate;
+			CompletedRequestDelegates.Add(Request.Request.Delegate);
 			VendorRequests.RemoveAt(i);
-			Delegate.ExecuteIfBound(true);
 		}
 		else
 		{
@@ -558,6 +569,12 @@ void URH_CatalogSubsystem::ProcessVendorRequests()
 	for (int32 SubVendorId : VendorsToRequest)
 	{
 		GetCatalogVendorSingle(SubVendorId);
+	}
+
+	// finally, execute any completed request delegates (this happens last so that the processing state is complete before the delegates are executed)
+	for (const auto& Delegate : CompletedRequestDelegates)
+	{
+		Delegate.ExecuteIfBound(true);
 	}
 }
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_CatalogSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_CatalogSubsystem.h
@@ -167,13 +167,7 @@ public:
 	 */
 	bool IsComplete(TArray<int32>& OutAwaitedVendors) const
 	{
-		OutAwaitedVendors = GetAwaitedVendorIds();
-		if (OutAwaitedVendors.Num() == 0)
-		{
-			Request.Delegate.ExecuteIfBound(true);
-			return true;
-		}
-		return false;
+		return GetAwaitedVendorIds().Num() == 0;
 	}
 };
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_CatalogSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_CatalogSubsystem.h
@@ -139,13 +139,12 @@ public:
 	/**
 	 * @brief Notify that a vendor has failed to be received.
 	 * @param [in] VendorId The VendorID that failed
-	 * @return Whether the vendor was awaited and the request should be completed
+	 * @return Whether the vendor was awaited and the request should be failed
 	 */
 	bool NotifyVendorFailure(int32 VendorId)
 	{
 		if (GetAwaitedVendorIds().Contains(VendorId))
 		{
-			Request.Delegate.ExecuteIfBound(false);
 			return true;
 		}
 
@@ -167,7 +166,8 @@ public:
 	 */
 	bool IsComplete(TArray<int32>& OutAwaitedVendors) const
 	{
-		return GetAwaitedVendorIds().Num() == 0;
+		OutAwaitedVendors = GetAwaitedVendorIds();
+		return OutAwaitedVendors.Num() == 0;
 	}
 };
 


### PR DESCRIPTION
This adds safety to calls to request subsequent vendors within the callback (which with subvendor requests being optional is now semi expected)