### PR TITLE
Fix vendor requests not properly calling callback in case of errors or not modified responses

### DIFF
--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_CatalogSubsystem.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_CatalogSubsystem.h
@@ -572,10 +572,17 @@ protected:
 	/**
 	* @brief Handles the response to a Get Catalog Vendor call
 	* @param [in] Resp Response given for the call
-	* @param [in] Delegate Delegate passed in for original call to respond to when call completes.
 	* @param [in] VendorId The Vendor Id that was requested.
 	*/
-	virtual void OnGetCatalogVendorResponse(const TGetCatalogVendor::Response& Resp, int32 VendorId);
+	virtual void OnGetCatalogVendorResponseUpdate(const TGetCatalogVendor::Response& Resp, int32 VendorId);
+	/**
+	* @brief Handles the response to a Get Catalog Vendor call
+	* @param [in] bSuccess If the call was successful.
+	* @param [in] ErrorInfo The error information if the call failed.
+	* @param [in] VendorId The Vendor Id that was requested.
+	* @param [in] Delegate Delegate passed in for original call to respond to when call completes.
+	*/
+	virtual void OnGetCatalogVendorResponseComplete(bool bSuccess, const FRH_ErrorInfo& ErrorInfo, int32 VendorId, FRH_GenericSuccessWithErrorBlock Delegate);
 	/**
 	 * @brief Processes the current vendor request list, kicking off any new requests that are needed, and completing existing requests that are done.
 	 */


### PR DESCRIPTION
Rework the vendor request callbacks to be properly split into an "update" callback and a "complete" callback, so that all paths will run completion work regardless of what response code is.