### PR TITLE
Have Host network tracking for PEX roll up the individual connection data once an interval into a local sample

### DIFF
--- a/Documentation/md/PlayerExperience.md
+++ b/Documentation/md/PlayerExperience.md
@@ -863,6 +863,8 @@ Stat group for capturing local whole-state network stats, plus per-player stats.
 `public `[`URH_PEXNetworkStats_Client`](PlayerExperience.md#classURH__PEXNetworkStats__Client)` * `[`ClientNetworkStats`](#classURH__PEXNetworkStats_1a212cb988d8d7039c901932789fe54318) | Client's connection to host, only used by summary
 `public `[`URH_PEXNetworkStats_Host`](PlayerExperience.md#classURH__PEXNetworkStats__Host)` * `[`HostNetworkStats`](#classURH__PEXNetworkStats_1a0b98f24749d884e7ee921ef93b213c97) | Host's connection to clients, only used by summary
 `public  `[`URH_PEXNetworkStats`](#classURH__PEXNetworkStats_1a3354185befc3c15728f1362cc34f95e2)`()` | 
+`public inline virtual void `[`GetPEXHostSummary`](#classURH__PEXNetworkStats_1a18a03108cbe2dcb94d6dc97dd4f1a229)`(`[`FRHAPI_PexHostRequest`](models/RHAPI_PexHostRequest.md#structFRHAPI__PexHostRequest)` & Report) const` | Fill in a API PEX host summary report with the summary data.
+`public inline virtual void `[`GetPEXClientSummary`](#classURH__PEXNetworkStats_1aa53c887acc51913905a8081079263e88)`(`[`FRHAPI_PexClientRequest`](models/RHAPI_PexClientRequest.md#structFRHAPI__PexClientRequest)` & Report) const` | Fill in a API PEX client summary report with the summary data.
 
 ### Members
 
@@ -879,6 +881,14 @@ Client's connection to host, only used by summary
 Host's connection to clients, only used by summary
 
 #### `public  `[`URH_PEXNetworkStats`](#classURH__PEXNetworkStats_1a3354185befc3c15728f1362cc34f95e2)`()` <a id="classURH__PEXNetworkStats_1a3354185befc3c15728f1362cc34f95e2"></a>
+
+#### `public inline virtual void `[`GetPEXHostSummary`](#classURH__PEXNetworkStats_1a18a03108cbe2dcb94d6dc97dd4f1a229)`(`[`FRHAPI_PexHostRequest`](models/RHAPI_PexHostRequest.md#structFRHAPI__PexHostRequest)` & Report) const` <a id="classURH__PEXNetworkStats_1a18a03108cbe2dcb94d6dc97dd4f1a229"></a>
+
+Fill in a API PEX host summary report with the summary data.
+
+#### `public inline virtual void `[`GetPEXClientSummary`](#classURH__PEXNetworkStats_1aa53c887acc51913905a8081079263e88)`(`[`FRHAPI_PexClientRequest`](models/RHAPI_PexClientRequest.md#structFRHAPI__PexClientRequest)` & Report) const` <a id="classURH__PEXNetworkStats_1aa53c887acc51913905a8081079263e88"></a>
+
+Fill in a API PEX client summary report with the summary data.
 
 ## class `URH_PEXGameStats` <a id="classURH__PEXGameStats"></a>
 
@@ -1054,6 +1064,7 @@ State of the accumulated stat.
 `public inline  `[`FRH_PEXStatState`](#structFRH__PEXStatState_1afbf06852851c62d7e57acfe36a7f15d0)`()` | 
 `public inline void `[`Reset`](#structFRH__PEXStatState_1a640b7389adc87774e29b2d4a6971629c)`()` | Reset the state to defaults.
 `public inline void `[`AddValue`](#structFRH__PEXStatState_1a0c07fc5f97ff5396f0073d21ce756f5a)`(float Value)` | Add a value to the accumulator.
+`public inline void `[`MergeAddValue`](#structFRH__PEXStatState_1ab7ff73a43515fc4ad23e8588759f8db5)`(const `[`FRH_PEXStatState`](#structFRH__PEXStatState)` & Other)` | Merge another stat state into this one.
 `public inline void `[`UpdateSummary`](#structFRH__PEXStatState_1a0a6f5e8339d76333b329d7a284de6a18)`(const `[`FRH_PEXStatState`](#structFRH__PEXStatState)` & CurrentState)` | Update the summary state with the current state.
 
 ### Members
@@ -1099,6 +1110,10 @@ Reset the state to defaults.
 #### `public inline void `[`AddValue`](#structFRH__PEXStatState_1a0c07fc5f97ff5396f0073d21ce756f5a)`(float Value)` <a id="structFRH__PEXStatState_1a0c07fc5f97ff5396f0073d21ce756f5a"></a>
 
 Add a value to the accumulator.
+
+#### `public inline void `[`MergeAddValue`](#structFRH__PEXStatState_1ab7ff73a43515fc4ad23e8588759f8db5)`(const `[`FRH_PEXStatState`](#structFRH__PEXStatState)` & Other)` <a id="structFRH__PEXStatState_1ab7ff73a43515fc4ad23e8588759f8db5"></a>
+
+Merge another stat state into this one.
 
 #### `public inline void `[`UpdateSummary`](#structFRH__PEXStatState_1a0a6f5e8339d76333b329d7a284de6a18)`(const `[`FRH_PEXStatState`](#structFRH__PEXStatState)` & CurrentState)` <a id="structFRH__PEXStatState_1a0a6f5e8339d76333b329d7a284de6a18"></a>
 

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlayerExperienceCollector.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_PlayerExperienceCollector.cpp
@@ -706,6 +706,22 @@ void URH_PEXNetworkStats_Host::CapturePerIntervalStats(const TScriptInterface<IR
 {
 	EnsureConnectionTrackersExist(Owner);
 	Super::CapturePerIntervalStats(Owner);
+
+	// generate captures of all the connection stats into our local stat tracking
+	for (auto PlayerNetworkStat : PlayerNetworkStats)
+	{
+		auto Child = PlayerNetworkStat.Value;
+		
+		for (int32 StatId = 0; StatId < static_cast<int32>(ECaptureStat::Max); ++StatId)
+		{
+			const auto StatEnum = static_cast<ECaptureStat>(StatId); 
+			auto& ChildStat = Child->GetCaptureStat(StatEnum);
+			auto& LocalStat = GetCaptureStat(StatEnum);
+
+			// use the update summary call, as it will merge in a target capture state
+			LocalStat.CaptureState.UpdateSummary(ChildStat.CaptureState);
+		}
+	}
 }
 
 void URH_PEXNetworkStats_Host::GetOrCreatePlayerNetworkStats(const UNetConnection* Connection, URH_PEXNetworkStats_Connection*& OutPlayerNetworkStats)

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerExperienceCollector.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerExperienceCollector.h
@@ -1329,7 +1329,8 @@ public:
 	virtual void GetPEXHostSummary(FRHAPI_PexHostRequest& Report) const
 	{
 		Super::GetPEXHostSummary(Report);
-		
+
+		// inject player count into the summary
 		{
 			FRHAPI_PexCount PexCount;
 			PexCount.SetCount(PlayerNetworkStats.Num());

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerExperienceCollector.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerExperienceCollector.h
@@ -262,6 +262,28 @@ struct RALLYHEREINTEGRATION_API FRH_PEXStatState
 			Variance = 0.0f;
 		}
 	}
+	
+	/** @brief Merge another stat state into this one */
+	void MergeAddValue(const FRH_PEXStatState& Other)
+	{
+		Current += Other.Current;
+		Min = FMath::Min(Min, Other.Min);
+		Max = FMath::Max(Max, Other.Max);
+		Sum += Other.Sum;
+		SumOfSquares += Other.SumOfSquares;
+		Count += Other.Count;
+
+		if (Count > 0)
+		{
+			Avg = Sum / Count;
+			Variance = (SumOfSquares / Count) - (Avg * Avg);
+		}
+		else
+		{
+			Avg = 0.0f;
+			Variance = 0.0f;
+		}
+	}
 
 	/** @brief Update the summary state with the current state */
 	void UpdateSummary(const FRH_PEXStatState& CurrentState)
@@ -1384,6 +1406,24 @@ public:
 	/** Host's connection to clients, only used by summary */
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="PlayerExperience")
 	URH_PEXNetworkStats_Host* HostNetworkStats;
+
+	/** @brief Fill in a API PEX host summary report with the summary data */
+	virtual void GetPEXHostSummary(FRHAPI_PexHostRequest& Report) const
+	{
+		// Super::GetPEXHostSummary(Report);
+
+		// the host reports the host network state from the host capture to the host capture summary
+		HostNetworkStats->GetPEXHostSummary(Report);
+	}
+
+	/** @brief Fill in a API PEX client summary report with the summary data */
+	virtual void GetPEXClientSummary(FRHAPI_PexClientRequest& Report) const
+	{
+		// Super::GetPEXClientSummary(Report);
+
+		// the client reports the client network state from the client capture to the client capture summary
+		ClientNetworkStats->GetPEXClientSummary(Report);
+	}
 };
 
 /** @brief Stat group for capturing game stats */

--- a/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerExperienceCollector.h
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Public/RH_PlayerExperienceCollector.h
@@ -266,45 +266,42 @@ struct RALLYHEREINTEGRATION_API FRH_PEXStatState
 	/** @brief Merge another stat state into this one */
 	void MergeAddValue(const FRH_PEXStatState& Other)
 	{
-		Current += Other.Current;
-		Min = FMath::Min(Min, Other.Min);
-		Max = FMath::Max(Max, Other.Max);
-		Sum += Other.Sum;
-		SumOfSquares += Other.SumOfSquares;
-		Count += Other.Count;
-
-		if (Count > 0)
+		if (Other.Count <= 0)
 		{
-			Avg = Sum / Count;
-			Variance = (SumOfSquares / Count) - (Avg * Avg);
+			// if no data is available to merge, do not merge anything
+		}
+		else if (Count <= 0)
+		{
+			// if we have no data locally, accept the new data as-is
+			*this = Other;
 		}
 		else
 		{
-			Avg = 0.0f;
-			Variance = 0.0f;
+			// merge the values
+			Current = Other.Current; // just take the current value from the other state, adding generally does not make sense
+			Min = FMath::Min(Min, Other.Min);
+			Max = FMath::Max(Max, Other.Max);
+			Sum += Other.Sum;
+			SumOfSquares += Other.SumOfSquares;
+			Count += Other.Count;
+
+			if (Count > 0)
+			{
+				Avg = Sum / Count;
+				Variance = (SumOfSquares / Count) - (Avg * Avg);
+			}
+			else
+			{
+				Avg = 0.0f;
+				Variance = 0.0f;
+			}
 		}
 	}
 
 	/** @brief Update the summary state with the current state */
 	void UpdateSummary(const FRH_PEXStatState& CurrentState)
 	{
-		Current = CurrentState.Current;
-		Min = FMath::Min(Min, CurrentState.Min);
-		Max = FMath::Max(Max, CurrentState.Max);
-		Sum += CurrentState.Sum;
-		SumOfSquares += CurrentState.SumOfSquares;
-		Count += CurrentState.Count;
-
-		if (Count > 0)
-		{
-			Avg = Sum / Count;
-			Variance = (SumOfSquares / Count) - (Avg * Avg);
-		}
-		else
-		{
-			Avg = 0.0f;
-			Variance = 0.0f;
-		}
+		MergeAddValue(CurrentState);
 	}
 };
 


### PR DESCRIPTION
That local sample can then be reported as an overall hosting network score.