### PR TITLE
Rather than hardcoded engine build version, allow GHA version to be passed from game layer via standardized lookup functions.

### DIFF
--- a/RallyHereIntegration/Source/RallyHereGameHostProvider/Private/RH_GameHostProviderGHA.cpp
+++ b/RallyHereIntegration/Source/RallyHereGameHostProvider/Private/RH_GameHostProviderGHA.cpp
@@ -57,9 +57,6 @@ FRH_GameHostProviderGHA::FRH_GameHostProviderGHA(const FString& Commandline)
 		stats.visibility = 0;
 		provided.set_visibility = true;
 
-		stats.version = (ANSICHAR*)BuildVersion.Get();
-		provided.set_version = true;
-
 		stats.server_type = IsRunningDedicatedServer() ? 'd' : 'l';
 		provided.set_server_type = true;
 
@@ -159,13 +156,21 @@ void FRH_GameHostProviderGHA::Tick(float DeltaTime)
 			memset(&provided, 0x00, sizeof(provided));
 
 			// make sure the string storage persists properly until the call
-			FString MapName;
+			FString MapName = GameStats.Map.Get(TEXT(""));
 			FTCHARToUTF8 MapNameUTF8(*MapName);
 			if (GameStats.Map.IsSet())
 			{
-				MapName = GameStats.Map.GetValue();
 				stats.map = (ANSICHAR*)MapNameUTF8.Get();
 				provided.set_map = true;
+			}
+
+			const auto& VersionSpecifier = GameStats.SessionCompatibilityVersion;
+			FString Version = VersionSpecifier.Get(TEXT(""));
+			FTCHARToUTF8 VersionUTF8(*Version);
+			if (VersionSpecifier.IsSet())
+			{
+				stats.version = (ANSICHAR*)VersionUTF8.Get();
+				provided.set_version = true;
 			}
 
 			if (GameStats.PlayerCount.IsSet())

--- a/RallyHereIntegration/Source/RallyHereGameHostProvider/Public/RH_GameHostProviderInterface.h
+++ b/RallyHereIntegration/Source/RallyHereGameHostProvider/Public/RH_GameHostProviderInterface.h
@@ -70,6 +70,10 @@ struct FRH_GameHostProviderStats
 	TOptional<bool> AntiCheatEnabled;
 	/** Whether the server is healthy, if known */
 	TOptional<bool> Healthy;
+	/** What build version to report the server is using, if known */
+	TOptional<FString> BuildVersion;
+	/** What session compatibility version to report the server is using, if known */
+	TOptional<FString> SessionCompatibilityVersion;
 
 	FRH_GameHostProviderStats()
 	{

--- a/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
+++ b/RallyHereIntegration/Source/RallyHereIntegration/Private/RH_GameInstanceBootstrappers.cpp
@@ -1532,6 +1532,10 @@ void URH_GameInstanceServerBootstrapper::OnGameHostProviderStats(FRH_GameHostPro
 {
 	// fill in basic information
 	{
+		// retrieve version information from the integration layer
+		Stats.BuildVersion = RH_VersionStrings::GetBuildVersion();
+		Stats.SessionCompatibilityVersion = RH_VersionStrings::GetVersionForSession();
+		
 		// retrieve game state from world
 		const auto* World = GetGameInstanceSubsystem()->GetGameInstance()->GetWorld();
 		if (World != nullptr)


### PR DESCRIPTION
Note: this causes the reported version to be reported slightly later (first tick update) than before.